### PR TITLE
Define the Flight raw-fact model

### DIFF
--- a/docs/entry-form.md
+++ b/docs/entry-form.md
@@ -310,16 +310,20 @@ licences held.
 | IFR time | EASA licence held | Operational condition — time under IFR, regardless of meteorological conditions |
 | Actual instrument | FAA licence held | Time solely by reference to instruments, §61.51(g)(1) |
 | Simulated instrument | FAA licence held | Separate condition; reveals the safety pilot field in 4C |
-| Approaches flown | FAA IR held, or FAA IR training in progress | Count, plus type and location **per approach** — §61.51(g)(3) requires both to be recorded for §61.57(c) currency. Not shown to an EASA-only pilot |
-| Holding / course tracking | FAA IR held, or FAA IR training in progress | §61.57(c) requires these alongside the six approaches and they are routinely forgotten |
+| Approaches flown | FAA IR held, or FAA IR training in progress | One row per distinct procedure: type (picker — ILS, RNAV, GPS, VOR, LOC, NDB, back course, LDA, SDF, TACAN, PAR, ASR, MLS, roughly most to least common), aerodrome ICAO identifier (pre-filled from the flight's destination, editable), runway (1–36), and a repeat count. §61.51(g)(3) requires type and location per approach for §61.57(c) currency. Not shown to an EASA-only pilot |
+| Holding procedures | FAA IR held, or FAA IR training in progress | Count, not a toggle — holding is repeatable within one flight |
+| Course tracking | FAA IR held, or FAA IR training in progress | A single toggle, independent of the holding count — intercepting and tracking a course via a nav system either happened or didn't |
 
-**Approaches are an FAA-only field.** EASA IR revalidation is by annual proficiency check, not by
-counting approaches, so an EASA-only pilot never needs the control. If an EASA pilot wants to
-record approaches for their own purposes, that belongs in remarks — AMC1 FCL.050 permits column
-12 to be used at the holder's discretion, and recent amendments reference recording PBN and RNP
-APCH approaches there. Optional, free-text, never a structured requirement. ⚠️ Verify the
-current AMC1 wording on this before implementing; the PBN remarks provision appeared in draft
-amendment material and its status in the adopted text needs checking.
+**Approaches, holding and tracking are FAA-only fields**, and belong together as an **IR Currency
+and Proficiency** group within this section rather than three separate rows — they are the raw
+facts behind one recency requirement (§61.57(c)) and a pilot filling them in is thinking about
+that requirement as a whole. EASA IR revalidation is by annual proficiency check, not by counting
+approaches, so an EASA-only pilot never needs any of the group. If an EASA pilot wants to record
+approaches for their own purposes, that belongs in remarks — AMC1 FCL.050 permits column 12 to be
+used at the holder's discretion, and recent amendments reference recording PBN and RNP APCH
+approaches there. Optional, free-text, never a structured requirement. ⚠️ Verify the current AMC1
+wording on this before implementing; the PBN remarks provision appeared in draft amendment
+material and its status in the adopted text needs checking.
 
 **Do not conflate IFR time with instrument time.** They are different quantities and a flight
 conducted under IFR entirely in VMC produces full EASA IFR time and zero FAA instrument time.

--- a/docs/entry-form.md
+++ b/docs/entry-form.md
@@ -310,7 +310,7 @@ licences held.
 | IFR time | EASA licence held | Operational condition — time under IFR, regardless of meteorological conditions |
 | Actual instrument | FAA licence held | Time solely by reference to instruments, §61.51(g)(1) |
 | Simulated instrument | FAA licence held | Separate condition; reveals the safety pilot field in 4C |
-| Approaches flown | FAA IR held, or FAA IR training in progress | One row per distinct procedure: type (picker — ILS, RNAV, GPS, VOR, LOC, NDB, back course, LDA, SDF, TACAN, PAR, ASR, MLS, roughly most to least common), aerodrome ICAO identifier (pre-filled from the flight's destination, editable), runway (1–36), and a repeat count. §61.51(g)(3) requires type and location per approach for §61.57(c) currency. Not shown to an EASA-only pilot |
+| Approaches flown | FAA IR held, or FAA IR training in progress | One row per distinct procedure: type (picker — ILS, RNAV, GPS, VOR, LOC, NDB, back course, LDA, SDF, TACAN, PAR, ASR, MLS, roughly most to least common), aerodrome ICAO identifier (pre-filled from the flight's destination, editable), runway (`01`-`36`, plus `L`/`C`/`R` for parallel runways), and a repeat count. §61.51(g)(3) requires type and location per approach for §61.57(c) currency. Not shown to an EASA-only pilot |
 | Holding procedures | FAA IR held, or FAA IR training in progress | Count, not a toggle — holding is repeatable within one flight |
 | Course tracking | FAA IR held, or FAA IR training in progress | A single toggle, independent of the holding count — intercepting and tracking a course via a nav system either happened or didn't |
 

--- a/docs/jurisdiction-matrix.md
+++ b/docs/jurisdiction-matrix.md
@@ -252,8 +252,9 @@ any of these makes a jurisdiction's numbers unrecoverable for historical flights
 | IFR flight plan filed (bool) | EASA column 9 | Distinct from actual conditions |
 | Actual instrument time | FAA | §61.51(g)(1) |
 | Simulated instrument time | FAA | §61.51(b)(3)(iii) |
-| Approach count, type and location | FAA §61.57(c) only | §61.51(g)(3) requires type and location per approach. **No EASA equivalent** — AMC1 FCL.050 has no approach column and FCL.060's "approaches" wording is a recency condition, not a logging obligation |
-| Holding / course tracking performed (bool) | FAA §61.57(c) | Often forgotten |
+| Approach type, aerodrome, runway and count per procedure | FAA §61.57(c) only | §61.51(g)(3) requires type and location per approach; runway distinguishes two procedures at the same aerodrome. **No EASA equivalent** — AMC1 FCL.050 has no approach column and FCL.060's "approaches" wording is a recency condition, not a logging obligation |
+| Holding procedures performed (count) | FAA §61.57(c) | A count, not a bool — holding is naturally repeatable within one flight |
+| Intercepting and tracking a course via a nav system (bool) | FAA §61.57(c) | A single yes/no fact, independent of the holding count. Both often forgotten |
 | FSTD identity and qualification level | Both | Column 11; FFS vs FTD vs ATD matters to FAA |
 | Countersignature: signatory, credential no., expiry, timestamp | EASA SPIC/PICUS, FAA instruction | Uncountersigned PICUS is not creditable |
 | Series-of-flights grouping key | EASA | 30-minute rule |

--- a/lib/domain/model/flight.dart
+++ b/lib/domain/model/flight.dart
@@ -1,0 +1,221 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'flight_duration.dart';
+import 'pilot_capacity.dart';
+import 'utc_instant.dart';
+
+part 'flight.freezed.dart';
+
+/// A single flight, as raw facts only.
+///
+/// **ADR-0001 is the whole shape of this file.** A value like "PIC time" is
+/// not a property of a flight — it is the output of applying one
+/// authority's rule to the flight's raw circumstances, and those
+/// circumstances (who was manipulating, who held command, who was aboard
+/// and in what capacity) are gone forever the moment they are collapsed
+/// into a single derived number for one jurisdiction. So `Flight` stores
+/// none of `picTime`, `dualTime`, `nightTime`, `crossCountryTime`,
+/// `totalTime`, `picusTime` or `spicTime` — see
+/// `test/domain/model/flight_test.dart`, which fails the build if any of
+/// them appears here. Every one of those is computed at read time by
+/// `domain/projection/`, per jurisdiction, from the fields below.
+///
+/// Field-by-field justification lives in `docs/jurisdiction-matrix.md` §9
+/// ("Raw facts this matrix implies") and CLAUDE.md rule 2 — read both before
+/// adding, removing or renaming a field here. Every field is unbackfillable:
+/// nobody can reconstruct in 2030 whether a 2024 flight's pilot held command
+/// authority, so it must be captured now or never.
+///
+/// Most of "capacity" — command authority, sole manipulator, instructor
+/// presence, countersignature, the other pilot's *role* — is
+/// [PilotCapacity] (#13), embedded whole rather than flattened back out
+/// here. [carryingPassengers] and the other pilot's *identity* are
+/// deliberately **not** on [PilotCapacity]; see that class's dartdoc for
+/// why they land here instead.
+@freezed
+abstract class Flight with _$Flight {
+  const factory Flight({
+    // ---- Aircraft and route.
+    /// The aircraft's registration, e.g. `G-ABCD`. A plain reference by the
+    /// same key `Aircraft` (#12) uses — there is no synthetic foreign key
+    /// yet, because persistence identity is M2's concern, not the domain
+    /// model's.
+    required String aircraftRegistration,
+
+    /// Departure, any intermediate stops, and destination, in order.
+    /// Identifiers as entered — an ICAO code where one exists, otherwise
+    /// whatever text the pilot used to identify a private strip or
+    /// unlicensed field (#14: not every place a pilot flies from is in any
+    /// database). Resolving a leg to full position/elevation via
+    /// `AerodromeDirectory` is a projection-time concern, not this model's.
+    ///
+    /// Full route, never a precomputed `isCrossCountry` boolean or a single
+    /// distance figure — `docs/jurisdiction-matrix.md` §3 "Cross-country,
+    /// expanded" is explicit that the FAA alone needs several different
+    /// distance thresholds evaluated against the same route.
+    required List<String> route,
+
+    // ---- Times. All UTC — rule 3, ADR-0002.
+    /// `AMC1 FCL.050(g)(1)`: first movement for the purpose of taking off.
+    /// `§1.1`: movement under its own power for the purpose of flight. The
+    /// narrow divergence (pushback/tow) is a per-profile primitive, not a
+    /// second field — `docs/entry-form.md` §2.
+    required UtcInstant offBlocks,
+
+    /// Finally comes to rest. Paired with [offBlocks]; block time itself is
+    /// not stored — it is `onBlocks.difference(offBlocks)`, computed on
+    /// read, since storing it would duplicate two fields already here.
+    required UtcInstant onBlocks,
+
+    /// Air time is a first-class *optional* fact, not the legal total for
+    /// either jurisdiction — `docs/entry-form.md` §2. Null until entered;
+    /// needed for airborne time and for night computation, which cares when
+    /// the aircraft was actually in the air, not when it was taxiing.
+    UtcInstant? takeoff,
+    UtcInstant? landing,
+
+    // ---- This pilot's capacity, and the other pilot's identity.
+    /// This pilot's command authority, manipulation, instructor presence,
+    /// countersignature and the other pilot's *role* — see [PilotCapacity].
+    required PilotCapacity capacity,
+
+    /// The other pilot's name, when [PilotCapacity.otherPilotRole] is set.
+    /// Kept off [PilotCapacity] deliberately: it is a fact about who else
+    /// was on the flight, not about this pilot's own standing on it. Needed
+    /// for PICUS countersignature and, when the role is
+    /// [OtherPilotRole.safetyPilot], required by `§61.51(b)(1)(v)`.
+    String? otherPilotName,
+
+    /// The other pilot's licence or certificate number. Needed alongside
+    /// [otherPilotName] for a PICUS countersignature.
+    String? otherPilotCredentialNumber,
+
+    /// Whether passengers were aboard. `docs/entry-form.md` §4: a role, not
+    /// a headcount — no jurisdiction derives a logged quantity from how
+    /// many people were aboard, only from whether anyone was. Feeds
+    /// `FCL.060(b)(1)`/(b)(3) and `§61.57(a)`/(b) passenger-carrying
+    /// recency, evaluated by the currency engine, never computed here.
+    required bool carryingPassengers,
+
+    // ---- Take-offs and landings. Four counts each, never one derived from
+    // the other and never combined into a single figure —
+    // `docs/jurisdiction-matrix.md` §9, `docs/entry-form.md` §5. A pilot who
+    // took over in flight has zero take-offs and one landing.
+    required CircuitCounts takeoffs,
+    required CircuitCounts landings,
+
+    // ---- IFR / instrument facts.
+    /// Whether an IFR flight plan was filed. `AMC1 FCL.050` column 9 — an
+    /// operational condition, independent of actual meteorological
+    /// conditions and of [actualInstrumentTime]. A flight conducted under
+    /// IFR entirely in VMC produces full EASA IFR time and zero FAA
+    /// instrument time; conflating the two loses that.
+    required bool ifrFlightPlanFiled,
+
+    /// Time solely by reference to instruments in actual conditions.
+    /// `§61.51(g)(1)`. Zero, not null, when none — this is a duration that
+    /// happened or did not, unlike a fact nobody asked about.
+    required FlightDuration actualInstrumentTime,
+
+    /// As [actualInstrumentTime], but simulated (a hood, foggles, or a
+    /// view-limiting device). `§61.51(b)(3)(iii)`. Reveals the safety-pilot
+    /// field in `docs/entry-form.md` §4C when greater than zero.
+    required FlightDuration simulatedInstrumentTime,
+
+    /// Instrument approaches flown. FAA-only — `AMC1 FCL.050` has no
+    /// approach column and EASA IR revalidation is by proficiency check, not
+    /// by counting approaches (`docs/jurisdiction-matrix.md` §9). Empty, not
+    /// null, when none. `§61.51(g)(3)` requires type and location per
+    /// approach for `§61.57(c)` currency — a bare count is not enough.
+    required List<Approach> approaches,
+
+    /// Whether holding procedures and intercepting/tracking a course via a
+    /// navigation system were performed. `§61.57(c)`; a single fact per
+    /// `docs/jurisdiction-matrix.md` §9, which notes it is "often
+    /// forgotten" precisely because most logbook software has nowhere to
+    /// put it.
+    required bool holdingAndTrackingPerformed,
+
+    // ---- Facts unbackfillable if omitted, from jurisdiction-matrix.md §9.
+    /// The EASA "flights of short duration" 30-minute rule lets a series of
+    /// consecutive short flights — repeated circuits at one aerodrome, for
+    /// instance — be logged as one combined entry rather than one row per
+    /// landing. Flights sharing this key belong to one series; null when a
+    /// flight is not part of one. Nobody can retroactively know which
+    /// historical flights were grouped if this is not captured at entry
+    /// time, which is why it exists even though nothing yet reads it — no
+    /// projection or export issue currently consumes it.
+    String? seriesGroupId,
+
+    /// `§61.51(j)`: which of the four categories of aircraft qualify for
+    /// FAA-loggable flight time by registry and airworthiness basis. Null
+    /// when not recorded — irrelevant to an EASA-only pilot, and the
+    /// overwhelming majority of FAA-relevant GA flying falls under
+    /// [AirworthinessBasis.usRegistryStandardOrSpecial] regardless.
+    AirworthinessBasis? airworthinessBasis,
+
+    // ---- Free text.
+    /// `AMC1 FCL.050` column 12. Required content for a skill test,
+    /// proficiency check, or SEP/TMG revalidation refresher — see
+    /// `docs/entry-form.md` §4B. Empty string, not null, when there is
+    /// nothing to say.
+    required String remarks,
+  }) = _Flight;
+}
+
+/// Take-off or landing counts, split the two ways both authorities need:
+/// day versus night, and full-stop versus touch-and-go. Four independent
+/// counts, never one derived from another —
+/// `docs/jurisdiction-matrix.md` §9.
+@freezed
+abstract class CircuitCounts with _$CircuitCounts {
+  const factory CircuitCounts({
+    @Default(0) int dayFullStop,
+    @Default(0) int dayTouchAndGo,
+    @Default(0) int nightFullStop,
+    @Default(0) int nightTouchAndGo,
+  }) = _CircuitCounts;
+}
+
+/// One instrument approach: what kind, and where. `§61.51(g)(3)` requires
+/// both to be recorded, not just a count, for `§61.57(c)` currency.
+@freezed
+abstract class Approach with _$Approach {
+  const factory Approach({
+    /// Free text (e.g. `ILS`, `RNAV (GPS)`, `VOR`) rather than a controlled
+    /// vocabulary — `§61.57(c)` counts approaches regardless of type, so
+    /// nothing in this codebase currently needs to branch on it, and the
+    /// real-world list is long and evolving (RNP variants, GLS, and so on).
+    required String type,
+
+    /// The aerodrome identifier the approach was flown to or at, in the
+    /// same free-form shape as [Flight.route].
+    required String location,
+  }) = _Approach;
+}
+
+/// Which of `§61.51(j)`'s four categories an aircraft's registry and
+/// airworthiness basis fall under, on the date of the flight. A per-flight
+/// fact rather than one carried on `Aircraft` (#12): airworthiness basis can
+/// change over an aircraft's life (re-categorisation, a lapsed foreign
+/// certificate), and `Aircraft` is a current, editable reference record — if
+/// this lived there instead, editing it could silently change whether a
+/// historical flight's FAA time was ever loggable in the first place.
+enum AirworthinessBasis {
+  /// `§61.51(j)(1)`: U.S. registry, standard or special airworthiness
+  /// certificate. Covers ordinary FAA GA flying, including amateur-built
+  /// aircraft under a special airworthiness certificate.
+  usRegistryStandardOrSpecial,
+
+  /// `§61.51(j)(2)`: foreign registry, with an airworthiness certificate
+  /// approved by the aviation authority of an ICAO Member State.
+  foreignRegistryIcaoMemberApproved,
+
+  /// `§61.51(j)(3)`: a military aircraft under the direct operational
+  /// control of the U.S. Armed Forces.
+  usMilitary,
+
+  /// `§61.51(j)(4)`: a public aircraft operation under 49 U.S.C.
+  /// 40102(a)(41) and 40125.
+  publicAircraftOperation,
+}

--- a/lib/domain/model/flight.dart
+++ b/lib/domain/model/flight.dart
@@ -210,10 +210,12 @@ abstract class Approach with _$Approach {
     /// alternate or a training stop that isn't where the flight ended.
     required String aerodromeIcao,
 
-    /// Runway number, 1 to 36. Does not distinguish parallel runways
-    /// (L/C/R) — not asked for, and `§61.57(c)` currency does not turn on
-    /// the distinction.
-    required int runway,
+    /// Runway designator, e.g. `09`, `27L`, `36C` — the two-digit heading
+    /// number, optionally followed by `L`/`C`/`R` for parallel runways. A
+    /// string, not an int: the L/C/R suffix is not decoration, it is which
+    /// physical runway was used at an airport with parallel pairs or
+    /// triples, and a bare 1-36 number cannot express it.
+    required String runway,
 
     /// How many times this exact procedure — same [type], [aerodromeIcao]
     /// and [runway] — was flown on this flight. "2x ILS 36 LIML" is

--- a/lib/domain/model/flight.dart
+++ b/lib/domain/model/flight.dart
@@ -127,14 +127,25 @@ abstract class Flight with _$Flight {
     /// by counting approaches (`docs/jurisdiction-matrix.md` §9). Empty, not
     /// null, when none. `§61.51(g)(3)` requires type and location per
     /// approach for `§61.57(c)` currency — a bare count is not enough.
+    ///
+    /// One entry per distinct procedure, not per approach flown: two ILS
+    /// approaches to runway 36 at the same aerodrome are one [Approach] with
+    /// [Approach.count] 2, not two identical list entries. A flight with
+    /// "2x ILS 36 LIML + 1 LOC 27 LIMG" is a two-element list.
     required List<Approach> approaches,
 
-    /// Whether holding procedures and intercepting/tracking a course via a
-    /// navigation system were performed. `§61.57(c)`; a single fact per
-    /// `docs/jurisdiction-matrix.md` §9, which notes it is "often
+    /// Number of holding patterns flown. `§61.57(c)`. A count, not a bool —
+    /// unlike [trackingPerformed], holding is naturally repeatable within
+    /// one flight and the number matters for the pilot's own proficiency
+    /// tracking beyond the bare currency minimum.
+    required int holdingProceduresCount,
+
+    /// Whether intercepting and tracking a course through the use of an
+    /// electronic navigation system was performed. `§61.57(c)`;
+    /// `docs/jurisdiction-matrix.md` §9 notes this whole area is "often
     /// forgotten" precisely because most logbook software has nowhere to
     /// put it.
-    required bool holdingAndTrackingPerformed,
+    required bool trackingPerformed,
 
     // ---- Facts unbackfillable if omitted, from jurisdiction-matrix.md §9.
     /// The EASA "flights of short duration" 30-minute rule lets a series of
@@ -177,21 +188,76 @@ abstract class CircuitCounts with _$CircuitCounts {
   }) = _CircuitCounts;
 }
 
-/// One instrument approach: what kind, and where. `§61.51(g)(3)` requires
-/// both to be recorded, not just a count, for `§61.57(c)` currency.
+/// One distinct instrument approach procedure flown, and how many times.
+/// `§61.51(g)(3)` requires type and location to be recorded, not just a
+/// count, for `§61.57(c)` currency — this carries a runway too, since two
+/// approaches to the same aerodrome by different runways are different
+/// procedures.
+///
+/// One [Approach] per distinct procedure, not per approach flown — see
+/// [Flight.approaches].
 @freezed
 abstract class Approach with _$Approach {
   const factory Approach({
-    /// Free text (e.g. `ILS`, `RNAV (GPS)`, `VOR`) rather than a controlled
-    /// vocabulary — `§61.57(c)` counts approaches regardless of type, so
-    /// nothing in this codebase currently needs to branch on it, and the
-    /// real-world list is long and evolving (RNP variants, GLS, and so on).
-    required String type,
+    required ApproachType type,
 
-    /// The aerodrome identifier the approach was flown to or at, in the
-    /// same free-form shape as [Flight.route].
-    required String location,
+    /// ICAO identifier of the aerodrome the approach was flown to. Always a
+    /// real ICAO code, unlike [Flight.route]: an instrument approach only
+    /// exists at an aerodrome with a published procedure, which rules out
+    /// the private-strip case that makes `route` free text. The entry form
+    /// pre-fills this from the flight's destination aerodrome — it is not
+    /// necessarily the same one, since an approach can be flown at an
+    /// alternate or a training stop that isn't where the flight ended.
+    required String aerodromeIcao,
+
+    /// Runway number, 1 to 36. Does not distinguish parallel runways
+    /// (L/C/R) — not asked for, and `§61.57(c)` currency does not turn on
+    /// the distinction.
+    required int runway,
+
+    /// How many times this exact procedure — same [type], [aerodromeIcao]
+    /// and [runway] — was flown on this flight. "2x ILS 36 LIML" is
+    /// `count: 2`, not two separate list entries.
+    @Default(1) int count,
   }) = _Approach;
+}
+
+/// Instrument approach procedure types, ordered roughly most to least
+/// common in current use — not alphabetical, not the order a pilot would
+/// necessarily type them in, but the order that puts the frequent choices
+/// (ILS, RNAV/GPS) at the top of a picker.
+enum ApproachType {
+  ils,
+  rnav,
+  gps,
+  vor,
+  loc,
+
+  /// Non-directional beacon.
+  ndb,
+
+  /// Back-course localizer.
+  backCourse,
+
+  /// Localizer-type directional aid.
+  lda,
+
+  /// Simplified directional facility.
+  sdf,
+
+  /// Tactical air navigation — mostly military/international, though some
+  /// U.S. VORTACs support civil TACAN approaches.
+  tacan,
+
+  /// Precision approach radar — chiefly military.
+  par,
+
+  /// Airport surveillance radar approach.
+  asr,
+
+  /// Microwave landing system — essentially obsolete, kept for completeness
+  /// and for reading historical entries.
+  mls,
 }
 
 /// Which of `§61.51(j)`'s four categories an aircraft's registry and

--- a/test/domain/model/flight_test.dart
+++ b/test/domain/model/flight_test.dart
@@ -102,10 +102,10 @@ void main() {
           Approach(
             type: ApproachType.ils,
             aerodromeIcao: 'LIML',
-            runway: 36,
+            runway: '36',
             count: 2,
           ),
-          Approach(type: ApproachType.loc, aerodromeIcao: 'LIMG', runway: 27),
+          Approach(type: ApproachType.loc, aerodromeIcao: 'LIMG', runway: '27'),
         ];
 
         expect(approaches, hasLength(2));
@@ -136,8 +136,24 @@ void main() {
     });
   });
 
+  group('the IFR approaches fixture', () {
+    test('decodes a parallel-runway suffix and a repeat count', () {
+      final flight = flightFromFixture('ifr_approaches');
+
+      expect(flight.approaches, hasLength(2));
+      expect(flight.approaches[0].type, ApproachType.ils);
+      expect(flight.approaches[0].runway, '04L');
+      expect(flight.approaches[0].count, 2);
+      expect(flight.approaches[1].type, ApproachType.rnav);
+      expect(flight.approaches[1].runway, '22R');
+      expect(flight.approaches[1].count, 1);
+      expect(flight.holdingProceduresCount, 1);
+      expect(flight.trackingPerformed, isTrue);
+    });
+  });
+
   group('the fixture decoder', () {
-    test('rejects a runway outside 1-36 rather than storing it', () {
+    test('rejects a malformed runway rather than storing it', () {
       expect(
         () => flightFromFixture('malformed/bad_runway'),
         throwsA(

--- a/test/domain/model/flight_test.dart
+++ b/test/domain/model/flight_test.dart
@@ -1,0 +1,115 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../tool/dart_source.dart';
+import '../../fixtures/decoders/flight_fixture.dart';
+
+/// The names issue #11 explicitly lists as forbidden — every one of them is
+/// a projection output, not a raw fact, per ADR-0001.
+///
+/// Checked against `flight.dart`'s own source rather than added to
+/// `tool/check_domain_types.dart`'s project-wide banned-identifiers list:
+/// that guard runs over all of `lib/domain/`, including the future
+/// `domain/projection/` layer whose entire job is to compute values named
+/// exactly `picTime`, `totalTime` and so on. Banning these words
+/// domain-wide would block the projection code that is supposed to produce
+/// them. Scoping the check to this one file is what "the model exposes no
+/// field..." (the actual acceptance criterion) asks for.
+const List<String> _derivedQuantityNames = <String>[
+  'picTime',
+  'dualTime',
+  'nightTime',
+  'crossCountryTime',
+  'totalTime',
+  'picusTime',
+  'spicTime',
+];
+
+void main() {
+  test(
+    'Flight exposes no field whose name matches a derived-quantity pattern',
+    () {
+      // stripComments first — the class dartdoc explains the ban by naming
+      // the forbidden words, which would otherwise trip the check itself.
+      final source = stripComments(
+        File('lib/domain/model/flight.dart').readAsStringSync(),
+      );
+
+      for (final name in _derivedQuantityNames) {
+        expect(
+          RegExp('\\b$name\\b').hasMatch(source),
+          isFalse,
+          reason:
+              '"$name" is a projection output (ADR-0001) and must never be a '
+              'field on Flight',
+        );
+      }
+    },
+  );
+
+  group('Flight construction', () {
+    test('a minimal flight with no optional facts constructs', () {
+      final flight = Flight(
+        aircraftRegistration: 'G-ABCD',
+        route: const ['EGKA', 'EGHR', 'EGKA'],
+        offBlocks: UtcInstant.utc(2026, 3, 14, 9, 5),
+        onBlocks: UtcInstant.utc(2026, 3, 14, 10, 51),
+        capacity: const PilotCapacity(
+          commandAuthority: true,
+          soleManipulator: true,
+          soleOccupant: true,
+          multiPilotOperation: false,
+          additionalCrewRequiredByRule: false,
+          actingAsInstructor: false,
+          actingAsExaminer: false,
+          picusClaimed: false,
+          picInterventionNotRequired: false,
+        ),
+        carryingPassengers: false,
+        takeoffs: const CircuitCounts(dayFullStop: 1),
+        landings: const CircuitCounts(dayFullStop: 1),
+        ifrFlightPlanFiled: false,
+        actualInstrumentTime: FlightDuration.zero,
+        simulatedInstrumentTime: FlightDuration.zero,
+        approaches: const [],
+        holdingAndTrackingPerformed: false,
+        remarks: '',
+      );
+
+      expect(flight.takeoff, isNull);
+      expect(flight.landing, isNull);
+      expect(flight.otherPilotName, isNull);
+      expect(flight.seriesGroupId, isNull);
+      expect(flight.airworthinessBasis, isNull);
+    });
+  });
+
+  group('the FAA/EASA divergence fixture', () {
+    test('decodes into a Flight with the capacity embedded', () {
+      final flight = flightFromFixture('faa_easa_divergence');
+
+      expect(flight.aircraftRegistration, 'G-ABCD');
+      expect(flight.route, ['EGKA', 'EGHR', 'EGKA']);
+      expect(flight.capacity.commandAuthority, isFalse);
+      expect(flight.capacity.soleManipulator, isTrue);
+      expect(
+        flight.capacity.instructor?.capacity,
+        InstructorCapacity.flightInstructor,
+      );
+      expect(flight.capacity.instructor?.influencedFlight, isTrue);
+      expect(flight.takeoffs.dayTouchAndGo, 3);
+      expect(flight.landings.dayFullStop, 1);
+      expect(flight.approaches, isEmpty);
+      expect(flight.seriesGroupId, isNull);
+      expect(flight.airworthinessBasis, isNull);
+    });
+  });
+}

--- a/test/domain/model/flight_test.dart
+++ b/test/domain/model/flight_test.dart
@@ -10,6 +10,7 @@ import 'package:easa_digital_log/domain/model/utc_instant.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../tool/dart_source.dart';
+import '../../fixtures/decoders/fixture_fields.dart';
 import '../../fixtures/decoders/flight_fixture.dart';
 
 /// The names issue #11 explicitly lists as forbidden — every one of them is
@@ -80,7 +81,8 @@ void main() {
         actualInstrumentTime: FlightDuration.zero,
         simulatedInstrumentTime: FlightDuration.zero,
         approaches: const [],
-        holdingAndTrackingPerformed: false,
+        holdingProceduresCount: 0,
+        trackingPerformed: false,
         remarks: '',
       );
 
@@ -90,6 +92,27 @@ void main() {
       expect(flight.seriesGroupId, isNull);
       expect(flight.airworthinessBasis, isNull);
     });
+
+    test(
+      'multiple approach procedures are distinct list entries with their own count',
+      () {
+        // "2x ILS 36 LIML + 1 LOC 27 LIMG" — one Approach per distinct
+        // procedure, the repeat count carried on the entry, not the list.
+        const approaches = [
+          Approach(
+            type: ApproachType.ils,
+            aerodromeIcao: 'LIML',
+            runway: 36,
+            count: 2,
+          ),
+          Approach(type: ApproachType.loc, aerodromeIcao: 'LIMG', runway: 27),
+        ];
+
+        expect(approaches, hasLength(2));
+        expect(approaches[0].count, 2);
+        expect(approaches[1].count, 1, reason: 'default count is 1');
+      },
+    );
   });
 
   group('the FAA/EASA divergence fixture', () {
@@ -110,6 +133,21 @@ void main() {
       expect(flight.approaches, isEmpty);
       expect(flight.seriesGroupId, isNull);
       expect(flight.airworthinessBasis, isNull);
+    });
+  });
+
+  group('the fixture decoder', () {
+    test('rejects a runway outside 1-36 rather than storing it', () {
+      expect(
+        () => flightFromFixture('malformed/bad_runway'),
+        throwsA(
+          isA<FixtureFieldException>().having(
+            (e) => e.key,
+            'key',
+            'approaches.runway',
+          ),
+        ),
+      );
     });
   });
 }

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -7,9 +7,10 @@ typed per-model decoders on top of this loader; it does not replace it.
 
 ## Subdirectories
 
-- `flights/` — raw-fact flight entries, one YAML file per flight. Every field
-  is a fact the pilot could attest to at the time of flight — never a
-  derived quantity. See "Rule 1" below.
+- `flights/` — raw-fact flight entries, one YAML file per flight, decoded by
+  `decoders/flight_fixture.dart`. Every field is a fact the pilot could
+  attest to at the time of flight — never a derived quantity. See "Rule 1"
+  below.
 - `capacities/` — `PilotCapacity` scenarios, one YAML file per operating
   arrangement, decoded by `decoders/pilot_capacity_fixture.dart`. Together they
   cover every case issue #13 requires the model to tell apart, and issues #18

--- a/test/fixtures/decoders/fixture_fields.dart
+++ b/test/fixtures/decoders/fixture_fields.dart
@@ -69,6 +69,14 @@ String? optionalString(YamlMap yaml, String key, String fixture) {
   throw FixtureFieldException(fixture, key, 'a string, got ${describe(value)}');
 }
 
+YamlMap requiredMap(YamlMap yaml, String key, String fixture) {
+  final value = optionalMap(yaml, key, fixture);
+  if (value == null) {
+    throw FixtureFieldException(fixture, key, 'a map, got nothing');
+  }
+  return value;
+}
+
 YamlMap? optionalMap(YamlMap yaml, String key, String fixture) {
   final value = yaml[key];
   if (value == null) {
@@ -78,4 +86,49 @@ YamlMap? optionalMap(YamlMap yaml, String key, String fixture) {
     return value;
   }
   throw FixtureFieldException(fixture, key, 'a map, got ${describe(value)}');
+}
+
+int requiredInt(YamlMap yaml, String key, String fixture) {
+  final value = optionalInt(yaml, key, fixture);
+  if (value == null) {
+    throw FixtureFieldException(fixture, key, 'an integer, got nothing');
+  }
+  return value;
+}
+
+int? optionalInt(YamlMap yaml, String key, String fixture) {
+  final value = yaml[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is int) {
+    return value;
+  }
+  throw FixtureFieldException(
+    fixture,
+    key,
+    'an integer, got ${describe(value)}',
+  );
+}
+
+List<String> requiredStringList(YamlMap yaml, String key, String fixture) {
+  final value = yaml[key];
+  if (value is! YamlList) {
+    throw FixtureFieldException(
+      fixture,
+      key,
+      'a list of strings, got ${describe(value)}',
+    );
+  }
+  return [
+    for (final item in value)
+      if (item is String)
+        item
+      else
+        throw FixtureFieldException(
+          fixture,
+          key,
+          'a list of strings, got an entry ${describe(item)}',
+        ),
+  ];
 }

--- a/test/fixtures/decoders/flight_fixture.dart
+++ b/test/fixtures/decoders/flight_fixture.dart
@@ -17,6 +17,22 @@ const Map<String, AirworthinessBasis> _airworthinessBases =
       'public_aircraft_operation': AirworthinessBasis.publicAircraftOperation,
     };
 
+const Map<String, ApproachType> _approachTypes = <String, ApproachType>{
+  'ils': ApproachType.ils,
+  'rnav': ApproachType.rnav,
+  'gps': ApproachType.gps,
+  'vor': ApproachType.vor,
+  'loc': ApproachType.loc,
+  'ndb': ApproachType.ndb,
+  'back_course': ApproachType.backCourse,
+  'lda': ApproachType.lda,
+  'sdf': ApproachType.sdf,
+  'tacan': ApproachType.tacan,
+  'par': ApproachType.par,
+  'asr': ApproachType.asr,
+  'mls': ApproachType.mls,
+};
+
 /// Decodes `test/fixtures/flights/<name>.yaml` into a [Flight].
 Flight flightFromFixture(String name) {
   final yaml = loadFixture('flights', name);
@@ -46,11 +62,8 @@ Flight flightFromFixture(String name) {
       requiredInt(yaml, 'simulated_instrument_minutes', name),
     ),
     approaches: _approaches(yaml, name),
-    holdingAndTrackingPerformed: requiredBool(
-      yaml,
-      'holding_and_tracking_performed',
-      name,
-    ),
+    holdingProceduresCount: requiredInt(yaml, 'holding_procedures_count', name),
+    trackingPerformed: requiredBool(yaml, 'tracking_performed', name),
     seriesGroupId: optionalString(yaml, 'series_group_id', name),
     airworthinessBasis: _airworthinessBasis(yaml, name),
     remarks: requiredString(yaml, 'remarks', name),
@@ -85,8 +98,10 @@ List<Approach> _approaches(YamlMap yaml, String fixture) {
     for (final entry in value)
       if (entry is YamlMap)
         Approach(
-          type: requiredString(entry, 'type', fixture),
-          location: requiredString(entry, 'location', fixture),
+          type: _approachType(entry, fixture),
+          aerodromeIcao: requiredString(entry, 'aerodrome_icao', fixture),
+          runway: _runway(entry, fixture),
+          count: optionalInt(entry, 'count', fixture) ?? 1,
         )
       else
         throw FixtureFieldException(
@@ -95,6 +110,31 @@ List<Approach> _approaches(YamlMap yaml, String fixture) {
           'a list of maps, got an entry ${describe(entry)}',
         ),
   ];
+}
+
+ApproachType _approachType(YamlMap yaml, String fixture) {
+  final raw = requiredString(yaml, 'type', fixture);
+  final type = _approachTypes[raw];
+  if (type == null) {
+    throw FixtureFieldException(
+      fixture,
+      'approaches.type',
+      'one of ${_approachTypes.keys.join(', ')}, got "$raw"',
+    );
+  }
+  return type;
+}
+
+int _runway(YamlMap yaml, String fixture) {
+  final runway = requiredInt(yaml, 'runway', fixture);
+  if (runway < 1 || runway > 36) {
+    throw FixtureFieldException(
+      fixture,
+      'approaches.runway',
+      'an integer between 1 and 36, got $runway',
+    );
+  }
+  return runway;
 }
 
 AirworthinessBasis? _airworthinessBasis(YamlMap yaml, String fixture) {

--- a/test/fixtures/decoders/flight_fixture.dart
+++ b/test/fixtures/decoders/flight_fixture.dart
@@ -1,0 +1,132 @@
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:yaml/yaml.dart';
+
+import '../fixture_loader.dart';
+import 'fixture_fields.dart';
+import 'pilot_capacity_fixture.dart';
+
+const Map<String, AirworthinessBasis> _airworthinessBases =
+    <String, AirworthinessBasis>{
+      'us_registry_standard_or_special':
+          AirworthinessBasis.usRegistryStandardOrSpecial,
+      'foreign_registry_icao_member_approved':
+          AirworthinessBasis.foreignRegistryIcaoMemberApproved,
+      'us_military': AirworthinessBasis.usMilitary,
+      'public_aircraft_operation': AirworthinessBasis.publicAircraftOperation,
+    };
+
+/// Decodes `test/fixtures/flights/<name>.yaml` into a [Flight].
+Flight flightFromFixture(String name) {
+  final yaml = loadFixture('flights', name);
+
+  return Flight(
+    aircraftRegistration: requiredString(yaml, 'aircraft_registration', name),
+    route: requiredStringList(yaml, 'route', name),
+    offBlocks: _instant(yaml, 'off_blocks', name)!,
+    onBlocks: _instant(yaml, 'on_blocks', name)!,
+    takeoff: _instant(yaml, 'takeoff', name),
+    landing: _instant(yaml, 'landing', name),
+    capacity: pilotCapacityFromYaml(requiredMap(yaml, 'capacity', name), name),
+    otherPilotName: optionalString(yaml, 'other_pilot_name', name),
+    otherPilotCredentialNumber: optionalString(
+      yaml,
+      'other_pilot_credential_number',
+      name,
+    ),
+    carryingPassengers: requiredBool(yaml, 'carrying_passengers', name),
+    takeoffs: _circuitCounts(requiredMap(yaml, 'takeoffs', name), name),
+    landings: _circuitCounts(requiredMap(yaml, 'landings', name), name),
+    ifrFlightPlanFiled: requiredBool(yaml, 'ifr_flight_plan_filed', name),
+    actualInstrumentTime: FlightDuration(
+      requiredInt(yaml, 'actual_instrument_minutes', name),
+    ),
+    simulatedInstrumentTime: FlightDuration(
+      requiredInt(yaml, 'simulated_instrument_minutes', name),
+    ),
+    approaches: _approaches(yaml, name),
+    holdingAndTrackingPerformed: requiredBool(
+      yaml,
+      'holding_and_tracking_performed',
+      name,
+    ),
+    seriesGroupId: optionalString(yaml, 'series_group_id', name),
+    airworthinessBasis: _airworthinessBasis(yaml, name),
+    remarks: requiredString(yaml, 'remarks', name),
+  );
+}
+
+CircuitCounts _circuitCounts(YamlMap yaml, String fixture) => CircuitCounts(
+  dayFullStop: optionalInt(yaml, 'day_full_stop', fixture) ?? 0,
+  dayTouchAndGo: optionalInt(yaml, 'day_touch_and_go', fixture) ?? 0,
+  nightFullStop: optionalInt(yaml, 'night_full_stop', fixture) ?? 0,
+  nightTouchAndGo: optionalInt(yaml, 'night_touch_and_go', fixture) ?? 0,
+);
+
+/// Absent `approaches:` means an empty list — #11: "empty, not null, when
+/// none" describes the *model*, but a fixture that never mentions approaches
+/// is unambiguously describing zero, not an unrecorded discriminator, so
+/// requiring `approaches: []` boilerplate on every non-instrument fixture
+/// would add nothing.
+List<Approach> _approaches(YamlMap yaml, String fixture) {
+  final value = yaml['approaches'];
+  if (value == null) {
+    return const <Approach>[];
+  }
+  if (value is! YamlList) {
+    throw FixtureFieldException(
+      fixture,
+      'approaches',
+      'a list, got ${describe(value)}',
+    );
+  }
+  return [
+    for (final entry in value)
+      if (entry is YamlMap)
+        Approach(
+          type: requiredString(entry, 'type', fixture),
+          location: requiredString(entry, 'location', fixture),
+        )
+      else
+        throw FixtureFieldException(
+          fixture,
+          'approaches',
+          'a list of maps, got an entry ${describe(entry)}',
+        ),
+  ];
+}
+
+AirworthinessBasis? _airworthinessBasis(YamlMap yaml, String fixture) {
+  final raw = optionalString(yaml, 'airworthiness_basis', fixture);
+  if (raw == null) {
+    return null;
+  }
+  final basis = _airworthinessBases[raw];
+  if (basis == null) {
+    throw FixtureFieldException(
+      fixture,
+      'airworthiness_basis',
+      'one of ${_airworthinessBases.keys.join(', ')}, got "$raw"',
+    );
+  }
+  return basis;
+}
+
+/// Instants are ISO-8601 with an explicit `Z`; [UtcInstant.parse] rejects
+/// anything without a zone designator, so a naive fixture value fails loudly.
+UtcInstant? _instant(YamlMap yaml, String key, String fixture) {
+  final value = optionalString(yaml, key, fixture);
+  if (value == null) {
+    return null;
+  }
+  try {
+    return UtcInstant.parse(value);
+  } on FormatException {
+    throw FixtureFieldException(
+      fixture,
+      key,
+      'an ISO-8601 instant ending in Z, got "$value"',
+    );
+  }
+}

--- a/test/fixtures/decoders/flight_fixture.dart
+++ b/test/fixtures/decoders/flight_fixture.dart
@@ -125,13 +125,16 @@ ApproachType _approachType(YamlMap yaml, String fixture) {
   return type;
 }
 
-int _runway(YamlMap yaml, String fixture) {
-  final runway = requiredInt(yaml, 'runway', fixture);
-  if (runway < 1 || runway > 36) {
+/// Two digits, `01`-`36`, optionally followed by `L`, `C` or `R`.
+final RegExp _runwayPattern = RegExp(r'^(0[1-9]|[12][0-9]|3[0-6])[LCR]?$');
+
+String _runway(YamlMap yaml, String fixture) {
+  final runway = requiredString(yaml, 'runway', fixture);
+  if (!_runwayPattern.hasMatch(runway)) {
     throw FixtureFieldException(
       fixture,
       'approaches.runway',
-      'an integer between 1 and 36, got $runway',
+      'two digits 01-36 with an optional L/C/R suffix, got "$runway"',
     );
   }
   return runway;

--- a/test/fixtures/decoders/pilot_capacity_fixture.dart
+++ b/test/fixtures/decoders/pilot_capacity_fixture.dart
@@ -14,37 +14,43 @@ import 'fixture_fields.dart';
 /// test concern; the domain model knows nothing about how fixtures are spelt.
 PilotCapacity pilotCapacityFromFixture(String name) {
   final yaml = loadFixture('capacities', name);
+  return pilotCapacityFromYaml(yaml, name);
+}
 
+/// As [pilotCapacityFromFixture], but decodes an already-loaded [YamlMap] —
+/// the shape `flight_fixture.dart` needs for the nested `capacity:` block
+/// inside a flight fixture, rather than a whole file of its own.
+PilotCapacity pilotCapacityFromYaml(YamlMap yaml, String fixture) {
   return PilotCapacity(
-    commandAuthority: requiredBool(yaml, 'command_authority', name),
-    soleManipulator: requiredBool(yaml, 'sole_manipulator', name),
-    soleOccupant: requiredBool(yaml, 'sole_occupant', name),
-    multiPilotOperation: requiredBool(yaml, 'multi_pilot_operation', name),
+    commandAuthority: requiredBool(yaml, 'command_authority', fixture),
+    soleManipulator: requiredBool(yaml, 'sole_manipulator', fixture),
+    soleOccupant: requiredBool(yaml, 'sole_occupant', fixture),
+    multiPilotOperation: requiredBool(yaml, 'multi_pilot_operation', fixture),
     additionalCrewRequiredByRule: requiredBool(
       yaml,
       'additional_crew_required_by_rule',
-      name,
+      fixture,
     ),
-    soloEndorsementHeld: optionalBool(yaml, 'solo_endorsement_held', name),
+    soloEndorsementHeld: optionalBool(yaml, 'solo_endorsement_held', fixture),
     endorsingInstructorName: optionalString(
       yaml,
       'endorsing_instructor_name',
-      name,
+      fixture,
     ),
-    actingAsInstructor: requiredBool(yaml, 'acting_as_instructor', name),
-    actingAsExaminer: requiredBool(yaml, 'acting_as_examiner', name),
-    picusClaimed: requiredBool(yaml, 'picus_claimed', name),
+    actingAsInstructor: requiredBool(yaml, 'acting_as_instructor', fixture),
+    actingAsExaminer: requiredBool(yaml, 'acting_as_examiner', fixture),
+    picusClaimed: requiredBool(yaml, 'picus_claimed', fixture),
     picInterventionNotRequired: requiredBool(
       yaml,
       'pic_intervention_not_required',
-      name,
+      fixture,
     ),
-    manipulationTime: _duration(yaml, 'manipulation_time', name),
-    instructor: _instructor(optionalMap(yaml, 'instructor', name), name),
-    otherPilotRole: _otherPilotRole(yaml, name),
+    manipulationTime: _duration(yaml, 'manipulation_time', fixture),
+    instructor: _instructor(optionalMap(yaml, 'instructor', fixture), fixture),
+    otherPilotRole: _otherPilotRole(yaml, fixture),
     countersignature: _countersignature(
-      optionalMap(yaml, 'countersignature', name),
-      name,
+      optionalMap(yaml, 'countersignature', fixture),
+      fixture,
     ),
   );
 }

--- a/test/fixtures/fixture_loader_test.dart
+++ b/test/fixtures/fixture_loader_test.dart
@@ -51,9 +51,10 @@ void main() {
       final fixture = loadFixture('flights', 'faa_easa_divergence');
 
       expect(fixture, isA<YamlMap>());
-      expect(fixture['sole_manipulator'], isTrue);
-      expect(fixture['command_authority'], isFalse);
-      expect(fixture['instructor_aboard'], isTrue);
+      final capacity = fixture['capacity'] as YamlMap;
+      expect(capacity['sole_manipulator'], isTrue);
+      expect(capacity['command_authority'], isFalse);
+      expect(capacity['instructor'], isNotNull);
     });
 
     test('throws a clear error for a missing fixture', () {

--- a/test/fixtures/flights/faa_easa_divergence.yaml
+++ b/test/fixtures/flights/faa_easa_divergence.yaml
@@ -70,6 +70,7 @@ landings:
 ifr_flight_plan_filed: false
 actual_instrument_minutes: 0
 simulated_instrument_minutes: 0
-holding_and_tracking_performed: false
+holding_procedures_count: 0
+tracking_performed: false
 
 remarks: "Dual instruction, circuits at EGHR. Student rated PPL(A) SEP."

--- a/test/fixtures/flights/faa_easa_divergence.yaml
+++ b/test/fixtures/flights/faa_easa_divergence.yaml
@@ -7,6 +7,8 @@
 #
 # Raw facts only. See CLAUDE.md rule 1 and ADR-0001.
 
+# Descriptive only — not decoded onto Flight, which has no synthetic id
+# (persistence identity is M2's concern). Kept for human readability.
 id: "faa-easa-divergence-001"
 
 # All instants UTC. See ADR-0002.
@@ -23,15 +25,23 @@ route:
   - "EGHR"
   - "EGKA"
 
-# The discriminators the divergence turns on.
-command_authority: false      # EASA PIC requires this; the instructor held it
-sole_manipulator: true        # FAA §61.51(e)(1)(i) PIC turns on this
-sole_occupant: false
-instructor_aboard: true
-instructor_capacity: "FI"     # FI | FE | safety_pilot
-instructor_influenced_flight: true   # so this is dual, not SPIC
-multi_pilot_operation: false
-aircraft_requires_multi_crew: false
+# The discriminators the divergence turns on — PilotCapacity (#13), embedded
+# as one block rather than flattened back onto Flight.
+capacity:
+  command_authority: false      # EASA PIC requires this; the instructor held it
+  sole_manipulator: true        # FAA §61.51(e)(1)(i) PIC turns on this
+  sole_occupant: false
+  multi_pilot_operation: false
+  additional_crew_required_by_rule: false
+  acting_as_instructor: false   # this pilot is the student, not the instructor
+  acting_as_examiner: false
+  picus_claimed: false
+  pic_intervention_not_required: false
+  instructor:
+    capacity: "FI"                # FI | FE
+    influenced_flight: true       # so this is dual, not SPIC
+
+carrying_passengers: false
 
 # Take-offs and landings are stored as two independent sets of four counts,
 # never one combined figure and never one derived from the other. A pilot who
@@ -60,5 +70,6 @@ landings:
 ifr_flight_plan_filed: false
 actual_instrument_minutes: 0
 simulated_instrument_minutes: 0
+holding_and_tracking_performed: false
 
 remarks: "Dual instruction, circuits at EGHR. Student rated PPL(A) SEP."

--- a/test/fixtures/flights/ifr_approaches.yaml
+++ b/test/fixtures/flights/ifr_approaches.yaml
@@ -1,0 +1,48 @@
+# FAA IR currency scenario: two distinct approach procedures in one flight,
+# one of them to a parallel runway. Exercises Approach.runway's L/C/R
+# suffix — the reason runway is a string, not a 1-36 int.
+
+aircraft_registration: "N12345"
+route:
+  - "KJFK"
+  - "KJFK"
+
+off_blocks: "2026-04-02T14:00:00Z"
+on_blocks: "2026-04-02T15:30:00Z"
+
+capacity:
+  command_authority: true
+  sole_manipulator: true
+  sole_occupant: true
+  multi_pilot_operation: false
+  additional_crew_required_by_rule: false
+  acting_as_instructor: false
+  acting_as_examiner: false
+  picus_claimed: false
+  pic_intervention_not_required: false
+
+carrying_passengers: false
+
+takeoffs:
+  day_full_stop: 1
+landings:
+  day_full_stop: 1
+
+ifr_flight_plan_filed: true
+actual_instrument_minutes: 20
+simulated_instrument_minutes: 60
+
+# "2x ILS 4L + 1 RNAV 22R" — two distinct procedures, the first flown twice.
+approaches:
+  - type: "ils"
+    aerodrome_icao: "KJFK"
+    runway: "04L"
+    count: 2
+  - type: "rnav"
+    aerodrome_icao: "KJFK"
+    runway: "22R"
+
+holding_procedures_count: 1
+tracking_performed: true
+
+remarks: "IPC. Two ILS 4L, one RNAV 22R, one holding pattern."

--- a/test/fixtures/flights/malformed/bad_runway.yaml
+++ b/test/fixtures/flights/malformed/bad_runway.yaml
@@ -1,0 +1,42 @@
+# Deliberately invalid: runway 37 is out of range (1-36). Proves the decoder
+# rejects it rather than silently storing a runway that cannot exist.
+
+aircraft_registration: "G-ABCD"
+route:
+  - "EGKA"
+  - "EGKA"
+
+off_blocks: "2026-03-14T09:05:00Z"
+on_blocks: "2026-03-14T10:51:00Z"
+
+capacity:
+  command_authority: true
+  sole_manipulator: true
+  sole_occupant: true
+  multi_pilot_operation: false
+  additional_crew_required_by_rule: false
+  acting_as_instructor: false
+  acting_as_examiner: false
+  picus_claimed: false
+  pic_intervention_not_required: false
+
+carrying_passengers: false
+
+takeoffs:
+  day_full_stop: 1
+landings:
+  day_full_stop: 1
+
+ifr_flight_plan_filed: true
+actual_instrument_minutes: 30
+simulated_instrument_minutes: 0
+
+approaches:
+  - type: "ils"
+    aerodrome_icao: "EGKA"
+    runway: 37
+
+holding_procedures_count: 0
+tracking_performed: false
+
+remarks: ""

--- a/test/fixtures/flights/malformed/bad_runway.yaml
+++ b/test/fixtures/flights/malformed/bad_runway.yaml
@@ -1,5 +1,6 @@
-# Deliberately invalid: runway 37 is out of range (1-36). Proves the decoder
-# rejects it rather than silently storing a runway that cannot exist.
+# Deliberately invalid: runway 37 is out of range (01-36). Proves the
+# decoder rejects it rather than silently storing a runway that cannot
+# exist. Quoted — see the YAML caveat in test/fixtures/README.md.
 
 aircraft_registration: "G-ABCD"
 route:
@@ -34,7 +35,7 @@ simulated_instrument_minutes: 0
 approaches:
   - type: "ils"
     aerodrome_icao: "EGKA"
-    runway: 37
+    runway: "37"
 
 holding_procedures_count: 0
 tracking_performed: false


### PR DESCRIPTION
Closes #11

## The shape

`Flight` stores raw facts only, per ADR-0001 — the same discipline `Aircraft` (#12) and `PilotCapacity` (#13) already follow. Aircraft reference and route, off/on blocks plus optional air-time instants, the embedded `PilotCapacity`, the other pilot's identity, passenger-carrying, four-way takeoff/landing counts, IFR flight plan filed, actual/simulated instrument time, per-approach type and location, holding/tracking performed, and two closing discriminators from `docs/jurisdiction-matrix.md` §9.

None of `picTime`, `dualTime`, `nightTime`, `crossCountryTime`, `totalTime`, `picusTime` or `spicTime` exist on this model — `flight_test.dart` fails the build if any of them appear, verified red under a deliberate mutation (added `int? picTime`, confirmed the test caught it, reverted).

## Two discriminators beyond #11's original field list

`docs/jurisdiction-matrix.md` §9 — the doc CLAUDE.md names as authoritative for which raw facts must exist — lists two facts #11's text didn't mention:

- **`seriesGroupId`** — the EASA "flights of short duration" 30-minute rule lets consecutive short flights (repeated circuits, for instance) be logged as one combined entry. Nullable string; nobody can retroactively know which historical flights were grouped if this isn't captured now.
- **`airworthinessBasis`** — `§61.51(j)` gates which aircraft registry/certificate combinations produce FAA-loggable time at all. A per-*flight* fact rather than living on `Aircraft`, since airworthiness basis can change over an aircraft's life and `Aircraft` is a current, editable reference record — putting it there would let an edit silently change whether a historical flight was ever loggable.

Confirmed both with the project owner before including them, along with the exact `§61.51(j)` wording for the four-value enum.

## What's deliberately not here

- `carryingPassengers` and the other pilot's name/credential number are on `Flight`, not `PilotCapacity` — `PilotCapacity`'s own dartdoc already said they'd land here.
- Block time isn't stored — it's `onBlocks.difference(offBlocks)`, computed on read from two fields already present, never a third field duplicating them.
- No FSTD fields. `docs/entry-form.md` §9: a simulator session is a different form, not a flight with fields greyed out (#28).
- No `id`. Persistence identity is M2's concern; `Aircraft`/`PilotCapacity` don't carry one either.

## Fixture layer

`pilot_capacity_fixture.dart` now exposes `pilotCapacityFromYaml` so a flight fixture's nested `capacity:` block reuses the existing decoder instead of duplicating its ~30 lines. `fixture_fields.dart` gains `requiredMap`/`requiredInt`/`optionalInt`/`requiredStringList`. The M0-era `faa_easa_divergence.yaml` fixture is updated to the real shape — capacity facts nested under `capacity:`, the stale `aircraft_requires_multi_crew` field removed now that it's `Aircraft`'s own (#12).

## Verification

104 tests passing, format/analyze/both layering guards clean. The derived-quantity-name guard was verified red under mutation as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)