### PR TITLE
Define Aerodrome model and bundle an offline ICAO database

### DIFF
--- a/assets/aerodromes/README.md
+++ b/assets/aerodromes/README.md
@@ -1,0 +1,27 @@
+# Aerodrome dataset
+
+`airports.csv` — downloaded from [OurAirports](https://ourairports.com/data/airports.csv) on
+2026-08-08.
+
+**Licence:** OurAirports data is public domain
+([ourairports.com/data](https://ourairports.com/data/)). No attribution is legally required; this
+file records provenance anyway so the source is traceable if the data ever needs re-verifying or
+re-downloading.
+
+**Format:** one CSV, one row per aerodrome, header:
+
+```
+id, ident, type, name, latitude_deg, longitude_deg, elevation_ft, continent, iso_country,
+iso_region, municipality, scheduled_service, icao_code, iata_code, gps_code, local_code,
+home_link, wikipedia_link, keywords
+```
+
+Parsed by `lib/domain/model/aerodrome_directory.dart`. Only `icao_code`, `iata_code`, `name`,
+`latitude_deg`, `longitude_deg`, `elevation_ft` and `iso_country` are used — see #14. A row with
+both `icao_code` and `iata_code` blank is skipped: those fields are the only public identifiers
+the app looks aerodromes up by, and OurAirports carries thousands of closed strips and heliports
+identified only by an internal `gps_code`/`local_code`.
+
+**Unfiltered, ~12 MB, ~85,800 rows.** Every entry worldwide, including closed and non-flying
+types. Deliberately left as-is for now — see #106 for the decision to slim it down before a
+release build, and how.

--- a/docs/jurisdiction-matrix.md
+++ b/docs/jurisdiction-matrix.md
@@ -86,18 +86,41 @@ single canonical model satisfies both, but the print/export layouts must be per 
 | **Flight time (helicopter)** | Rotor start to rotor stop | Same practical effect via §1.1 | Aligned |
 | **Night (logging)** | End of evening civil twilight to beginning of morning civil twilight | Same — §1.1 defines night by the sun's position, not a fixed clock time | **Aligned for logging** |
 | **Night (currency)** | Same civil-twilight window (FCL.060) | 1 hour after sunset to 1 hour before sunrise (§61.57(b)) | **Two different night windows under FAA alone.** A landing can be night-for-logging but not night-for-currency. |
-| **Cross-country** | Single definition: flight time navigating to a destination away from the departure aerodrome following a pre-planned route using standard navigation procedures — no minimum distance in the definition itself; specific distances sit in the individual experience requirements | At least four distinct definitions under §61.1(b)(3) depending on the certificate sought | **Largest divergence.** Store the route; never store an `isCrossCountry` boolean. |
+| **Cross-country** | Single definition: flight time navigating to a destination away from the departure aerodrome following a pre-planned route using standard navigation procedures — no minimum distance in the definition itself; specific distances sit in the individual experience requirements | A general logging definition with no minimum distance (§61.1(b)(3)(i)), plus six purpose-specific credit tests at 50, 25 or 15 nm depending on the certificate or rating being credited (§61.1(b)(3)(ii)–(vii)) | **Largest divergence.** Store the route; never store an `isCrossCountry` boolean — FAA alone needs several simultaneously live answers per flight. |
 | **Instrument time** | Column 9 records **IFR time** — an operational condition | Only time operating the aircraft solely by reference to instruments under actual or simulated instrument conditions (§61.51(g)(1)) | An IFR flight entirely in VMC = full EASA IFR time, **zero** FAA instrument time. |
 | **Simulated instrument** | Not separately columned | Separate condition (§61.51(b)(3)(iii)) | FAA needs actual/simulated split; EASA does not |
 | **FSTD time** | Column 11, separated from flight time (group 6) | Logged, but not flight time | Aligned in principle |
 
-### ⚠️ Cross-country, expanded
+### Cross-country, expanded
 
-The EASA definition does not require the arrival point to differ from departure, so a
-pre-planned navigation exercise returning to the origin can qualify. This is contested in
-practice and interpretation varies by authority. The FAA general definition requires a landing
-at a point other than departure; most rating credit additionally requires a landing more than
-50 nm straight-line from the origin. ATPL credit differs again under both systems.
+**FAA — §61.1(b)(3).** Seven sub-paragraphs, not one. (i) is what cross-country *time* actually
+is — no minimum distance — and is what gets logged as such; (ii)–(vii) are purpose-specific
+*credit* tests layered on top, each gating whether a cross-country flight counts toward one
+particular certificate or rating's aeronautical experience requirement.
+
+| § | Applies to | Minimum landing distance | Notes |
+|---|---|---|---|
+| (i) | General definition — any certificated pilot, any aircraft | None | A landing anywhere other than the point of departure, navigated to by dead reckoning, pilotage, or an electronic/radio/other nav system. This is the loggable definition, not a credit test. |
+| (ii) | Private (except powered-parachute rating), commercial, instrument rating; recreational privileges except rotorcraft | > 50 nm straight-line | The threshold most people mean by "the 50 nm rule" |
+| (iii) | Sport pilot, except powered-parachute privileges | > 25 nm straight-line | |
+| (iv) | Sport pilot with powered-parachute privileges; private pilot with powered-parachute category rating | > 15 nm straight-line | |
+| (v) | Any certificate with rotorcraft category rating; instrument–helicopter rating; recreational privileges in a rotorcraft | > 25 nm straight-line | Rotorcraft takes the sport-pilot distance, not the private-pilot one |
+| (vi) | Airline transport pilot, except rotorcraft category rating | > 50 nm straight-line | |
+| (vii) | Military pilot qualifying for a commercial certificate under §61.73, except rotorcraft | > 50 nm straight-line | |
+
+**Consequence for the model:** a single flight can be cross-country under the general definition
+(i) — and loggable as such — while failing every credit test that applies to the certificate the
+pilot is actually pursuing, or passing some and not others if the pilot is working toward more
+than one. Which threshold applies is a function of *which certificate or rating's credit is being
+evaluated* and *the aircraft's category* (rotorcraft vs. not; powered-parachute vs. not — see
+`AircraftCategory` in `lib/domain/model/aircraft.dart`), never a single number. #24's projection
+needs to answer "is this cross-country toward a private certificate" and "is this cross-country
+toward a rotorcraft rating" as two different questions over the same flight and the same stored
+route.
+
+**EASA / UK.** The definition does not require the arrival point to differ from departure, so a
+pre-planned navigation exercise returning to the origin can qualify. This is contested in practice
+and interpretation varies by competent authority. ATPL credit differs again.
 
 **Implication:** cross-country is not one field. It is a per-profile, per-purpose predicate
 evaluated over the stored route.

--- a/lib/domain/model/aerodrome.dart
+++ b/lib/domain/model/aerodrome.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'geo_coordinate.dart';
+
+part 'aerodrome.freezed.dart';
+
+/// An aerodrome a flight can depart from or arrive at.
+///
+/// [icaoCode] and [iataCode] are both nullable — not every place a pilot
+/// flies from has either. #14's acceptance criteria are explicit that this
+/// is not an edge case: plenty of GA flying happens from private strips and
+/// unlicensed grass fields no dataset knows about, and the app must be able
+/// to record a flight there with only a name and a position.
+@freezed
+abstract class Aerodrome with _$Aerodrome {
+  const factory Aerodrome({
+    String? icaoCode,
+    String? iataCode,
+    required String name,
+    required GeoCoordinate position,
+
+    /// Feet AMSL. Null where the source dataset doesn't record it — mainly
+    /// very small or closed sites.
+    int? elevationFt,
+
+    /// ISO 3166-1 alpha-2, e.g. `US`, `GB`. Free text rather than an enum:
+    /// the dataset carries ~250 of these and the app has no rule that
+    /// branches on a closed set of them today.
+    String? isoCountry,
+  }) = _Aerodrome;
+}

--- a/lib/domain/model/aerodrome_directory.dart
+++ b/lib/domain/model/aerodrome_directory.dart
@@ -1,0 +1,115 @@
+import 'package:csv/csv.dart';
+
+import 'aerodrome.dart';
+import 'geo_coordinate.dart';
+
+/// Column names `parseOurAirportsCsv` reads. Looked up by name rather than
+/// fixed position, so a harmless reorder or an added column in a future
+/// OurAirports download doesn't break parsing — only a renamed or removed
+/// column does, and that raises [FormatException] naming it.
+const List<String> _requiredColumns = [
+  'icao_code',
+  'iata_code',
+  'name',
+  'latitude_deg',
+  'longitude_deg',
+  'elevation_ft',
+  'iso_country',
+];
+
+/// Parses OurAirports' `airports.csv` format (see
+/// `assets/aerodromes/README.md` for provenance and licence) into
+/// [Aerodrome]s.
+///
+/// Skips a row if both [Aerodrome.icaoCode] and [Aerodrome.iataCode] would
+/// be blank — those are the only public identifiers the app looks
+/// aerodromes up by, and OurAirports carries thousands of closed strips and
+/// heliports identified only by an internal `gps_code`/`local_code`. Also
+/// skips a row with an unparseable latitude or longitude, which happens for
+/// a handful of very old entries in the dataset; a bundled reference file is
+/// not user input; the design that matters here is not asking one bad row
+/// out of ~85,000 to fail the whole load.
+List<Aerodrome> parseOurAirportsCsv(String csvContent) {
+  final rows = Csv().decode(csvContent);
+  if (rows.isEmpty) {
+    return const <Aerodrome>[];
+  }
+
+  final header = rows.first.map((cell) => cell.toString()).toList();
+  final columnIndex = <String, int>{};
+  for (final name in _requiredColumns) {
+    final index = header.indexOf(name);
+    if (index == -1) {
+      throw FormatException(
+        'OurAirports CSV is missing expected column "$name". The upstream '
+        'column layout may have changed.',
+      );
+    }
+    columnIndex[name] = index;
+  }
+
+  final aerodromes = <Aerodrome>[];
+  for (final row in rows.skip(1)) {
+    final icao = _cell(row, columnIndex['icao_code']!);
+    final iata = _cell(row, columnIndex['iata_code']!);
+    if (icao == null && iata == null) {
+      continue;
+    }
+
+    final lat = double.tryParse(row[columnIndex['latitude_deg']!].toString());
+    final lon = double.tryParse(row[columnIndex['longitude_deg']!].toString());
+    if (lat == null || lon == null) {
+      continue;
+    }
+
+    aerodromes.add(
+      Aerodrome(
+        icaoCode: icao,
+        iataCode: iata,
+        name: row[columnIndex['name']!].toString(),
+        position: GeoCoordinate(latitude: lat, longitude: lon),
+        elevationFt: int.tryParse(row[columnIndex['elevation_ft']!].toString()),
+        isoCountry: _cell(row, columnIndex['iso_country']!),
+      ),
+    );
+  }
+  return aerodromes;
+}
+
+/// Reads `row[index]` as a trimmed string, or `null` if blank.
+String? _cell(List<dynamic> row, int index) {
+  final value = row[index].toString().trim();
+  return value.isEmpty ? null : value;
+}
+
+/// O(1) lookup of a bundled or user-supplied [Aerodrome] set by ICAO code.
+///
+/// Keyed on [Aerodrome.icaoCode] only — #14 treats IATA as a secondary
+/// identifier, not the primary lookup key, and most GA aerodromes have no
+/// IATA code at all. An aerodrome with no ICAO code isn't indexed; [byIcao]
+/// returning `null` for an unindexed or unknown code — never throwing — is
+/// the "gracefully handle absence" behaviour #14 asks for.
+class AerodromeDirectory {
+  /// If [aerodromes] contains two entries with the same ICAO code
+  /// (case-insensitively), the later one wins — the source dataset is
+  /// curated data, not a place this is expected to happen, so no error is
+  /// raised for it.
+  AerodromeDirectory(Iterable<Aerodrome> aerodromes)
+    : _byIcao = {
+        for (final aerodrome in aerodromes)
+          if (aerodrome.icaoCode != null)
+            aerodrome.icaoCode!.toUpperCase(): aerodrome,
+      };
+
+  factory AerodromeDirectory.fromOurAirportsCsv(String csvContent) =>
+      AerodromeDirectory(parseOurAirportsCsv(csvContent));
+
+  final Map<String, Aerodrome> _byIcao;
+
+  /// Looks up an aerodrome by ICAO code, case-insensitively. `null` if
+  /// [code] isn't in this directory — never throws.
+  Aerodrome? byIcao(String code) => _byIcao[code.toUpperCase()];
+
+  /// Number of aerodromes indexed (i.e. with a non-null ICAO code).
+  int get length => _byIcao.length;
+}

--- a/lib/domain/model/geo_coordinate.dart
+++ b/lib/domain/model/geo_coordinate.dart
@@ -1,0 +1,74 @@
+import 'dart:math';
+
+/// A point on Earth's surface, WGS84 latitude/longitude in degrees.
+///
+/// Validated at construction so a transposed lat/lon or a stray sign typo
+/// fails where it was entered instead of silently corrupting every distance
+/// calculation that later reads it.
+class GeoCoordinate {
+  const GeoCoordinate._(this.latitude, this.longitude);
+
+  /// Throws [ArgumentError] if [latitude] is outside -90..90 or [longitude]
+  /// is outside -180..180.
+  factory GeoCoordinate({required double latitude, required double longitude}) {
+    if (latitude < -90 || latitude > 90) {
+      throw ArgumentError.value(
+        latitude,
+        'latitude',
+        'must be between -90 and 90 degrees',
+      );
+    }
+    if (longitude < -180 || longitude > 180) {
+      throw ArgumentError.value(
+        longitude,
+        'longitude',
+        'must be between -180 and 180 degrees',
+      );
+    }
+    return GeoCoordinate._(latitude, longitude);
+  }
+
+  final double latitude;
+  final double longitude;
+
+  @override
+  bool operator ==(Object other) =>
+      other is GeoCoordinate &&
+      other.latitude == latitude &&
+      other.longitude == longitude;
+
+  @override
+  int get hashCode => Object.hash(latitude, longitude);
+
+  @override
+  String toString() => 'GeoCoordinate($latitude, $longitude)';
+}
+
+/// Mean Earth radius in nautical miles: 6371.0088 km (IUGG mean radius) /
+/// 1.852 km per nm.
+const double _earthRadiusNm = 3440.065;
+
+const double _degreesToRadians = pi / 180;
+
+/// Great-circle distance between [a] and [b] along Earth's surface, in
+/// nautical miles — the unit `docs/jurisdiction-matrix.md` cites for the
+/// FAA's 50 nm cross-country threshold, so callers never need to convert.
+///
+/// Haversine, not Vincenty: FAA and EASA cross-country thresholds don't need
+/// ellipsoid precision, and Vincenty can fail to converge for near-antipodal
+/// points — a worse failure mode for a logbook than a fraction of a percent
+/// of spherical-Earth error.
+double greatCircleDistanceNm(GeoCoordinate a, GeoCoordinate b) {
+  final lat1 = a.latitude * _degreesToRadians;
+  final lat2 = b.latitude * _degreesToRadians;
+  final dLat = (b.latitude - a.latitude) * _degreesToRadians;
+  final dLon = (b.longitude - a.longitude) * _degreesToRadians;
+
+  final sinHalfDLat = sin(dLat / 2);
+  final sinHalfDLon = sin(dLon / 2);
+  final h =
+      sinHalfDLat * sinHalfDLat +
+      cos(lat1) * cos(lat2) * sinHalfDLon * sinHalfDLon;
+  final c = 2 * atan2(sqrt(h), sqrt(1 - h));
+  return _earthRadiusNm * c;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csv:
+    dependency: "direct main"
+    description:
+      name: csv
+      sha256: "2e0a52fb729f2faacd19c9c0c954ff450bba37aa8ab999410309e2342e7013a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   dart_style:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.12.0
 
 dependencies:
+  csv: ^8.0.0
   flutter:
     sdk: flutter
   freezed_annotation: ^3.1.0
@@ -29,3 +30,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/aerodromes/

--- a/test/domain/model/aerodrome_directory_test.dart
+++ b/test/domain/model/aerodrome_directory_test.dart
@@ -1,0 +1,125 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fixtures live under `test/fixtures/aerodromes/` as raw CSV, matching
+/// OurAirports' own format directly — see the README there. This differs
+/// from the YAML-plus-decoder pattern used elsewhere in `test/fixtures/`
+/// because the thing under test *is* the CSV parser; wrapping the input in
+/// YAML would just add a translation step with nothing to verify.
+String _fixture(String name) =>
+    File('test/fixtures/aerodromes/$name.csv').readAsStringSync();
+
+void main() {
+  group('parseOurAirportsCsv', () {
+    late final aerodromes = parseOurAirportsCsv(_fixture('sample_ourairports'));
+
+    test('keeps a row with both ICAO and IATA codes', () {
+      final jfk = aerodromes.firstWhere((a) => a.icaoCode == 'KJFK');
+      expect(jfk.iataCode, 'JFK');
+      expect(jfk.name, 'John F Kennedy International Airport');
+      expect(jfk.elevationFt, 13);
+      expect(jfk.isoCountry, 'US');
+      expect(jfk.position.latitude, 40.639801);
+      expect(jfk.position.longitude, -73.7789);
+    });
+
+    test('an embedded comma in the name does not shift later columns', () {
+      // "Newark, Liberty International Airport" — if the parser split on
+      // literal commas instead of respecting the CSV quoting, icao_code and
+      // iata_code (which come after name in the row) would read garbage.
+      final ewr = aerodromes.firstWhere((a) => a.icaoCode == 'KEWR');
+      expect(ewr.name, 'Newark, Liberty International Airport');
+      expect(ewr.iataCode, 'EWR');
+    });
+
+    test('skips a row with neither ICAO nor IATA code', () {
+      expect(aerodromes.where((a) => a.name == 'Total RF Heliport'), isEmpty);
+    });
+
+    test('keeps a row with only an IATA code', () {
+      final remote = aerodromes.firstWhere(
+        (a) => a.name == 'Remote Island Strip',
+      );
+      expect(remote.icaoCode, isNull);
+      expect(remote.iataCode, 'XYZ');
+    });
+
+    test('a blank elevation becomes null, not zero', () {
+      final noElevation = aerodromes.firstWhere((a) => a.icaoCode == 'ZZZZ');
+      expect(noElevation.elevationFt, isNull);
+    });
+
+    test('skips a row with an unparseable position', () {
+      expect(
+        aerodromes.where((a) => a.name == 'Bad Coordinates Airport'),
+        isEmpty,
+      );
+    });
+
+    test('throws naming the missing column', () {
+      expect(
+        () => parseOurAirportsCsv(_fixture('missing_column')),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('iso_country'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('AerodromeDirectory', () {
+    late final directory = AerodromeDirectory.fromOurAirportsCsv(
+      _fixture('sample_ourairports'),
+    );
+
+    test('finds an aerodrome by ICAO code case-insensitively', () {
+      expect(
+        directory.byIcao('KJFK')?.name,
+        'John F Kennedy International Airport',
+      );
+      expect(
+        directory.byIcao('kjfk')?.name,
+        'John F Kennedy International Airport',
+      );
+    });
+
+    test('returns null, never throws, for an unknown code', () {
+      expect(directory.byIcao('ZZZZ99'), isNull);
+    });
+
+    test('an aerodrome parsed with no ICAO code is not indexed', () {
+      // The "Remote Island Strip" fixture row is IATA-only. It's still in
+      // the parsed list (see parseOurAirportsCsv tests above), just not
+      // reachable through byIcao.
+      expect(
+        directory.byIcao('XYZ'),
+        isNull,
+        reason: 'IATA is not a lookup key for byIcao',
+      );
+    });
+
+    test('indexes exactly the rows that carry an ICAO code', () {
+      // KJFK, EGLL, ZZZZ, KEWR. Heliport and bad-coordinate rows never made
+      // it into the parsed list; the IATA-only row made the list but has no
+      // ICAO code to index by.
+      expect(directory.length, 4);
+    });
+
+    test('a duplicate ICAO code keeps the later entry', () {
+      // Documented, deliberate behaviour, not an accident: the bundled
+      // dataset is curated data, not user input, so this is not expected to
+      // occur in practice and no error is raised for it.
+      final directory = AerodromeDirectory.fromOurAirportsCsv(
+        _fixture('duplicate_icao'),
+      );
+      expect(directory.byIcao('DUPE')?.name, 'Second Entry');
+    });
+  });
+}

--- a/test/domain/model/aerodrome_test.dart
+++ b/test/domain/model/aerodrome_test.dart
@@ -1,0 +1,55 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Aerodrome', () {
+    test('two aerodromes with the same fields are equal', () {
+      final a = Aerodrome(
+        icaoCode: 'EGLL',
+        iataCode: 'LHR',
+        name: 'London Heathrow Airport',
+        position: GeoCoordinate(latitude: 51.4706, longitude: -0.461941),
+        elevationFt: 83,
+        isoCountry: 'GB',
+      );
+      final b = Aerodrome(
+        icaoCode: 'EGLL',
+        iataCode: 'LHR',
+        name: 'London Heathrow Airport',
+        position: GeoCoordinate(latitude: 51.4706, longitude: -0.461941),
+        elevationFt: 83,
+        isoCountry: 'GB',
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('a different field breaks equality', () {
+      final heathrow = Aerodrome(
+        icaoCode: 'EGLL',
+        iataCode: 'LHR',
+        name: 'London Heathrow Airport',
+        position: GeoCoordinate(latitude: 51.4706, longitude: -0.461941),
+        elevationFt: 83,
+        isoCountry: 'GB',
+      );
+      expect(heathrow, isNot(heathrow.copyWith(icaoCode: 'EGKK')));
+    });
+
+    test('a private strip can be recorded with no ICAO or IATA code', () {
+      // #14 is explicit: this is not an edge case. Plenty of GA flying
+      // happens from places no public dataset knows about.
+      final strip = Aerodrome(
+        name: "Someone's Farm Strip",
+        position: GeoCoordinate(latitude: 52.1, longitude: -1.3),
+      );
+      expect(strip.icaoCode, isNull);
+      expect(strip.iataCode, isNull);
+      expect(strip.elevationFt, isNull);
+      expect(strip.isoCountry, isNull);
+    });
+  });
+}

--- a/test/domain/model/geo_coordinate_test.dart
+++ b/test/domain/model/geo_coordinate_test.dart
@@ -1,0 +1,96 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GeoCoordinate validation', () {
+    test('accepts the boundary values', () {
+      expect(
+        () => GeoCoordinate(latitude: 90, longitude: 180),
+        returnsNormally,
+      );
+      expect(
+        () => GeoCoordinate(latitude: -90, longitude: -180),
+        returnsNormally,
+      );
+    });
+
+    test('rejects latitude outside -90..90', () {
+      expect(
+        () => GeoCoordinate(latitude: 90.0001, longitude: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => GeoCoordinate(latitude: -90.0001, longitude: 0),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects longitude outside -180..180', () {
+      expect(
+        () => GeoCoordinate(latitude: 0, longitude: 180.0001),
+        throwsArgumentError,
+      );
+      expect(
+        () => GeoCoordinate(latitude: 0, longitude: -180.0001),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('GeoCoordinate equality', () {
+    test('two coordinates with the same values are equal', () {
+      final a = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      final b = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('a different latitude or longitude breaks equality', () {
+      final base = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      expect(base, isNot(GeoCoordinate(latitude: 51.47, longitude: -0.461941)));
+      expect(base, isNot(GeoCoordinate(latitude: 51.4706, longitude: 0)));
+    });
+  });
+
+  group('greatCircleDistanceNm', () {
+    test('the same point is zero nm away from itself', () {
+      final point = GeoCoordinate(latitude: 40.6413, longitude: -73.7781);
+      expect(greatCircleDistanceNm(point, point), 0);
+    });
+
+    test('distance is symmetric', () {
+      final jfk = GeoCoordinate(latitude: 40.639801, longitude: -73.7789);
+      final lhr = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      expect(
+        greatCircleDistanceNm(jfk, lhr),
+        closeTo(greatCircleDistanceNm(lhr, jfk), 1e-9),
+      );
+    });
+
+    test('a quarter of the equator is R * pi/2 nm exactly', () {
+      // Two equatorial points 90 degrees of longitude apart reduce the
+      // haversine formula to R * dLon with no approximation involved, so
+      // this is an exact check on the formula, not a real-world estimate.
+      final a = GeoCoordinate(latitude: 0, longitude: 0);
+      final b = GeoCoordinate(latitude: 0, longitude: 90);
+      expect(greatCircleDistanceNm(a, b), closeTo(5403.64, 0.5));
+    });
+
+    test('antipodal points are half of Earth\'s circumference apart', () {
+      final a = GeoCoordinate(latitude: 10, longitude: 20);
+      final b = GeoCoordinate(latitude: -10, longitude: -160);
+      expect(greatCircleDistanceNm(a, b), closeTo(10807.28, 1.0));
+    });
+
+    test('JFK to LHR matches the published great-circle distance', () {
+      // Published distance is commonly cited as ~2991 nm (5541 km). A unit
+      // or formula bug (degrees instead of radians, statute miles instead
+      // of nm, swapped lat/lon) would miss by far more than this tolerance.
+      final jfk = GeoCoordinate(latitude: 40.639801, longitude: -73.7789);
+      final lhr = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      expect(greatCircleDistanceNm(jfk, lhr), closeTo(2991, 20));
+    });
+  });
+}

--- a/test/fixtures/aerodromes/README.md
+++ b/test/fixtures/aerodromes/README.md
@@ -1,0 +1,15 @@
+# Aerodrome fixtures
+
+Raw CSV, in OurAirports' own column format — unlike most of `test/fixtures/`, there is no YAML
+wrapper here, because the thing under test is the CSV parser itself; wrapping the input in YAML
+would add a translation step with nothing left to verify.
+
+- `sample_ourairports.csv` — a handful of representative rows: full ICAO+IATA (JFK, LHR), an
+  embedded comma inside a quoted `name` field (EWR, proving RFC4180 quoting is respected rather
+  than a naive comma split), a heliport with neither code (skipped), an IATA-only strip (kept,
+  not indexed by ICAO), a blank elevation, and an otherwise-valid row with unparseable
+  coordinates (skipped).
+- `duplicate_icao.csv` — two rows sharing one ICAO code, for the documented "later wins"
+  behaviour of `AerodromeDirectory`.
+- `missing_column.csv` — a header with `iso_country` removed, for the "reject rather than guess"
+  path when the upstream column layout changes.

--- a/test/fixtures/aerodromes/duplicate_icao.csv
+++ b/test/fixtures/aerodromes/duplicate_icao.csv
@@ -1,0 +1,3 @@
+"id","ident","type","name","latitude_deg","longitude_deg","elevation_ft","continent","iso_country","iso_region","municipality","scheduled_service","icao_code","iata_code","gps_code","local_code","home_link","wikipedia_link","keywords"
+1,"AAA","small_airport","First Entry",1.0,1.0,,,,,,,"DUPE",,,,,,
+2,"BBB","small_airport","Second Entry",2.0,2.0,,,,,,,"DUPE",,,,,,

--- a/test/fixtures/aerodromes/missing_column.csv
+++ b/test/fixtures/aerodromes/missing_column.csv
@@ -1,0 +1,2 @@
+"id","ident","type","name","latitude_deg","longitude_deg","elevation_ft","continent","iso_region","municipality","scheduled_service","icao_code","iata_code","gps_code","local_code","home_link","wikipedia_link","keywords"
+1,"AAA","small_airport","Missing Country Column",1.0,1.0,,,,,,"DUPE",,,,,,

--- a/test/fixtures/aerodromes/sample_ourairports.csv
+++ b/test/fixtures/aerodromes/sample_ourairports.csv
@@ -1,0 +1,8 @@
+"id","ident","type","name","latitude_deg","longitude_deg","elevation_ft","continent","iso_country","iso_region","municipality","scheduled_service","icao_code","iata_code","gps_code","local_code","home_link","wikipedia_link","keywords"
+3622,"JFK","large_airport","John F Kennedy International Airport",40.639801,-73.7789,13,"NA","US","US-NY","New York","yes","KJFK","JFK","KJFK","JFK",,"https://en.wikipedia.org/wiki/John_F._Kennedy_International_Airport","New York, NYC, Idlewild"
+2434,"LHR","large_airport","London Heathrow Airport",51.4706,-0.461941,83,"EU","GB","GB-ENG","London","yes","EGLL","LHR","EGLL","LHR",,"https://en.wikipedia.org/wiki/Heathrow_Airport","Heathrow, LHR, London Airport"
+6523,"00A","heliport","Total RF Heliport",40.070985,-74.933689,11,"NA","US","US-PA","Bensalem","no",,,"K00A","00A",,,
+99999,"XYZ1","small_airport","Remote Island Strip",-8.5,159.2,5,"OC","SB","SB-CT","Remote Island","no",,"XYZ",,"XYZ1",,,"remote strip"
+88888,"ZZZZ","small_airport","No Elevation Field Airport",10.0,20.0,,"AS","XX","XX-01","Nowhere","no","ZZZZ",,"ZZZZ","ZZZZ",,,
+77777,"BAD1","small_airport","Bad Coordinates Airport",,,,"AF","YY","YY-01","Somewhere","no","BADX",,"BADX","BAD1",,,
+55555,"EWR","large_airport","Newark, Liberty International Airport",40.6925,-74.1687,18,"NA","US","US-NJ","Newark","yes","KEWR","EWR","KEWR","EWR",,"https://en.wikipedia.org/wiki/Newark_Liberty_International_Airport","Newark Airport"


### PR DESCRIPTION
Closes #14

## The shape

`Aerodrome` — ICAO/IATA codes, name, position, elevation, country — is a plain freezed record with no derived fields. Both identifiers are nullable: #14 is explicit that a private strip or unlicensed field with no public dataset entry is the common case for GA logging, not an edge case.

`GeoCoordinate` validates its own lat/lon range at construction and carries `greatCircleDistanceNm` — haversine, in nautical miles since that's the unit `docs/jurisdiction-matrix.md` cites for FAA cross-country thresholds. #23/#24 will call it directly rather than each reimplementing distance math.

## The dataset

OurAirports' `airports.csv`, public domain, downloaded 2026-08-08. Bundled unfiltered for now — ~12 MB, every entry worldwide including closed strips and heliports. #106 tracks slimming it down before a release build; not urgent.

`parseOurAirportsCsv` reads columns by name, not fixed position, so a harmless reorder or an added column in a future re-download doesn't break parsing — only a renamed/removed required column does, and that raises `FormatException` naming it. A row is skipped if both ICAO and IATA would be blank (OurAirports carries thousands of closed/heliport entries with neither), or if its lat/lon doesn't parse.

`AerodromeDirectory` gives O(1) lookup by ICAO code. `byIcao` returns `null` for an unknown or unindexed code — it never throws, which is the "gracefully handle absence" behaviour #14 asks for.

## Also in this PR

`docs/jurisdiction-matrix.md`'s FAA cross-country entry previously summarised §61.1(b)(3) as "at least four distinct definitions" with a single 50 nm figure. Corrected to the full breakdown — a distance-less general definition plus six purpose-specific credit tests at 50, 25 or 15 nm depending on certificate/rating and rotorcraft/powered-parachute category — and #24 updated to match, since it's the issue that will need to implement all seven.

## Verification

101 tests passing, format/analyze/both layering guards clean. Mutation-tested the load-bearing logic: the ICAO-or-IATA skip condition, the haversine cross term, the missing-column guard, and the duplicate-ICAO last-wins behaviour each verified red under a deliberate mutation, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)