### PR TITLE
Correct the AMC1 FCL.050 column numbering and transcribe the sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,12 @@ violating one of them.
 
 - `docs/jurisdiction-matrix.md` — how EASA, FAA and UK CAA differ, rule by rule. The
   authoritative source for which raw facts must exist. Read §4 and §9 before touching a model.
-- `docs/entry-form.md` — how the flight entry screen should behave and why.
+- `docs/amc1-fcl050-layout.md` — the printed EASA logbook sheet, transcribed from the template
+  EASA publishes. **Twelve** column groups. The authority for any "column N" citation: pilot
+  function time is 10, FSTD session 11, remarks 12. Single-pilot and multi-pilot time share
+  group 5, which is why counting them separately gives thirteen and is wrong.
+- `docs/entry-form.md` — how the flight entry screen should behave and why. §9 covers FSTD
+  sessions, which are a separate form rather than a flight with fields greyed out.
 - `docs/adr/` — existing decisions, kept as history. Add a new one only for a decision that is
   genuinely hard to reverse and cannot live in a code comment.
 

--- a/docs/amc1-fcl050-layout.md
+++ b/docs/amc1-fcl050-layout.md
@@ -1,0 +1,120 @@
+---
+paths: ["lib/export/**", "test/fixtures/pdf/**"]
+---
+
+# AMC1 FCL.050 — the printed logbook layout
+
+Transcribed from the EASA-published pilot logbook template, **ED Decision 2020/005/R**. This is
+the sheet the EASA/UK PDF export must reproduce, and the authority for every "column N"
+citation in this codebase.
+
+> **Note the ED Decision number.** `docs/jurisdiction-matrix.md` attributes the column structure
+> to ED Decision 2022/014/R as amended by 2025/002/R. The template EASA actually publishes is
+> marked 2020/005/R. Before M6 hardens the layout, confirm whether a later decision revised the
+> sheet — if it did, this file needs re-transcribing from that one.
+
+---
+
+## 1. Front matter
+
+Page 1, centred:
+
+```
+PILOT LOGBOOK
+
+Holder's name(s)         ______________________________
+
+Holder's licence number  ______________________________
+```
+
+Page 2 — **HOLDER'S ADDRESS**, six blocks in a 2 × 3 grid. The first block is the original
+address; the remaining five are each labelled *[space for address change]* and carry three
+blank rules. A pilot's address changes over a career and the record has to absorb that without
+a reissue.
+
+## 2. The entry table
+
+Twelve numbered column groups, spread across a landscape opening: groups 1–8 on the left page,
+9–12 on the right. **Groups, not columns** — several carry sub-columns, and the group number is
+what regulations and this codebase cite.
+
+| # | Group | Sub-columns |
+|---|---|---|
+| 1 | DATE | dd/mm/yy |
+| 2 | DEPARTURE | PLACE, TIME |
+| 3 | ARRIVAL | PLACE, TIME |
+| 4 | AIRCRAFT | MAKE, MODEL, VARIANT — REGISTRATION |
+| 5 | SINGLE-PILOT TIME / MULTI-PILOT TIME | SE, ME (single-pilot); multi-pilot has no sub-column |
+| 6 | TOTAL TIME OF FLIGHT | — |
+| 7 | NAME(S) PIC | — |
+| 8 | LANDINGS | DAY, NIGHT |
+| 9 | OPERATIONAL CONDITION TIME | NIGHT, IFR |
+| 10 | PILOT FUNCTION TIME | PIC, CO-PILOT, DUAL, INSTRUCTOR |
+| 11 | FSTD SESSION | DATE (dd/mm/yy), TYPE, TOTAL TIME OF SESSION |
+| 12 | REMARKS AND ENDORSEMENTS | — |
+
+**Group 5 spans both single-pilot and multi-pilot time under one number.** This is the detail
+that made every earlier count come out at thirteen groups instead of twelve, and it is why
+"multi-pilot time is column 6" — which this repo asserted in several places — was wrong.
+
+Group 11 records a *session*, and carries its own date. An FSTD session is therefore a row of
+this table that has no aircraft, no departure or arrival, no landings and no flight time: the
+sheet itself treats simulator time as a different kind of entry sharing a page with flights.
+See §5.
+
+## 3. Page totals
+
+Three summary rows close every page, rendered in the time columns:
+
+```
+TOTAL THIS PAGE
+TOTAL FROM PREVIOUS PAGES
+TOTAL TIME
+```
+
+These are the exact printed labels — not "brought forward" / "carried forward", which is the
+usual paper-logbook wording and which CLAUDE.md paraphrases. `TOTAL TIME` is the running
+total to date, and must equal `TOTAL THIS PAGE + TOTAL FROM PREVIOUS PAGES` exactly, in every
+time column, on every page. That reconciliation is the golden test M6 needs.
+
+## 4. Certification block
+
+Sits inside group 12 on each page:
+
+```
+I certify that the entries in this log are true.
+
+PILOT'S SIGNATURE
+```
+
+Verbatim wording. It must be rendered on every page **even when unsigned** — an electronic
+logbook is accepted on the basis that it can be printed, signed and dated, so an export that
+omits the block where a signature would go is not a compliant printout.
+
+## 5. What this implies for the data model
+
+- **Group 10 is the projection layer's output surface.** PIC, co-pilot, dual and instructor are
+  four separate sub-columns of one group, which is exactly the per-jurisdiction derivation
+  `domain/projection/` produces. The sheet has no column for "sole manipulator" or "command
+  authority" — those are raw facts that never appear in print, which is the clearest possible
+  statement of why the model stores them and the logbook does not.
+- **Group 5 forces the single/multi-pilot split to be a stored fact**, not a lookup from the
+  aircraft record at print time. Both halves are printed side by side.
+- **Group 11 confirms FSTD sessions are entries, not flights.** Its own date column means a
+  session need not correspond to any flight, and its total is deliberately outside
+  `TOTAL TIME OF FLIGHT` (group 6). Issue #28 covers the model; nothing yet designs the entry
+  screen for one — see `docs/entry-form.md`, which assumes an aircraft throughout.
+- **Group 12 is a single free-text cell** carrying both the mandatory remarks (skill tests,
+  proficiency checks, SPIC/PICUS countersignatures, instrument training toward a licence) and
+  the certification block. It is not a structured field in the printed record, however
+  structured the app makes it internally.
+- **Group 2 and 3 carry a TIME each**, in UTC. There is no separate "block time" column: total
+  time of flight (group 6) is the derived figure, and departure/arrival times are the raw ones.
+
+## 6. Still to confirm before M6
+
+1. Whether a decision later than 2020/005/R revised this sheet.
+2. Column widths and the rows-per-page count, neither of which is prescribed by the AMC — they
+   are a layout choice, but a fixed one once golden tests exist.
+3. Whether the UK CAA's published template diverges from this. UK Part-FCL is retained EU law
+   that the CAA amends independently, so the layout is a per-profile field for a reason.

--- a/docs/entry-form.md
+++ b/docs/entry-form.md
@@ -360,7 +360,48 @@ Requirements:
 
 ---
 
-## 9. Speed
+## 9. FSTD sessions are a different form
+
+Everything above assumes an aircraft. A simulator session is not a flight with some fields
+greyed out — it is a different entry that happens to live in the same logbook.
+
+`AMC1 FCL.050` column 11 makes this explicit: an FSTD session has **its own date column**,
+separate from column 1, and its total sits outside total time of flight (column 6). See
+`docs/amc1-fcl050-layout.md`. Under `§61.51(b)(1)(ii)` the FAA records the *location of the
+lesson* where a flight would carry departure and arrival.
+
+**Fields that do not appear:** route, aircraft registration, off/on blocks, landings, night
+time, cross-country. A session has no take-offs and no landings in any logbook sense, and
+`FCL.060` recency generally cannot be satisfied in a device below the level that represents the
+class or type.
+
+**Fields the flight form does not have:**
+
+| Field | Why |
+|---|---|
+| Device qualification level | FFS A–D, FTD 1–2, ATD/BATD/AATD. Determines what the session is creditable toward, and differs between EASA and FAA. CLAUDE.md rule 2: "FSTD qualification level, not just sim: yes" |
+| Device identity / approval number | Which specific device. Unbackfillable — nobody reconstructs this years later |
+| Device operator and location | `§61.51(b)(1)(ii)` records the location of the lesson |
+| Represented aircraft type | An FFS represents a specific type; credit follows the type it represents, not the device |
+| Session type | Training, proficiency check, skill test, IPC |
+
+**Time semantics differ.** A session has a single total, entered directly — there is no
+equivalent of block time derived from off and on blocks, and no air time. Whatever the pilot
+enters is the figure.
+
+**Instructor presence is near-universal**, so the four-way crew selector in §4 does not apply.
+A session has an instructor or examiner and, in a multi-crew device, another pilot occupying
+the other seat. Whether that reuses `PilotCapacity` or needs its own type is open — some fields
+carry over (instructor aboard, dual versus PIC-equivalent), and others are meaningless in a box
+that never leaves the ground (sole occupant, sole manipulator). Settle it when issue #28 lands,
+not before: guessing produces either a model that lies or a duplicate one.
+
+**The one hard rule, regardless:** FSTD time never contributes to aircraft flight time totals,
+in any jurisdiction. That is issue #28's load-bearing test.
+
+---
+
+## 10. Speed
 
 The interaction that matters most is **repeat last flight**, with the route optionally reversed.
 Training and circuit flying are highly repetitive, and for a large share of entries the correct

--- a/docs/jurisdiction-matrix.md
+++ b/docs/jurisdiction-matrix.md
@@ -6,9 +6,14 @@ authorities this app must support. Written as a working reference for building t
 
 > **Status: working summary, not legal advice.** Every row here needs verification against the
 > current instrument before it becomes load-bearing in code. Regulations cited were checked in
-> August 2026; AMC1 FCL.050 is amended by ED Decision 2025/002/R and the UK diverged again in
-> October 2025. Treat this document as a map of *where to look*, not as the authority itself.
-> Where a row is marked ⚠️ the rule is genuinely ambiguous or authority-dependent.
+> August 2026; the UK diverged again in October 2025. Treat this document as a map of *where to
+> look*, not as the authority itself. Where a row is marked ⚠️ the rule is genuinely ambiguous
+> or authority-dependent.
+>
+> The one exception is the column layout in §2, which is transcribed from the sheet EASA
+> publishes and lives in [`docs/amc1-fcl050-layout.md`](amc1-fcl050-layout.md). ⚠️ That sheet is
+> marked **ED Decision 2020/005/R**, not the 2022/014/R or 2025/002/R this document previously
+> cited for it — confirm which decision governs before M6 hardens the printed layout.
 
 ---
 
@@ -36,23 +41,33 @@ authority, so acceptance practice varies by member state. Known example: Ireland
 
 ### EASA / UK — AMC1 FCL.050 column groups
 
+**Twelve** groups, not thirteen. Transcribed in full — including the front matter, page totals
+and certification block — in [`docs/amc1-fcl050-layout.md`](amc1-fcl050-layout.md), from the
+EASA-published template (ED Decision 2020/005/R). That file is the authority for every
+"column N" citation in this codebase; this table is a summary of it.
+
 | # | Column group | Subfields |
 |---|---|---|
 | 1 | Date | dd/mm/yy, date flight commences |
 | 2 | Departure | Place, time (UTC) |
 | 3 | Arrival | Place, time (UTC) |
 | 4 | Aircraft | Make, model, variant; registration |
-| 5 | Single-pilot time | SE / ME |
-| 6 | Multi-pilot time | — |
-| 7 | Total time of flight | Hours+minutes or decimal |
-| 8 | Name(s) of PIC | Or "SELF" |
-| 9 | Landings | Day / night, as pilot flying |
-| 10 | Operational condition time | Night / IFR |
-| 11 | Pilot function time | PIC / co-pilot / dual / instructor |
-| 12 | FSTD session | Date, type, total session time |
-| 13 | Remarks and endorsements | See §7 below |
+| 5 | Single-pilot time / multi-pilot time | SE / ME for single-pilot; multi-pilot undivided |
+| 6 | Total time of flight | Hours+minutes or decimal |
+| 7 | Name(s) of PIC | Or "SELF" |
+| 8 | Landings | Day / night, as pilot flying |
+| 9 | Operational condition time | Night / IFR |
+| 10 | Pilot function time | PIC / co-pilot / dual / instructor |
+| 11 | FSTD session | Date, type, total session time |
+| 12 | Remarks and endorsements | See §7 below |
 
-Places may be entered in full or as the three- or four-letter designator, and all times should be in UTC. Column 5 indicates SP or MP, and for SP whether SE or ME. Column 8 takes the number of landings as pilot flying by day or night. Column 10 takes flight time at night or under IFR.
+⚠️ **This table was wrong until 2026-08-08** and is corrected here against the published sheet.
+It previously listed thirteen groups, splitting single-pilot and multi-pilot time into 5 and 6.
+They are one group, so everything from 5 onward was numbered one too high. Any external note or
+older commit citing "column 11 pilot function time" or "column 13 remarks" is using the old,
+wrong numbering.
+
+Places may be entered in full or as the three- or four-letter designator, and all times should be in UTC. Column 5 indicates SP or MP, and for SP whether SE or ME. Column 8 takes the number of landings as pilot flying by day or night. Column 9 takes flight time at night or under IFR.
 
 ### FAA — §61.51(b)
 
@@ -72,9 +87,9 @@ single canonical model satisfies both, but the print/export layouts must be per 
 | **Night (logging)** | End of evening civil twilight to beginning of morning civil twilight | Same — §1.1 defines night by the sun's position, not a fixed clock time | **Aligned for logging** |
 | **Night (currency)** | Same civil-twilight window (FCL.060) | 1 hour after sunset to 1 hour before sunrise (§61.57(b)) | **Two different night windows under FAA alone.** A landing can be night-for-logging but not night-for-currency. |
 | **Cross-country** | Single definition: flight time navigating to a destination away from the departure aerodrome following a pre-planned route using standard navigation procedures — no minimum distance in the definition itself; specific distances sit in the individual experience requirements | At least four distinct definitions under §61.1(b)(3) depending on the certificate sought | **Largest divergence.** Store the route; never store an `isCrossCountry` boolean. |
-| **Instrument time** | Column 10 records **IFR time** — an operational condition | Only time operating the aircraft solely by reference to instruments under actual or simulated instrument conditions (§61.51(g)(1)) | An IFR flight entirely in VMC = full EASA IFR time, **zero** FAA instrument time. |
+| **Instrument time** | Column 9 records **IFR time** — an operational condition | Only time operating the aircraft solely by reference to instruments under actual or simulated instrument conditions (§61.51(g)(1)) | An IFR flight entirely in VMC = full EASA IFR time, **zero** FAA instrument time. |
 | **Simulated instrument** | Not separately columned | Separate condition (§61.51(b)(3)(iii)) | FAA needs actual/simulated split; EASA does not |
-| **FSTD time** | Column 11, separated from flight time | Logged, but not flight time | Aligned in principle |
+| **FSTD time** | Column 11, separated from flight time (group 6) | Logged, but not flight time | Aligned in principle |
 
 ### ⚠️ Cross-country, expanded
 
@@ -97,7 +112,7 @@ evaluated over the stored route.
 | **PIC (logging)** | Only where command authority is held, plus the specific cases below | Sole manipulator of the controls of an aircraft for which the pilot is rated; or sole occupant; or acting PIC of an aircraft requiring more than one pilot; or performing PIC duties under an approved supervised programme (§61.51(e)) | **The core divergence.** FAA separates *logging* PIC from *acting* PIC; EASA does not. |
 | **SPIC** | A student pilot acting as PIC on a flight with an instructor where the instructor only observes and does not influence or control the flight | **No analogue** | Closest FAA concept is §61.87 solo, which is a different situation. Logged in the PIC column, countersigned. |
 | **PICUS** | A co-pilot performing, under supervision of the PIC, the duties and functions of a PIC; logged as PIC provided the PIC's intervention in the interest of safety was not required, and countersigned by the PIC | **No analogue** | Up to 500 hours creditable toward the ATPL(A) PIC requirement under FCL.510(a)(2). |
-| **Co-pilot** | Column 11 co-pilot time; multi-pilot operations only | SIC — requires §61.55 qualification and a crewmember station in an aircraft requiring more than one pilot by type certificate, or equivalent under §135.99(c) | ⚠️ Second pilot in a single-pilot aeroplane logs **nothing** under EASA |
+| **Co-pilot** | Column 10 co-pilot time; multi-pilot operations only | SIC — requires §61.55 qualification and a crewmember station in an aircraft requiring more than one pilot by type certificate, or equivalent under §135.99(c) | ⚠️ Second pilot in a single-pilot aeroplane logs **nothing** under EASA |
 | **Dual instruction** | Flight time during which a person is receiving flight instruction from a properly authorised instructor | Training received from an authorised instructor | SPIC and dual are mutually exclusive under FCL.010 — they cannot be recorded concurrently. |
 | **Instructor** | Recorded as instructor time and also entered as PIC | A CFI may log PIC for all time serving as the authorised instructor if rated to act as PIC of that aircraft (§61.51(e)(3)) | Broadly aligned |
 | **Safety pilot** | No defined category ⚠️ | Name must be recorded when required by §91.109; logs PIC or SIC depending on the arrangement | FAA-only field. Store it anyway. |
@@ -205,13 +220,13 @@ any of these makes a jurisdiction's numbers unrecoverable for historical flights
 | Sole occupant (bool) | Both, solo | §61.51(d) |
 | Instructor aboard + capacity | Both | Dual vs SPIC vs nothing |
 | Instructor actually influenced the flight (bool) | EASA | SPIC requires that they did not |
-| Multi-pilot operation (bool) | EASA co-pilot, FAA SIC | Column 5/6, §61.51(f) |
+| Multi-pilot operation (bool) | EASA co-pilot, FAA SIC | Column 5, §61.51(f) |
 | Aircraft requires >1 pilot by TC (bool) | FAA | §61.51(e)(1)(iii), (f) |
 | Safety pilot identity | FAA | §61.51(b)(1)(v) |
 | Full route with waypoints | Cross-country, all profiles | Distance thresholds differ |
 | Take-offs and landings, split full-stop / touch-and-go **and** day / night | FAA night currency, EASA column 8 | Four counts, not one |
 | Timestamps precise enough to resolve civil twilight and sunset±1h | Both night definitions | Two windows |
-| IFR flight plan filed (bool) | EASA column 10 | Distinct from actual conditions |
+| IFR flight plan filed (bool) | EASA column 9 | Distinct from actual conditions |
 | Actual instrument time | FAA | §61.51(g)(1) |
 | Simulated instrument time | FAA | §61.51(b)(3)(iii) |
 | Approach count, type and location | FAA §61.57(c) only | §61.51(g)(3) requires type and location per approach. **No EASA equivalent** — AMC1 FCL.050 has no approach column and FCL.060's "approaches" wording is a recency condition, not a logging obligation |

--- a/lib/domain/model/pilot_capacity.dart
+++ b/lib/domain/model/pilot_capacity.dart
@@ -53,8 +53,9 @@ abstract class PilotCapacity with _$PilotCapacity {
     required bool soleOccupant,
 
     /// Whether the flight was a multi-pilot *operation* in the logbook sense.
-    /// `AMC1 FCL.050` splits single-pilot (column 5) from multi-pilot
-    /// (column 6) time, so an EASA logbook cannot be printed without it.
+    /// `AMC1 FCL.050` column 5 holds single-pilot time (split SE/ME) and
+    /// multi-pilot time side by side as one group, so an EASA logbook cannot
+    /// be printed without this. See `docs/amc1-fcl050-layout.md`.
     ///
     /// Deliberately **not** the same question as
     /// [additionalCrewRequiredByRule]. A light aeroplane flown under a hood
@@ -76,7 +77,8 @@ abstract class PilotCapacity with _$PilotCapacity {
     required bool additionalCrewRequiredByRule,
 
     /// Whether this pilot was the authorised instructor. `AMC1 FCL.050`
-    /// column 11 records instructor time as its own function; `§61.51(e)(3)`
+    /// column 10 (pilot function time) records instructor time as its own
+    /// function; `§61.51(e)(3)`
     /// lets a CFI log PIC for instruction given when rated to act as PIC.
     ///
     /// The mirror of [instructor]: this flag says *this* pilot instructed,
@@ -159,7 +161,7 @@ abstract class PilotCapacity with _$PilotCapacity {
 enum OtherPilotRole {
   /// Required to be there by the type certificate or the operating rules.
   ///
-  /// Covers both the EASA co-pilot / FAA SIC case (`AMC1 FCL.050` column 11,
+  /// Covers both the EASA co-pilot / FAA SIC case (`AMC1 FCL.050` column 10,
   /// `§61.51(f)`) *and* the case where the other pilot is the single required
   /// pilot of a single-pilot aircraft — a projection must therefore read
   /// [PilotCapacity.multiPilotOperation] alongside this value rather than

--- a/test/fixtures/capacities/co_pilot_sic.yaml
+++ b/test/fixtures/capacities/co_pilot_sic.yaml
@@ -2,8 +2,8 @@
 # PICUS claimed. The ordinary airline right-hand-seat sector.
 #
 # Expected projections (asserted by issues #18 and #19 — NOT stored here):
-#   EASA AMC1 FCL.050: co-pilot time = full block time (column 11 pilot
-#                      function time), recorded as multi-pilot time (column 6).
+#   EASA AMC1 FCL.050: co-pilot time = full block time (column 10 pilot
+#                      function time), recorded as multi-pilot time (column 5).
 #                      PIC = 0.
 #   FAA  §61.51(f):    SIC = full block time, provided the pilot is qualified
 #                      under §61.55 and the aircraft requires more than one
@@ -23,7 +23,7 @@ id: "capacity-co-pilot-sic"
 command_authority: false
 sole_manipulator: false       # the captain flew this sector
 sole_occupant: false
-multi_pilot_operation: true   # §61.51(f); AMC1 FCL.050 column 6
+multi_pilot_operation: true   # §61.51(f); AMC1 FCL.050 column 5
 additional_crew_required_by_rule: true  # multi-crew operation
 acting_as_instructor: false
 acting_as_examiner: false

--- a/test/fixtures/capacities/flight_instructor.yaml
+++ b/test/fixtures/capacities/flight_instructor.yaml
@@ -3,7 +3,7 @@
 #
 # Expected projections (asserted by issues #18 and #19 — NOT stored here):
 #   EASA AMC1 FCL.050: instructor time = full block time, and the same time
-#                      entered as PIC (column 11 records both functions).
+#                      entered as PIC (column 10 records both functions).
 #   FAA  §61.51(e)(3): PIC = full block time for all flight time while
 #                      serving as the authorised instructor, if rated to act
 #                      as PIC of that aircraft. Not because of §61.51(e)(1)(i)
@@ -24,7 +24,7 @@ sole_manipulator: false       # the student flew
 sole_occupant: false
 multi_pilot_operation: false  # a single-pilot aeroplane with two aboard
 additional_crew_required_by_rule: false
-acting_as_instructor: true    # AMC1 FCL.050 column 11; §61.51(e)(3)
+acting_as_instructor: true    # AMC1 FCL.050 column 10; §61.51(e)(3)
 acting_as_examiner: false
 picus_claimed: false
 pic_intervention_not_required: false
@@ -32,7 +32,7 @@ pic_intervention_not_required: false
 # `instructor` stays absent. It names an instructor *other than* this pilot;
 # there was none. The person receiving the instruction is not modelled here
 # either — crew identity is a Flight concern (issue #11), alongside AMC1
-# FCL.050 column 8, "name(s) of PIC".
+# FCL.050 column 7, "name(s) PIC".
 #
 # `other_pilot_role` is likewise absent: the student is receiving instruction,
 # not occupying a required-crew station, and is not a safety pilot. Recording

--- a/test/fixtures/capacities/pic_sole_occupant.yaml
+++ b/test/fixtures/capacities/pic_sole_occupant.yaml
@@ -1,7 +1,7 @@
 # Solo. The pilot alone in the aircraft, in command, flying it.
 #
 # Expected projections (asserted by issues #18 and #19 — NOT stored here):
-#   EASA FCL.010:     PIC = full block time. Column 11 pilot function = PIC.
+#   EASA FCL.010:     PIC = full block time. Column 10 pilot function = PIC.
 #   FAA  §61.51(e)(1)(i): PIC = full block time (sole manipulator, rated).
 #   FAA  §61.51(d):   solo = full block time (sole occupant).
 #

--- a/test/fixtures/capacities/picus_countersigned.yaml
+++ b/test/fixtures/capacities/picus_countersigned.yaml
@@ -23,7 +23,7 @@ id: "capacity-picus-countersigned"
 command_authority: false      # FCL.010 — the supervising PIC held command
 sole_manipulator: true        # pilot flying for this sector
 sole_occupant: false
-multi_pilot_operation: true   # AMC1 FCL.050 column 6; PICUS is a co-pilot case
+multi_pilot_operation: true   # AMC1 FCL.050 column 5; PICUS is a co-pilot case
 additional_crew_required_by_rule: true  # multi-crew operation
 acting_as_instructor: false
 acting_as_examiner: false


### PR DESCRIPTION
The EASA-published logbook template has **twelve** column groups, not thirteen. Single-pilot time (SE/ME) and multi-pilot time share group 5, so everything from 5 onward was numbered one too high in `docs/jurisdiction-matrix.md` and in every citation that followed it.

| | Was | Now |
|---|---|---|
| Single-pilot / multi-pilot time | 5 and 6 | **5** (one group) |
| Total time of flight | 7 | **6** |
| Name(s) PIC | 8 | **7** |
| Landings | 9 | **8** |
| Operational condition time (night / IFR) | 10 | **9** |
| Pilot function time (PIC / co-pilot / dual / instructor) | 11 | **10** |
| FSTD session | 12 | **11** |
| Remarks and endorsements | 13 | **12** |

Corrected in the matrix, in `pilot_capacity.dart`, and in four fixtures. The matrix's *prose* was mostly right and its *table* was wrong, which is how the two drifted apart unnoticed.

## `docs/amc1-fcl050-layout.md`

Transcribes the whole sheet for M6, not just the columns: front matter, the six-block address page, all twelve groups with sub-columns, the three page-total rows with their exact printed labels — `TOTAL THIS PAGE` / `TOTAL FROM PREVIOUS PAGES` / `TOTAL TIME`, not the "brought forward" wording CLAUDE.md paraphrases — and the verbatim certification block, which must render on every page even unsigned.

⚠️ The sheet is marked **ED Decision 2020/005/R**. The matrix attributed the layout to 2022/014/R as amended by 2025/002/R. Flagged for confirmation before M6 hardens anything.

## FSTD

Column 11 gives an FSTD session its own date, separate from column 1 — the sheet itself says a session is a distinct entry, not a flight with fields greyed out. `entry-form.md` §9 now covers what that form needs (device qualification level, identity, operator, represented type) and what must not appear on it (route, registration, blocks, landings). Issue #28 rewritten to match, including the open question of whether a session reuses `PilotCapacity`.

Docs and comments only — no behaviour change. Local pipeline clean, 65 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)