### PR TITLE
Define the Projection interface and ship EASA + FAA pilot function time

### DIFF
--- a/assets/jurisdictions/eu.easa.part-fcl.yaml
+++ b/assets/jurisdictions/eu.easa.part-fcl.yaml
@@ -1,0 +1,7 @@
+# EASA Part-FCL. See docs/jurisdiction-matrix.md and docs/adr/0001-raw-facts-only.md.
+#
+# Root profile — nothing to extend yet. UK CAA Part-FCL will extend this
+# once it's modelled; see JurisdictionProfile's dartdoc for the mechanism.
+id: eu.easa.part-fcl
+
+pic_rule: easa.pilot_function_time

--- a/assets/jurisdictions/us.faa.part61.yaml
+++ b/assets/jurisdictions/us.faa.part61.yaml
@@ -1,0 +1,7 @@
+# FAA 14 CFR Part 61. See docs/jurisdiction-matrix.md and docs/adr/0001-raw-facts-only.md.
+#
+# A root profile like eu.easa.part-fcl.yaml — the FAA is its own lineage,
+# not a variant of EASA, so it does not extend anything.
+id: us.faa.part61
+
+pic_rule: faa.pilot_function_time

--- a/lib/domain/jurisdiction/jurisdiction_profile.dart
+++ b/lib/domain/jurisdiction/jurisdiction_profile.dart
@@ -1,0 +1,120 @@
+import 'package:yaml/yaml.dart';
+
+/// One authority's declarative profile, as written in
+/// `assets/jurisdictions/*.yaml` — CLAUDE.md: "Authorities are declarative
+/// profiles... resolved through a registry," never a Dart class or an enum
+/// value per authority.
+///
+/// This is the profile *as authored in one file*: its own rules, plus a
+/// pointer to what it [extends], if anything. It is not yet resolved — a
+/// profile that extends another does not carry the parent's rules until
+/// [JurisdictionRegistry.resolve] walks the chain. See
+/// [ResolvedJurisdictionProfile] for the flattened result.
+class JurisdictionProfile {
+  const JurisdictionProfile({
+    required this.id,
+    this.extendsId,
+    required this.rules,
+  });
+
+  /// e.g. `eu.easa.part-fcl`, `us.faa.part61`, `uk.caa.part-fcl`.
+  final String id;
+
+  /// The parent profile's [id], or `null` for a root profile. UK Part-FCL
+  /// extending EASA is CLAUDE.md's own example of why this exists — a fix
+  /// to the shared EASA lineage lands in one place rather than two.
+  final String? extendsId;
+
+  /// Rule-name to primitive-id mappings this profile declares or overrides,
+  /// e.g. `{'pic_rule': 'easa.pilot_function_time'}`. For a profile with no
+  /// [extendsId], these are its complete rules; for one that extends another,
+  /// these are only the deltas — see [JurisdictionRegistry.resolve] for how
+  /// the two are merged.
+  final Map<String, String> rules;
+}
+
+/// A [JurisdictionProfile] with its whole `extends` chain flattened into one
+/// rule set — what [PrimitiveRegistry] lookups actually read. Never
+/// constructed directly; see [JurisdictionRegistry.resolve].
+class ResolvedJurisdictionProfile {
+  const ResolvedJurisdictionProfile({required this.id, required this.rules});
+
+  final String id;
+  final Map<String, String> rules;
+
+  /// The primitive id registered under [ruleName], or `null` if this
+  /// profile's chain never set it — e.g. `night_rule` before #21/#22 give
+  /// EASA and FAA anything to reference there.
+  String? operator [](String ruleName) => rules[ruleName];
+}
+
+/// Parses one `assets/jurisdictions/*.yaml` document into a
+/// [JurisdictionProfile].
+///
+/// A root profile's rules are its top-level keys, besides `id`. A profile
+/// that `extends` another puts its deltas under `overrides:` instead —
+/// CLAUDE.md's own worked example:
+/// ```yaml
+/// id: uk.caa.part-fcl
+/// extends: eu.easa.part-fcl
+/// overrides:
+///   currency_rules: [uk.fcl060.passenger_recency]
+/// ```
+/// so a reader can tell "this profile's own rules" apart from "everything it
+/// inherits" without cross-referencing the parent file.
+JurisdictionProfile parseJurisdictionProfileYaml(String yamlContent) {
+  final yaml = loadYaml(yamlContent);
+  if (yaml is! YamlMap) {
+    throw FormatException(
+      'Jurisdiction profile YAML must be a map',
+      yamlContent,
+    );
+  }
+
+  final id = yaml['id'];
+  if (id is! String || id.isEmpty) {
+    throw FormatException(
+      'Jurisdiction profile is missing a non-empty "id"',
+      yamlContent,
+    );
+  }
+
+  final extendsId = yaml['extends'];
+  if (extendsId != null && extendsId is! String) {
+    throw FormatException(
+      'Jurisdiction profile "$id": "extends" must be a string if present',
+      yamlContent,
+    );
+  }
+
+  final Object? rulesSource = extendsId == null ? yaml : yaml['overrides'];
+  final rules = <String, String>{};
+  if (rulesSource is YamlMap) {
+    for (final entry in rulesSource.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      if (key == 'id' || key == 'extends' || key == 'overrides') {
+        continue;
+      }
+      if (key is! String || value is! String) {
+        throw FormatException(
+          'Jurisdiction profile "$id": rule "$key" must map a string name '
+          'to a string primitive id',
+          yamlContent,
+        );
+      }
+      rules[key] = value;
+    }
+  } else if (extendsId != null && rulesSource != null) {
+    throw FormatException(
+      'Jurisdiction profile "$id": "overrides" must be a map if present',
+      yamlContent,
+    );
+  }
+
+  return JurisdictionProfile(
+    id: id,
+    extendsId: extendsId as String?,
+    rules: rules,
+  );
+}

--- a/lib/domain/jurisdiction/jurisdiction_registry.dart
+++ b/lib/domain/jurisdiction/jurisdiction_registry.dart
@@ -1,0 +1,48 @@
+import 'jurisdiction_profile.dart';
+
+/// Resolves a [JurisdictionProfile] id to its fully-merged rule set, walking
+/// the `extends` chain.
+class JurisdictionRegistry {
+  JurisdictionRegistry(Iterable<JurisdictionProfile> profiles)
+    : _byId = {for (final profile in profiles) profile.id: profile};
+
+  final Map<String, JurisdictionProfile> _byId;
+
+  /// Flattens [id]'s `extends` chain into one [ResolvedJurisdictionProfile],
+  /// root first so a child's own rules always win over anything it
+  /// inherits — the same precedence CLAUDE.md's `overrides:` example
+  /// implies.
+  ///
+  /// Throws [ArgumentError] naming the missing id if [id] or anything in its
+  /// chain is not registered, and [StateError] naming the repeated id if the
+  /// chain cycles — either is a configuration bug in the profile data, not a
+  /// state this should silently resolve around.
+  ResolvedJurisdictionProfile resolve(String id) {
+    final chain = <JurisdictionProfile>[];
+    final seen = <String>{};
+    String? current = id;
+    while (current != null) {
+      if (!seen.add(current)) {
+        throw StateError(
+          'Jurisdiction profile inheritance cycle involving "$current"',
+        );
+      }
+      final profile = _byId[current];
+      if (profile == null) {
+        throw ArgumentError.value(
+          id,
+          'id',
+          'no registered jurisdiction profile "$current"',
+        );
+      }
+      chain.add(profile);
+      current = profile.extendsId;
+    }
+
+    final rules = <String, String>{};
+    for (final profile in chain.reversed) {
+      rules.addAll(profile.rules);
+    }
+    return ResolvedJurisdictionProfile(id: id, rules: rules);
+  }
+}

--- a/lib/domain/primitives/default_primitives.dart
+++ b/lib/domain/primitives/default_primitives.dart
@@ -1,0 +1,14 @@
+import 'easa_pilot_function_time.dart';
+import 'pilot_function_time.dart';
+
+/// The [PrimitiveRegistry] the app actually ships — every primitive id an
+/// `assets/jurisdictions/*.yaml` profile can reference, wired to its real
+/// implementation.
+///
+/// Grows by one line per primitive as #19 (FAA) and later #21-26
+/// (night/cross-country/instrument) land — never by a change to
+/// [JurisdictionProjection], which only ever sees this through the
+/// [PrimitiveRegistry] interface.
+final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry({
+  'easa.pilot_function_time': easaPilotFunctionTime,
+});

--- a/lib/domain/primitives/default_primitives.dart
+++ b/lib/domain/primitives/default_primitives.dart
@@ -1,14 +1,16 @@
 import 'easa_pilot_function_time.dart';
+import 'faa_pilot_function_time.dart';
 import 'pilot_function_time.dart';
 
 /// The [PrimitiveRegistry] the app actually ships — every primitive id an
 /// `assets/jurisdictions/*.yaml` profile can reference, wired to its real
 /// implementation.
 ///
-/// Grows by one line per primitive as #19 (FAA) and later #21-26
-/// (night/cross-country/instrument) land — never by a change to
+/// Grows by one line per primitive as later issues (#21-26:
+/// night/cross-country/instrument) land — never by a change to
 /// [JurisdictionProjection], which only ever sees this through the
 /// [PrimitiveRegistry] interface.
 final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry({
   'easa.pilot_function_time': easaPilotFunctionTime,
+  'faa.pilot_function_time': faaPilotFunctionTime,
 });

--- a/lib/domain/primitives/easa_pilot_function_time.dart
+++ b/lib/domain/primitives/easa_pilot_function_time.dart
@@ -1,0 +1,211 @@
+import '../model/countersignature.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../model/pilot_capacity.dart';
+import '../projection/derived_quantity.dart';
+
+const String _pic = 'pic';
+const String _dual = 'dual';
+const String _spic = 'spic';
+const String _picus = 'picus';
+const String _copilot = 'copilot';
+const String _instructor = 'instructor';
+
+const List<String> _allNames = [
+  _pic,
+  _dual,
+  _spic,
+  _picus,
+  _copilot,
+  _instructor,
+];
+
+/// EASA `FCL.010` pilot function time: PIC, dual, SPIC and PICUS, plus
+/// co-pilot and instructor time. One function, not six, because the six are
+/// interdependent — see the dartdoc on [PilotFunctionTimeRule].
+///
+/// Every branch below was checked against all fifteen scenarios in
+/// `test/fixtures/capacities/`, whose header comments record the exact
+/// expected EASA outcome for issues #18/#19 to assert against — see
+/// `easa_pilot_function_time_test.dart`, which is table-driven over that
+/// same fixture set.
+///
+/// Branch order matters where a flight could theoretically match more than
+/// one — FCL.010 does not allow that in practice (no fixture exercises it),
+/// but the first matching branch below always wins.
+Map<String, DerivedQuantity> easaPilotFunctionTime(
+  Flight flight,
+  FlightDuration blockTime,
+) {
+  final capacity = flight.capacity;
+
+  // 1. Acting as instructor. AMC1 FCL.050(b)(1)(ii) records the same time as
+  // both instructor time (column 10) and PIC — flight_instructor.yaml.
+  if (capacity.actingAsInstructor) {
+    return _result(
+      blockTime,
+      reason: 'this pilot was instructing',
+      overrides: {
+        _pic: DerivedQuantity.creditable(
+          blockTime,
+          'FCL.010: PIC while serving as the authorised instructor',
+        ),
+        _instructor: DerivedQuantity.creditable(
+          blockTime,
+          'AMC1 FCL.050 column 10: instructor time',
+        ),
+      },
+    );
+  }
+
+  // 2. PICUS claimed. picus_countersigned/pending/refused.yaml: the claim
+  // itself is the raw fact (PilotCapacity.picusClaimed); creditability turns
+  // entirely on the countersignature that arrives after the flight.
+  if (capacity.picusClaimed) {
+    final quantity = _countersignedQuantity(
+      blockTime,
+      capacity.countersignature,
+      claim: 'PICUS',
+    );
+    return _result(
+      blockTime,
+      reason: 'PICUS claimed instead',
+      overrides: {_pic: quantity, _picus: quantity},
+    );
+  }
+
+  if (capacity.commandAuthority) {
+    final instructor = capacity.instructor;
+
+    // 3a. SPIC: command held, an instructor aboard who did not influence
+    // the flight. spic.yaml. Do not implement this as "instructor aboard
+    // and not influencing" alone — that is wrong for any flight where the
+    // pilot did not hold command (sole_manipulator_receiving_instruction
+    // .yaml fails exactly this test and is dual instead, below).
+    if (instructor != null && !instructor.influencedFlight) {
+      final quantity = _countersignedQuantity(
+        blockTime,
+        capacity.countersignature,
+        claim: 'SPIC',
+      );
+      return _result(
+        blockTime,
+        reason: 'SPIC claimed instead',
+        overrides: {_pic: quantity, _spic: quantity},
+      );
+    }
+
+    // 3b. Ordinary command PIC. FCL.010 does not care who was manipulating
+    // — mid_flight_takeover.yaml, safety_pilot.yaml (EASA has no
+    // safety-pilot category and reads command authority alone), examiner
+    // .yaml (the mandatory column-12 remark is a Flight/export concern, not
+    // a time computation), student_solo.yaml.
+    return _result(
+      blockTime,
+      reason: 'command authority held instead',
+      overrides: {
+        _pic: DerivedQuantity.creditable(
+          blockTime,
+          'FCL.010: command authority held',
+        ),
+      },
+    );
+  }
+
+  // 4. Dual received: an instructor aboard who did influence the flight.
+  // sole_manipulator_receiving_instruction.yaml, dual_received_not_
+  // manipulating.yaml. Mutually exclusive with SPIC under FCL.010 — SPIC
+  // (branch 3a) requires commandAuthority, which this branch has already
+  // ruled out.
+  final instructor = capacity.instructor;
+  if (instructor != null && instructor.influencedFlight) {
+    return _result(
+      blockTime,
+      reason: 'dual instruction received instead',
+      overrides: {
+        _dual: DerivedQuantity.creditable(
+          blockTime,
+          'FCL.010: dual instruction received',
+        ),
+      },
+    );
+  }
+
+  // 5. Co-pilot / multi-pilot time. co_pilot_sic.yaml. Gated on
+  // multiPilotOperation, not merely on another required pilot being aboard —
+  // second_pilot_single_pilot_aircraft.yaml is the counterintuitive case
+  // this excludes: EASA co-pilot time exists only in multi-pilot
+  // operations, so a spare qualified pilot in a single-pilot aeroplane logs
+  // nothing at all, however competent.
+  if (capacity.multiPilotOperation &&
+      capacity.otherPilotRole == OtherPilotRole.requiredCrew) {
+    return _result(
+      blockTime,
+      reason: 'co-pilot time instead',
+      overrides: {
+        _copilot: DerivedQuantity.creditable(
+          blockTime,
+          'AMC1 FCL.050 column 5/10: multi-pilot co-pilot time',
+        ),
+      },
+    );
+  }
+
+  // 6. None of the above. second_pilot_single_pilot_aircraft.yaml,
+  // skill_test_with_examiner.yaml (candidate side: the examiner holds
+  // command on a test flight, and an assessment is not instruction, so
+  // neither PIC nor dual accrues to the candidate).
+  return _result(
+    blockTime,
+    reason: 'no pilot function time accrues to this pilot for this flight',
+    overrides: const {},
+  );
+}
+
+/// All six named quantities, zeroed with [reason] and then [overrides]
+/// applied on top — every branch in [easaPilotFunctionTime] returns the
+/// complete six-key set this way, so no branch can accidentally omit a name
+/// the next branch happened to set.
+Map<String, DerivedQuantity> _result(
+  FlightDuration blockTime, {
+  required String reason,
+  required Map<String, DerivedQuantity> overrides,
+}) {
+  final result = <String, DerivedQuantity>{
+    for (final name in _allNames)
+      name: DerivedQuantity.zero('FCL.010: $reason'),
+  };
+  result.addAll(overrides);
+  return result;
+}
+
+/// The shared shape of SPIC and PICUS: both are logged as [claim] in the PIC
+/// column, creditable only once countersigned — `AMC1 FCL.050` requires the
+/// signature for both, and an unsigned entry must be reported as *not
+/// creditable, with a reason*, never silently 0 and never silently valid
+/// (`test/fixtures/capacities/picus_pending.yaml`,
+/// `test/fixtures/capacities/spic.yaml`).
+DerivedQuantity _countersignedQuantity(
+  FlightDuration blockTime,
+  Countersignature? countersignature, {
+  required String claim,
+}) {
+  switch (countersignature?.status) {
+    case CountersignatureStatus.signed:
+      return DerivedQuantity.creditable(
+        blockTime,
+        'FCL.010: $claim, countersigned',
+      );
+    case CountersignatureStatus.refused:
+      return DerivedQuantity.notCreditable(
+        blockTime,
+        'AMC1 FCL.050: $claim claimed; countersignature refused',
+      );
+    case CountersignatureStatus.pending:
+    case null:
+      return DerivedQuantity.notCreditable(
+        blockTime,
+        'AMC1 FCL.050: $claim claimed; awaiting countersignature',
+      );
+  }
+}

--- a/lib/domain/primitives/faa_pilot_function_time.dart
+++ b/lib/domain/primitives/faa_pilot_function_time.dart
@@ -1,0 +1,136 @@
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../model/instructor_presence.dart';
+import '../model/pilot_capacity.dart';
+import '../projection/derived_quantity.dart';
+
+/// FAA `§61.51` pilot function time: logged PIC, acting PIC, dual received,
+/// SIC and solo.
+///
+/// Unlike [easaPilotFunctionTime], these five are **not** mutually
+/// exclusive — `pic_sole_occupant.yaml` has logged PIC, acting PIC and solo
+/// all simultaneously non-zero for the same flight, because `§61.51`
+/// answers five separate questions rather than assigning one flight to one
+/// bucket. So each quantity is computed independently below, not as a
+/// branching chain where the first match wins.
+///
+/// Every rule was checked against all sixteen documented scenarios in
+/// `test/fixtures/capacities/` — see `faa_pilot_function_time_test.dart`,
+/// table-driven over that same set, and shared with #18's EASA test so the
+/// two jurisdictions' answers for one fixture sit side by side.
+Map<String, DerivedQuantity> faaPilotFunctionTime(
+  Flight flight,
+  FlightDuration blockTime,
+) {
+  final capacity = flight.capacity;
+
+  return {
+    'actingPic': _actingPic(capacity, blockTime),
+    'loggedPic': _loggedPic(capacity, blockTime),
+    'dualReceived': _dualReceived(capacity, blockTime),
+    'sic': _sic(capacity, blockTime),
+    'solo': _solo(capacity, blockTime),
+  };
+}
+
+/// `§91.3`: final authority and responsibility. Mirrors
+/// [PilotCapacity.commandAuthority] directly — it is the same jurisdiction-
+/// agnostic fact FCL.010 reads for command, restated for the FAA reading.
+/// `safety_pilot.yaml` is explicit that this and [_loggedPic] can both be
+/// full block time for the same flight, for different reasons.
+DerivedQuantity _actingPic(PilotCapacity capacity, FlightDuration blockTime) =>
+    capacity.commandAuthority
+    ? DerivedQuantity.creditable(
+        blockTime,
+        '§91.3: acting PIC, command authority held',
+      )
+    : DerivedQuantity.zero('§91.3: command authority not held');
+
+/// `§61.51(d)`. Independent of every other quantity here — a pilot can be
+/// solo and receiving no instruction, or solo is simply `false` the moment
+/// anyone else is aboard, instructor or not.
+DerivedQuantity _solo(PilotCapacity capacity, FlightDuration blockTime) =>
+    capacity.soleOccupant
+    ? DerivedQuantity.creditable(blockTime, '§61.51(d): sole occupant')
+    : DerivedQuantity.zero('§61.51(d): not the sole occupant');
+
+/// Three independent bases can each justify logging PIC time, checked in
+/// this order — `flight_instructor.yaml`, `student_solo.yaml`,
+/// `mid_flight_takeover.yaml` each exercise a different one. Whichever
+/// basis applies, the *value* is the same in every fixture but one:
+/// `mid_flight_takeover.yaml`, where §61.51(e)(1)(i) covers only the
+/// manipulated portion, never overclaiming the whole flight.
+///
+/// None of these bases verify the pilot was actually *rated* for the
+/// aircraft — no licence/rating record exists yet in this codebase (M1).
+/// Every fixture's own comment carries the same "(sole manipulator, rated)"
+/// qualifier; this is a known, uniform limitation, not an omission specific
+/// to any one branch.
+DerivedQuantity _loggedPic(PilotCapacity capacity, FlightDuration blockTime) {
+  if (capacity.actingAsInstructor && capacity.commandAuthority) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      '§61.51(e)(3): PIC while serving as the authorised instructor',
+    );
+  }
+  if (capacity.soloEndorsementHeld == true && capacity.soleOccupant) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      '§61.51(e)(4): student solo under a §61.87 endorsement',
+    );
+  }
+  if (capacity.soleManipulator) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      '§61.51(e)(1)(i): sole manipulator, rated',
+    );
+  }
+  final manipulationTime = capacity.manipulationTime;
+  if (manipulationTime != null) {
+    return DerivedQuantity.creditable(
+      manipulationTime,
+      '§61.51(e)(1)(i): sole manipulator for the manipulated portion only',
+    );
+  }
+  return DerivedQuantity.zero(
+    '§61.51(e)(1)(i): not the sole manipulator, in whole or in part',
+  );
+}
+
+/// `§61.51(h)`. Gated on [InstructorPresence.capacity] as well as
+/// [InstructorPresence.influencedFlight] — an examiner's checkride is not
+/// "training received" even where an examiner did actively fly, which no
+/// fixture exercises but which `§61.51(h)` does not cover either.
+DerivedQuantity _dualReceived(
+  PilotCapacity capacity,
+  FlightDuration blockTime,
+) {
+  final instructor = capacity.instructor;
+  final receivedInstruction =
+      instructor != null &&
+      instructor.influencedFlight &&
+      instructor.capacity == InstructorCapacity.flightInstructor;
+  return receivedInstruction
+      ? DerivedQuantity.creditable(blockTime, '§61.51(h): training received')
+      : DerivedQuantity.zero('§61.51(h): no training received');
+}
+
+/// `§61.51(f)`: SIC requires an aircraft that needs more than one pilot by
+/// type certificate or by the rules the flight is operated under
+/// ([PilotCapacity.additionalCrewRequiredByRule] or
+/// [PilotCapacity.multiPilotOperation]), and this pilot not being the one
+/// flying or in command. `co_pilot_sic.yaml` is the case where this fires;
+/// `second_pilot_single_pilot_aircraft.yaml` is the case where neither
+/// multi-pilot flag is set and it correctly does not.
+DerivedQuantity _sic(PilotCapacity capacity, FlightDuration blockTime) {
+  final multiCrew =
+      capacity.additionalCrewRequiredByRule || capacity.multiPilotOperation;
+  final qualifiesAsSic =
+      !capacity.commandAuthority && !capacity.soleManipulator && multiCrew;
+  return qualifiesAsSic
+      ? DerivedQuantity.creditable(
+          blockTime,
+          '§61.51(f): SIC, qualified crewmember of a multi-pilot operation',
+        )
+      : DerivedQuantity.zero('§61.51(f): SIC conditions not met');
+}

--- a/lib/domain/primitives/pilot_function_time.dart
+++ b/lib/domain/primitives/pilot_function_time.dart
@@ -1,0 +1,50 @@
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../projection/derived_quantity.dart';
+
+/// A named, jurisdiction-specific rule computing the pilot-function-time
+/// quantities (PIC, dual, and whatever else that jurisdiction distinguishes)
+/// for one flight, from its already-computed [blockTime].
+///
+/// One function per jurisdiction, not one per quantity: EASA's PIC, dual,
+/// SPIC and PICUS are interdependent — knowing whether a flight is SPIC
+/// changes what PIC is — so they are derived together from one reading of
+/// [flight.capacity], not as four independent lookups that could disagree
+/// with each other. CLAUDE.md's `pic_rule: faa.sole_manipulator` naming is
+/// shorthand for exactly this: one profile key, one primitive, the whole
+/// related bundle back at once.
+typedef PilotFunctionTimeRule =
+    Map<String, DerivedQuantity> Function(
+      Flight flight,
+      FlightDuration blockTime,
+    );
+
+/// Looks up a [PilotFunctionTimeRule] by the id a [JurisdictionProfile]
+/// names in its `pic_rule` key, e.g. `easa.pilot_function_time`.
+///
+/// A registry, not a hardcoded `switch` on jurisdiction id, because the
+/// engine that calls it ([JurisdictionProjection]) must never itself branch
+/// on which jurisdiction it is running — CLAUDE.md's acceptance test for
+/// this whole abstraction is that adding a new authority needs a YAML
+/// profile and at most one new primitive, never a change here.
+class PrimitiveRegistry {
+  const PrimitiveRegistry(this._pilotFunctionTimeRules);
+
+  final Map<String, PilotFunctionTimeRule> _pilotFunctionTimeRules;
+
+  /// Throws [ArgumentError] naming [ruleId] if nothing is registered under
+  /// it — a profile referencing a primitive that was never wired up is a
+  /// configuration bug, not a state to silently paper over with a zeroed
+  /// result.
+  PilotFunctionTimeRule pilotFunctionTime(String ruleId) {
+    final rule = _pilotFunctionTimeRules[ruleId];
+    if (rule == null) {
+      throw ArgumentError.value(
+        ruleId,
+        'ruleId',
+        'no pilot-function-time primitive is registered under this id',
+      );
+    }
+    return rule;
+  }
+}

--- a/lib/domain/projection/derived_quantity.dart
+++ b/lib/domain/projection/derived_quantity.dart
@@ -1,0 +1,56 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/flight_duration.dart';
+
+part 'derived_quantity.freezed.dart';
+
+/// One computed value a [Projection] produces, plus whether it can actually
+/// be relied on and why it has the value it has.
+///
+/// **Never silently zero, never silently valid.** `PICUS` awaiting
+/// countersignature (`test/fixtures/capacities/picus_pending.yaml`) has a
+/// real, non-zero [value] — the pilot flew the time — but [creditable] is
+/// `false` until the signature arrives. Collapsing that to `0` would lie
+/// about what happened; collapsing it to a bare creditable value would lie
+/// about whether it counts. Both are wrong in a way nobody would notice
+/// until an export or a currency check relied on it.
+///
+/// [explanation] exists because a number with no reason attached is not
+/// explainable — `docs/entry-form.md` §7's derivation strip requires every
+/// number to be traceable to a named rule, and a bare `Map<String, dynamic>`
+/// (which #17 explicitly rules out) could never carry this.
+@freezed
+abstract class DerivedQuantity with _$DerivedQuantity {
+  const factory DerivedQuantity({
+    required FlightDuration value,
+    required bool creditable,
+    required String explanation,
+  }) = _DerivedQuantity;
+
+  /// A quantity that counts in full, for [explanation].
+  factory DerivedQuantity.creditable(
+    FlightDuration value,
+    String explanation,
+  ) =>
+      DerivedQuantity(value: value, creditable: true, explanation: explanation);
+
+  /// A quantity with a real, non-zero [value] that does not yet — or does
+  /// not ever — count, for [explanation]. See the class dartdoc: this is
+  /// the case a `Map<String, dynamic>` result would be tempted to collapse
+  /// to a bare `0`.
+  factory DerivedQuantity.notCreditable(
+    FlightDuration value,
+    String explanation,
+  ) => DerivedQuantity(
+    value: value,
+    creditable: false,
+    explanation: explanation,
+  );
+
+  /// Nothing to claim under this rule, for [explanation].
+  factory DerivedQuantity.zero(String explanation) => DerivedQuantity(
+    value: FlightDuration.zero,
+    creditable: true,
+    explanation: explanation,
+  );
+}

--- a/lib/domain/projection/jurisdiction_projection.dart
+++ b/lib/domain/projection/jurisdiction_projection.dart
@@ -1,0 +1,112 @@
+import '../jurisdiction/jurisdiction_registry.dart';
+import '../model/aircraft.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../primitives/pilot_function_time.dart';
+import 'derived_quantity.dart';
+import 'projection.dart';
+import 'projection_result.dart';
+
+/// The one, jurisdiction-agnostic [Projection] implementation. An instance
+/// is bound to one jurisdiction at construction — `JurisdictionProjection
+/// (jurisdictionId: 'eu.easa.part-fcl', ...)` is "the EASA projection" (#18),
+/// a second instance bound to `us.faa.part61` is "the FAA projection" (#19)
+/// — but this class itself never names either one. It only resolves a
+/// profile and dispatches to whatever primitive the profile names.
+///
+/// This is the acceptance test CLAUDE.md sets for the whole abstraction:
+/// adding Transport Canada is a new YAML profile and at most one new
+/// primitive, never a change in this file.
+class JurisdictionProjection implements Projection {
+  JurisdictionProjection({
+    required this.registry,
+    required this.primitives,
+    required this.jurisdictionId,
+  });
+
+  final JurisdictionRegistry registry;
+  final PrimitiveRegistry primitives;
+  final String jurisdictionId;
+
+  @override
+  ProjectionResult project(Flight flight, Aircraft aircraft) {
+    final profile = registry.resolve(jurisdictionId);
+    final ruleId = profile['pic_rule'];
+    if (ruleId == null) {
+      // No pilot-function-time rule configured for this jurisdiction yet —
+      // an empty result, not an error. #20-26 will add night/cross-country/
+      // instrument rule keys the same way; a profile with none of them set
+      // yet is incomplete, not broken.
+      return ProjectionResult(
+        jurisdictionId: jurisdictionId,
+        quantities: const {},
+      );
+    }
+
+    final rule = primitives.pilotFunctionTime(ruleId);
+    final blockTime = FlightDuration(
+      flight.onBlocks.difference(flight.offBlocks).inMinutes,
+    );
+    return ProjectionResult(
+      jurisdictionId: jurisdictionId,
+      quantities: rule(flight, blockTime),
+    );
+  }
+
+  @override
+  ProjectionResult projectAggregate(Iterable<(Flight, Aircraft)> flights) {
+    final perFlight = [
+      for (final (flight, aircraft) in flights) project(flight, aircraft),
+    ];
+
+    final names = <String>{
+      for (final result in perFlight) ...result.quantities.keys,
+    };
+
+    final aggregated = <String, DerivedQuantity>{};
+    for (final name in names) {
+      aggregated[name] = _aggregateQuantity(name, perFlight);
+    }
+
+    return ProjectionResult(
+      jurisdictionId: jurisdictionId,
+      quantities: aggregated,
+    );
+  }
+
+  /// Sums the creditable contributions to [name] across [perFlight] into one
+  /// reliable total. Non-creditable contributions (an unsigned PICUS, say)
+  /// are named and counted in the explanation rather than folded into
+  /// [DerivedQuantity.value] — see [Projection.projectAggregate].
+  DerivedQuantity _aggregateQuantity(
+    String name,
+    List<ProjectionResult> perFlight,
+  ) {
+    var creditableTotal = FlightDuration.zero;
+    var excludedTotal = FlightDuration.zero;
+    var flightCount = 0;
+    var excludedCount = 0;
+
+    for (final result in perFlight) {
+      final quantity = result[name];
+      if (quantity == null) {
+        continue;
+      }
+      flightCount++;
+      if (quantity.creditable) {
+        creditableTotal = creditableTotal + quantity.value;
+      } else {
+        excludedTotal = excludedTotal + quantity.value;
+        excludedCount++;
+      }
+    }
+
+    final explanation = excludedCount == 0
+        ? '${creditableTotal.toHoursMinutes()} across $flightCount flight(s)'
+        : '${creditableTotal.toHoursMinutes()} across $flightCount flight(s); '
+              '${excludedTotal.toHoursMinutes()} from $excludedCount flight(s) '
+              'excluded — not creditable';
+
+    return DerivedQuantity.creditable(creditableTotal, explanation);
+  }
+}

--- a/lib/domain/projection/projection.dart
+++ b/lib/domain/projection/projection.dart
@@ -1,0 +1,32 @@
+import '../model/aircraft.dart';
+import '../model/flight.dart';
+import 'projection_result.dart';
+
+/// Applies one jurisdiction's rules to a [Flight], or to a set of them, to
+/// produce derived quantities. The abstraction CLAUDE.md's architecture
+/// section describes as `domain/projection/`: it keeps jurisdiction-specific
+/// interpretation out of [Flight] itself (ADR-0001) and out of the UI.
+///
+/// **No caching or memoisation.** #17's acceptance criteria are explicit:
+/// correctness first, measure before optimising. A stale cached result that
+/// silently outlives an edited flight or an updated jurisdiction profile is
+/// a worse failure than recomputing every time.
+///
+/// [Aircraft] is part of the signature even though the pilot-function-time
+/// rules in this PR (#18, #19) don't read it — later primitives (night,
+/// cross-country, instrument) do, and #17 fixes the interface shape once
+/// rather than growing it per-primitive.
+abstract class Projection {
+  /// Derived quantities for one [flight], flown in [aircraft].
+  ProjectionResult project(Flight flight, Aircraft aircraft);
+
+  /// Derived quantities aggregated over [flights] — e.g. a logbook total or
+  /// a currency window, not a per-flight figure.
+  ///
+  /// Aggregation is not simple addition: a [DerivedQuantity] with
+  /// `creditable: false` (an unsigned PICUS, say) must not silently
+  /// contribute to a total the pilot could rely on, and must not silently
+  /// vanish from it either — see [JurisdictionProjection.projectAggregate]
+  /// for how the two needs are kept apart.
+  ProjectionResult projectAggregate(Iterable<(Flight, Aircraft)> flights);
+}

--- a/lib/domain/projection/projection_result.dart
+++ b/lib/domain/projection/projection_result.dart
@@ -1,0 +1,37 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'derived_quantity.dart';
+
+part 'projection_result.freezed.dart';
+
+/// The named [DerivedQuantity] set a [Projection] produced for one
+/// jurisdiction, for one flight or one aggregate over a flight set.
+///
+/// A `Map<String, DerivedQuantity>` rather than fixed fields, because the
+/// vocabulary genuinely differs by jurisdiction — EASA's `pic`/`dual`/
+/// `spic`/`picus`/`copilot`/`instructor` is not FAA's `logged_pic`/
+/// `acting_pic`/`dual_received`/`sic`/`solo`, and #17's acceptance test
+/// (CLAUDE.md: "adding Transport Canada should require a YAML profile and
+/// at most one new primitive") fails if the result type has to grow a field
+/// every time a jurisdiction adds a quantity. This still satisfies #17's
+/// "not a `Map<String, dynamic>`" requirement: every value is a real
+/// [DerivedQuantity], never a raw number or a bag of untyped data.
+@freezed
+abstract class ProjectionResult with _$ProjectionResult {
+  const ProjectionResult._();
+
+  const factory ProjectionResult({
+    /// The jurisdiction profile id this result was computed under, e.g.
+    /// `eu.easa.part-fcl`. Rule 5: an unlabelled derived number is a bug,
+    /// and carrying the jurisdiction on the result itself — not just on
+    /// whoever called [Projection.project] — means it survives being passed
+    /// around or displayed away from the call site.
+    required String jurisdictionId,
+    required Map<String, DerivedQuantity> quantities,
+  }) = _ProjectionResult;
+
+  /// Looks up a named quantity, e.g. `result['pic']`. `null` if this
+  /// jurisdiction's rules never populated that name — never a missing-key
+  /// exception, since which names exist is itself jurisdiction-specific.
+  DerivedQuantity? operator [](String name) => quantities[name];
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,3 +32,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/aerodromes/
+    - assets/jurisdictions/

--- a/test/domain/jurisdiction/jurisdiction_profile_test.dart
+++ b/test/domain/jurisdiction/jurisdiction_profile_test.dart
@@ -1,0 +1,63 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseJurisdictionProfileYaml', () {
+    test('parses a root profile\'s top-level keys as rules', () {
+      final profile = parseJurisdictionProfileYaml('''
+id: eu.easa.part-fcl
+pic_rule: easa.pilot_function_time
+''');
+
+      expect(profile.id, 'eu.easa.part-fcl');
+      expect(profile.extendsId, isNull);
+      expect(profile.rules, {'pic_rule': 'easa.pilot_function_time'});
+    });
+
+    test(
+      'parses an extending profile\'s overrides, ignoring top-level noise',
+      () {
+        final profile = parseJurisdictionProfileYaml('''
+id: uk.caa.part-fcl
+extends: eu.easa.part-fcl
+overrides:
+  pic_rule: uk.pilot_function_time
+''');
+
+        expect(profile.id, 'uk.caa.part-fcl');
+        expect(profile.extendsId, 'eu.easa.part-fcl');
+        expect(profile.rules, {'pic_rule': 'uk.pilot_function_time'});
+      },
+    );
+
+    test('an extending profile with no overrides has empty rules', () {
+      final profile = parseJurisdictionProfileYaml('''
+id: uk.caa.part-fcl
+extends: eu.easa.part-fcl
+''');
+
+      expect(profile.rules, isEmpty);
+    });
+
+    test('rejects a document with no id', () {
+      expect(
+        () =>
+            parseJurisdictionProfileYaml('pic_rule: easa.pilot_function_time'),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects a rule value that is not a string', () {
+      expect(
+        () => parseJurisdictionProfileYaml('''
+id: eu.easa.part-fcl
+pic_rule:
+  nested: true
+'''),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/domain/jurisdiction/jurisdiction_registry_test.dart
+++ b/test/domain/jurisdiction/jurisdiction_registry_test.dart
@@ -1,0 +1,108 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A synthetic three-generation lineage — not real regulatory data, just
+/// enough to prove `extends` resolution actually walks the chain and lets a
+/// child's own rules win. The real profiles (eu.easa.part-fcl,
+/// us.faa.part61) don't extend anything yet, so this is the only place the
+/// mechanism itself is exercised until a real UK CAA profile lands.
+const _root = JurisdictionProfile(
+  id: 'test.root',
+  rules: {'pic_rule': 'root.pic', 'night_rule': 'root.night'},
+);
+
+const _middle = JurisdictionProfile(
+  id: 'test.middle',
+  extendsId: 'test.root',
+  rules: {'night_rule': 'middle.night'},
+);
+
+const _leaf = JurisdictionProfile(
+  id: 'test.leaf',
+  extendsId: 'test.middle',
+  rules: {'pic_rule': 'leaf.pic'},
+);
+
+void main() {
+  group('JurisdictionRegistry.resolve', () {
+    test('a root profile with no extends resolves to its own rules', () {
+      final registry = JurisdictionRegistry([_root]);
+      final resolved = registry.resolve('test.root');
+
+      expect(resolved.id, 'test.root');
+      expect(resolved['pic_rule'], 'root.pic');
+      expect(resolved['night_rule'], 'root.night');
+    });
+
+    test('a middle profile inherits what it does not override', () {
+      final registry = JurisdictionRegistry([_root, _middle]);
+      final resolved = registry.resolve('test.middle');
+
+      expect(resolved['pic_rule'], 'root.pic', reason: 'inherited from root');
+      expect(resolved['night_rule'], 'middle.night', reason: 'overridden');
+    });
+
+    test('a three-generation chain merges root-first so the leaf wins', () {
+      final registry = JurisdictionRegistry([_root, _middle, _leaf]);
+      final resolved = registry.resolve('test.leaf');
+
+      expect(resolved['pic_rule'], 'leaf.pic', reason: 'leaf overrides root');
+      expect(
+        resolved['night_rule'],
+        'middle.night',
+        reason: 'leaf does not override night_rule, so middle wins over root',
+      );
+    });
+
+    test('an unset rule name resolves to null, not a missing-key throw', () {
+      final registry = JurisdictionRegistry([_root]);
+      final resolved = registry.resolve('test.root');
+
+      expect(resolved['cross_country_rule'], isNull);
+    });
+
+    test('resolving an unregistered id throws ArgumentError naming it', () {
+      final registry = JurisdictionRegistry([_root]);
+      expect(
+        () => registry.resolve('does.not.exist'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.toString(),
+            'message',
+            contains('does.not.exist'),
+          ),
+        ),
+      );
+    });
+
+    test('resolving a profile whose extends target is missing throws', () {
+      final registry = JurisdictionRegistry([_leaf]); // no root or middle
+      expect(
+        () => registry.resolve('test.leaf'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+      'an inheritance cycle throws StateError rather than looping forever',
+      () {
+        const cycleA = JurisdictionProfile(
+          id: 'cycle.a',
+          extendsId: 'cycle.b',
+          rules: {},
+        );
+        const cycleB = JurisdictionProfile(
+          id: 'cycle.b',
+          extendsId: 'cycle.a',
+          rules: {},
+        );
+        final registry = JurisdictionRegistry([cycleA, cycleB]);
+
+        expect(() => registry.resolve('cycle.a'), throwsA(isA<StateError>()));
+      },
+    );
+  });
+}

--- a/test/domain/primitives/easa_pilot_function_time_test.dart
+++ b/test/domain/primitives/easa_pilot_function_time_test.dart
@@ -1,0 +1,238 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/easa_pilot_function_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../fixtures/decoders/pilot_capacity_fixture.dart';
+
+const _block = FlightDuration(90); // 1:30, an arbitrary but fixed block time
+const _zero = FlightDuration.zero;
+
+Flight _flightWith(PilotCapacity capacity) => Flight(
+  aircraftRegistration: 'G-TEST',
+  route: const ['EGKA', 'EGKA'],
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
+  capacity: capacity,
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+/// One expected value: (minutes, creditable).
+typedef _Expected = (int, bool);
+
+const _fullCreditable = (90, true);
+const _zeroCreditable = (0, true);
+const _fullNotCreditable = (90, false);
+
+/// Every one of the sixteen capacity scenarios, EASA outcome — transcribed
+/// from the "Expected projections" comment block already documented in each
+/// `test/fixtures/capacities/*.yaml` file. Not editorial: these are the
+/// specs #13's fixtures were written against.
+final Map<String, Map<String, _Expected>> _expected = {
+  'pic_sole_occupant': {'pic': _fullCreditable},
+  'pic_with_passengers': {'pic': _fullCreditable},
+  'sole_manipulator_receiving_instruction': {'dual': _fullCreditable},
+  'dual_received_not_manipulating': {'dual': _fullCreditable},
+  'spic': {'pic': _fullNotCreditable, 'spic': _fullNotCreditable},
+  'picus_countersigned': {'pic': _fullCreditable, 'picus': _fullCreditable},
+  'picus_pending': {'pic': _fullNotCreditable, 'picus': _fullNotCreditable},
+  'picus_refused': {'pic': _fullNotCreditable, 'picus': _fullNotCreditable},
+  'co_pilot_sic': {'copilot': _fullCreditable},
+  'flight_instructor': {'pic': _fullCreditable, 'instructor': _fullCreditable},
+  'examiner': {'pic': _fullCreditable},
+  'skill_test_with_examiner': {}, // all zero: examiner holds command, no dual
+  'mid_flight_takeover': {'pic': _fullCreditable},
+  'second_pilot_single_pilot_aircraft':
+      {}, // all zero — the counterintuitive case
+  'student_solo': {'pic': _fullCreditable},
+  'safety_pilot': {'pic': _fullCreditable},
+};
+
+const List<String> _allQuantityNames = [
+  'pic',
+  'dual',
+  'spic',
+  'picus',
+  'copilot',
+  'instructor',
+];
+
+void main() {
+  group('easaPilotFunctionTime, table-driven over every capacity fixture', () {
+    for (final entry in _expected.entries) {
+      final fixture = entry.key;
+      final overrides = entry.value;
+
+      test(fixture, () {
+        final capacity = pilotCapacityFromFixture(fixture);
+        final result = easaPilotFunctionTime(_flightWith(capacity), _block);
+
+        for (final name in _allQuantityNames) {
+          final (expectedMinutes, expectedCreditable) =
+              overrides[name] ?? _zeroCreditable;
+          final quantity = result[name];
+          expect(quantity, isNotNull, reason: '$fixture: missing "$name"');
+          expect(
+            quantity!.value,
+            expectedMinutes == 0 ? _zero : _block,
+            reason: '$fixture: "$name" value',
+          );
+          expect(
+            quantity.creditable,
+            expectedCreditable,
+            reason: '$fixture: "$name" creditability',
+          );
+        }
+      });
+    }
+
+    test('every fixture is covered by this table', () {
+      // Guards against a fixture being added to test/fixtures/capacities/
+      // without a matching entry here — silently skipping EASA coverage for
+      // it would be exactly the kind of gap #18 exists to prevent.
+      const knownFixtures = [
+        'co_pilot_sic',
+        'dual_received_not_manipulating',
+        'examiner',
+        'flight_instructor',
+        'mid_flight_takeover',
+        'pic_sole_occupant',
+        'pic_with_passengers',
+        'picus_countersigned',
+        'picus_pending',
+        'picus_refused',
+        'safety_pilot',
+        'second_pilot_single_pilot_aircraft',
+        'skill_test_with_examiner',
+        'sole_manipulator_receiving_instruction',
+        'spic',
+        'student_solo',
+      ];
+      expect(_expected.keys.toSet(), knownFixtures.toSet());
+    });
+  });
+
+  group('the canonical SPIC/dual distinction', () {
+    test(
+      'spic and sole_manipulator_receiving_instruction differ by exactly two facts',
+      () {
+        // Both are "command_authority + instructor aboard + sole manipulator".
+        // The only two facts that differ are command_authority itself and
+        // instructor.influencedFlight — and they produce opposite EASA answers.
+        final spicCapacity = pilotCapacityFromFixture('spic');
+        final dualCapacity = pilotCapacityFromFixture(
+          'sole_manipulator_receiving_instruction',
+        );
+
+        final spicResult = easaPilotFunctionTime(
+          _flightWith(spicCapacity),
+          _block,
+        );
+        final dualResult = easaPilotFunctionTime(
+          _flightWith(dualCapacity),
+          _block,
+        );
+
+        expect(spicResult['spic']!.value, _block);
+        expect(dualResult['spic']!.value, _zero);
+        expect(spicResult['dual']!.value, _zero);
+        expect(dualResult['dual']!.value, _block);
+      },
+    );
+
+    test('command authority wins over an influencing instructor — no fixture '
+        'covers this combination, so it is asserted directly', () {
+      // Not a scenario any capacity fixture models — every fixture where
+      // an instructor influences the flight also has commandAuthority:
+      // false (the instructor holds command while actively instructing).
+      // But PilotCapacity's fields are independent, so this combination
+      // is constructible, and the branch order in
+      // easaPilotFunctionTime must have a defined answer for it: holding
+      // command is a general, independent claim (mid_flight_takeover.yaml
+      // — "EASA PIC time does not depend on who was handling the
+      // controls"), so it wins regardless of what an aboard instructor
+      // did. This is what stops that branch order from silently
+      // regressing to treating any instructor presence as SPIC-eligible.
+      const capacity = PilotCapacity(
+        commandAuthority: true,
+        soleManipulator: false,
+        soleOccupant: false,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+        instructor: InstructorPresence(
+          capacity: InstructorCapacity.flightInstructor,
+          influencedFlight: true,
+        ),
+      );
+
+      final result = easaPilotFunctionTime(_flightWith(capacity), _block);
+
+      expect(result['pic']!.value, _block);
+      expect(
+        result['pic']!.creditable,
+        isTrue,
+        reason: 'ordinary command PIC, not gated by a countersignature',
+      );
+      expect(result['spic']!.value, _zero);
+      expect(result['dual']!.value, _zero);
+    });
+  });
+
+  group('PICUS creditability', () {
+    test('countersigned, pending and refused PICUS all claim the same value, '
+        'differing only in creditability and reason', () {
+      final signed = easaPilotFunctionTime(
+        _flightWith(pilotCapacityFromFixture('picus_countersigned')),
+        _block,
+      );
+      final pending = easaPilotFunctionTime(
+        _flightWith(pilotCapacityFromFixture('picus_pending')),
+        _block,
+      );
+      final refused = easaPilotFunctionTime(
+        _flightWith(pilotCapacityFromFixture('picus_refused')),
+        _block,
+      );
+
+      expect(signed['picus']!.value, _block);
+      expect(
+        pending['picus']!.value,
+        _block,
+        reason: 'not silently 0 while pending',
+      );
+      expect(
+        refused['picus']!.value,
+        _block,
+        reason: 'not silently 0 when refused',
+      );
+
+      expect(signed['picus']!.creditable, isTrue);
+      expect(pending['picus']!.creditable, isFalse);
+      expect(refused['picus']!.creditable, isFalse);
+
+      expect(
+        pending['picus']!.explanation,
+        isNot(refused['picus']!.explanation),
+        reason: '#18: pending and refused must give different reasons',
+      );
+    });
+  });
+}

--- a/test/domain/primitives/faa_pilot_function_time_test.dart
+++ b/test/domain/primitives/faa_pilot_function_time_test.dart
@@ -1,0 +1,213 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/faa_pilot_function_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../fixtures/decoders/pilot_capacity_fixture.dart';
+
+const _block = FlightDuration(90); // 1:30, matching the EASA test's fixture
+
+Flight _flightWith(PilotCapacity capacity) => Flight(
+  aircraftRegistration: 'N12345',
+  route: const ['KJFK', 'KJFK'],
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
+  capacity: capacity,
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+/// (minutes, creditable). Default when a name is absent from a fixture's
+/// entry below is (0, true).
+typedef _Expected = (int, bool);
+
+const _full = (90, true);
+
+/// Every one of the sixteen capacity scenarios, FAA outcome — transcribed
+/// from the same "Expected projections" comments the EASA table reads,
+/// so the two side by side are exactly what #19's acceptance criteria ask
+/// for ("table-driven tests mirroring the EASA test matrix").
+final Map<String, Map<String, _Expected>> _expected = {
+  'pic_sole_occupant': {'loggedPic': _full, 'actingPic': _full, 'solo': _full},
+  'pic_with_passengers': {'loggedPic': _full, 'actingPic': _full},
+  'sole_manipulator_receiving_instruction': {
+    'loggedPic': _full,
+    'dualReceived': _full,
+  },
+  'dual_received_not_manipulating': {'dualReceived': _full},
+  'spic': {'loggedPic': _full, 'actingPic': _full},
+  'picus_countersigned': {'loggedPic': _full},
+  'picus_pending': {'loggedPic': _full},
+  'picus_refused': {'loggedPic': _full},
+  'co_pilot_sic': {'sic': _full},
+  'flight_instructor': {'loggedPic': _full, 'actingPic': _full},
+  'examiner': {'actingPic': _full},
+  'skill_test_with_examiner': {'loggedPic': _full},
+  'mid_flight_takeover': {'loggedPic': (45, true), 'actingPic': _full},
+  'second_pilot_single_pilot_aircraft': {},
+  'student_solo': {'loggedPic': _full, 'actingPic': _full, 'solo': _full},
+  'safety_pilot': {'loggedPic': _full, 'actingPic': _full},
+};
+
+const List<String> _allQuantityNames = [
+  'loggedPic',
+  'actingPic',
+  'dualReceived',
+  'sic',
+  'solo',
+];
+
+void main() {
+  group('faaPilotFunctionTime, table-driven over every capacity fixture', () {
+    for (final entry in _expected.entries) {
+      final fixture = entry.key;
+      final overrides = entry.value;
+
+      test(fixture, () {
+        final capacity = pilotCapacityFromFixture(fixture);
+        final result = faaPilotFunctionTime(_flightWith(capacity), _block);
+
+        for (final name in _allQuantityNames) {
+          final (expectedMinutes, expectedCreditable) =
+              overrides[name] ?? (0, true);
+          final quantity = result[name];
+          expect(quantity, isNotNull, reason: '$fixture: missing "$name"');
+          expect(
+            quantity!.value,
+            FlightDuration(expectedMinutes),
+            reason: '$fixture: "$name" value',
+          );
+          expect(
+            quantity.creditable,
+            expectedCreditable,
+            reason: '$fixture: "$name" creditability',
+          );
+        }
+      });
+    }
+
+    test('every fixture is covered by this table', () {
+      const knownFixtures = [
+        'co_pilot_sic',
+        'dual_received_not_manipulating',
+        'examiner',
+        'flight_instructor',
+        'mid_flight_takeover',
+        'pic_sole_occupant',
+        'pic_with_passengers',
+        'picus_countersigned',
+        'picus_pending',
+        'picus_refused',
+        'safety_pilot',
+        'second_pilot_single_pilot_aircraft',
+        'skill_test_with_examiner',
+        'sole_manipulator_receiving_instruction',
+        'spic',
+        'student_solo',
+      ];
+      expect(_expected.keys.toSet(), knownFixtures.toSet());
+    });
+  });
+
+  group('logging PIC versus acting PIC', () {
+    test('an examiner acts as PIC but does not log it', () {
+      // §91.3 command authority is independent of §61.51(e)(1)(i) sole
+      // manipulation. #19's own acceptance criteria call this distinction
+      // out explicitly.
+      final result = faaPilotFunctionTime(
+        _flightWith(pilotCapacityFromFixture('examiner')),
+        _block,
+      );
+
+      expect(result['actingPic']!.value, _block);
+      expect(result['loggedPic']!.value, FlightDuration.zero);
+    });
+
+    test('the candidate on a checkride logs PIC but does not act as it', () {
+      final result = faaPilotFunctionTime(
+        _flightWith(pilotCapacityFromFixture('skill_test_with_examiner')),
+        _block,
+      );
+
+      expect(result['loggedPic']!.value, _block);
+      expect(result['actingPic']!.value, FlightDuration.zero);
+    });
+  });
+
+  group('the safety pilot case, both seats', () {
+    test('the flying pilot logs PIC, acts as PIC, and is not solo', () {
+      final result = faaPilotFunctionTime(
+        _flightWith(pilotCapacityFromFixture('safety_pilot')),
+        _block,
+      );
+
+      expect(result['loggedPic']!.value, _block);
+      expect(result['actingPic']!.value, _block);
+      expect(result['solo']!.value, FlightDuration.zero);
+    });
+  });
+
+  group('mid-flight takeover', () {
+    test(
+      'logged PIC is exactly the manipulated portion, acting PIC is the whole flight',
+      () {
+        final result = faaPilotFunctionTime(
+          _flightWith(pilotCapacityFromFixture('mid_flight_takeover')),
+          _block,
+        );
+
+        expect(result['loggedPic']!.value, const FlightDuration(45));
+        expect(result['actingPic']!.value, _block);
+      },
+    );
+  });
+
+  group('dual received excludes an examiner', () {
+    test('an examiner who actively flew is not "training received" — no '
+        'fixture covers this, so it is asserted directly', () {
+      // skill_test_with_examiner.yaml has influencedFlight: false, so it
+      // cannot distinguish "examiner, not gated" from "gated on
+      // InstructorCapacity.flightInstructor" — both give dualReceived: 0
+      // there either way. This fixture is the one that can tell them
+      // apart: an examiner who *did* influence the flight.
+      const capacity = PilotCapacity(
+        commandAuthority: false,
+        soleManipulator: true,
+        soleOccupant: false,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+        instructor: InstructorPresence(
+          capacity: InstructorCapacity.flightExaminer,
+          influencedFlight: true,
+        ),
+      );
+
+      final result = faaPilotFunctionTime(_flightWith(capacity), _block);
+
+      expect(
+        result['dualReceived']!.value,
+        FlightDuration.zero,
+        reason:
+            '§61.51(h) is training received, not an examiner flying '
+            'part of a checkride',
+      );
+    });
+  });
+}

--- a/test/domain/projection/derived_quantity_test.dart
+++ b/test/domain/projection/derived_quantity_test.dart
@@ -1,0 +1,39 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/projection/derived_quantity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DerivedQuantity factories', () {
+    test('creditable carries the value and marks it reliable', () {
+      final quantity = DerivedQuantity.creditable(
+        const FlightDuration(90),
+        'command authority held',
+      );
+      expect(quantity.value, const FlightDuration(90));
+      expect(quantity.creditable, isTrue);
+      expect(quantity.explanation, 'command authority held');
+    });
+
+    test(
+      'notCreditable keeps a real, non-zero value while marking it unreliable',
+      () {
+        // The whole reason this type exists: PICUS pending countersignature
+        // is neither silently 0 nor silently valid.
+        final quantity = DerivedQuantity.notCreditable(
+          const FlightDuration(90),
+          'PICUS awaiting countersignature',
+        );
+        expect(quantity.value, const FlightDuration(90));
+        expect(quantity.creditable, isFalse);
+      },
+    );
+
+    test('zero is creditable and carries FlightDuration.zero', () {
+      final quantity = DerivedQuantity.zero('not the sole manipulator');
+      expect(quantity.value, FlightDuration.zero);
+      expect(quantity.creditable, isTrue);
+    });
+  });
+}

--- a/test/domain/projection/easa_projection_integration_test.dart
+++ b/test/domain/projection/easa_projection_integration_test.dart
@@ -1,0 +1,108 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/default_primitives.dart';
+import 'package:easa_digital_log/domain/projection/jurisdiction_projection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../fixtures/decoders/flight_fixture.dart';
+
+Aircraft _aircraft() => const Aircraft(
+  registration: 'G-ABCD',
+  manufacturer: 'Test',
+  model: 'Test',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+/// Proves the actual shipped `assets/jurisdictions/eu.easa.part-fcl.yaml` —
+/// not a copy, not a synthetic fixture — parses, resolves, and dispatches
+/// through the real `defaultPrimitives` registry end to end. Everything
+/// else in this test suite exercises the mechanism or the rule logic in
+/// isolation; this is the one test that would fail if the two were wired
+/// together wrong.
+void main() {
+  test(
+    'the shipped EASA profile resolves and dispatches to the real primitive',
+    () {
+      final yaml = File(
+        'assets/jurisdictions/eu.easa.part-fcl.yaml',
+      ).readAsStringSync();
+      final registry = JurisdictionRegistry([
+        parseJurisdictionProfileYaml(yaml),
+      ]);
+
+      final projection = JurisdictionProjection(
+        registry: registry,
+        primitives: defaultPrimitives,
+        jurisdictionId: 'eu.easa.part-fcl',
+      );
+
+      final flight = Flight(
+        aircraftRegistration: 'G-ABCD',
+        route: const ['EGKA', 'EGKA'],
+        offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+        onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
+        capacity: const PilotCapacity(
+          commandAuthority: true,
+          soleManipulator: true,
+          soleOccupant: true,
+          multiPilotOperation: false,
+          additionalCrewRequiredByRule: false,
+          actingAsInstructor: false,
+          actingAsExaminer: false,
+          picusClaimed: false,
+          picInterventionNotRequired: false,
+        ),
+        carryingPassengers: false,
+        takeoffs: const CircuitCounts(dayFullStop: 1),
+        landings: const CircuitCounts(dayFullStop: 1),
+        ifrFlightPlanFiled: false,
+        actualInstrumentTime: FlightDuration.zero,
+        simulatedInstrumentTime: FlightDuration.zero,
+        approaches: const [],
+        holdingProceduresCount: 0,
+        trackingPerformed: false,
+        remarks: '',
+      );
+
+      final result = projection.project(flight, _aircraft());
+      expect(result.jurisdictionId, 'eu.easa.part-fcl');
+      expect(result['pic']?.value, const FlightDuration(90));
+      expect(result['pic']?.creditable, isTrue);
+    },
+  );
+
+  test('the divergence fixture resolves through the real EASA profile too', () {
+    final yaml = File(
+      'assets/jurisdictions/eu.easa.part-fcl.yaml',
+    ).readAsStringSync();
+    final registry = JurisdictionRegistry([parseJurisdictionProfileYaml(yaml)]);
+    final projection = JurisdictionProjection(
+      registry: registry,
+      primitives: defaultPrimitives,
+      jurisdictionId: 'eu.easa.part-fcl',
+    );
+
+    final flight = flightFromFixture('faa_easa_divergence');
+    final result = projection.project(flight, _aircraft());
+
+    expect(
+      result['pic']?.value,
+      FlightDuration.zero,
+      reason: 'the instructor held command',
+    );
+    expect(result['dual']?.value, isNot(FlightDuration.zero));
+  });
+}

--- a/test/domain/projection/faa_easa_divergence_projection_test.dart
+++ b/test/domain/projection/faa_easa_divergence_projection_test.dart
@@ -1,0 +1,72 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/primitives/default_primitives.dart';
+import 'package:easa_digital_log/domain/projection/jurisdiction_projection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../fixtures/decoders/flight_fixture.dart';
+
+Aircraft _aircraft() => const Aircraft(
+  registration: 'G-ABCD',
+  manufacturer: 'Test',
+  model: 'Test',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+JurisdictionRegistry _registryFromShippedProfiles() {
+  final profiles = [
+    'assets/jurisdictions/eu.easa.part-fcl.yaml',
+    'assets/jurisdictions/us.faa.part61.yaml',
+  ].map((path) => parseJurisdictionProfileYaml(File(path).readAsStringSync()));
+  return JurisdictionRegistry(profiles);
+}
+
+/// #18's own acceptance criterion: "An explicit test asserting that
+/// sole-manipulator-under-instruction yields dual under EASA and PIC under
+/// FAA." This is that test, run through the real shipped profiles and the
+/// real registered primitives — not a copy of either, and not the
+/// primitives called directly — so it fails if the wiring between #17,
+/// #18 and #19 is wrong even when each piece's own unit tests pass.
+void main() {
+  test('the same flight gives dual under EASA and PIC under FAA', () {
+    final registry = _registryFromShippedProfiles();
+    final flight = flightFromFixture('faa_easa_divergence');
+    final aircraft = _aircraft();
+
+    final easa = JurisdictionProjection(
+      registry: registry,
+      primitives: defaultPrimitives,
+      jurisdictionId: 'eu.easa.part-fcl',
+    ).project(flight, aircraft);
+
+    final faa = JurisdictionProjection(
+      registry: registry,
+      primitives: defaultPrimitives,
+      jurisdictionId: 'us.faa.part61',
+    ).project(flight, aircraft);
+
+    // EASA: no general sole-manipulator concept. The instructor held
+    // command, so this pilot logs dual, not PIC.
+    expect(easa['pic']?.value, FlightDuration.zero);
+    expect(easa['dual']?.value, isNot(FlightDuration.zero));
+
+    // FAA: §61.51(e)(1)(i) grants PIC to the sole manipulator regardless of
+    // who held command.
+    expect(faa['loggedPic']?.value, isNot(FlightDuration.zero));
+
+    // The two disagree about PIC for the identical flight, and both are
+    // correct under their own rules — that disagreement is the entire
+    // reason this codebase exists rather than storing one number.
+    expect(easa['pic']?.value, isNot(faa['loggedPic']?.value));
+  });
+}

--- a/test/domain/projection/jurisdiction_projection_test.dart
+++ b/test/domain/projection/jurisdiction_projection_test.dart
@@ -1,0 +1,208 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/pilot_function_time.dart';
+import 'package:easa_digital_log/domain/projection/derived_quantity.dart';
+import 'package:easa_digital_log/domain/projection/jurisdiction_projection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A fake primitive, not EASA or FAA logic — #18/#19 own the real rules.
+/// This proves the engine (profile resolution -> primitive dispatch ->
+/// result) works in isolation, before any real regulatory logic exists to
+/// entangle the two concerns.
+Map<String, DerivedQuantity> _fakeRule(
+  Flight flight,
+  FlightDuration blockTime,
+) => {
+  'pic': flight.capacity.commandAuthority
+      ? DerivedQuantity.creditable(blockTime, 'fake: command authority held')
+      : DerivedQuantity.zero('fake: no command authority'),
+};
+
+Aircraft _aircraft() => const Aircraft(
+  registration: 'G-TEST',
+  manufacturer: 'Test',
+  model: 'Test',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight({required bool commandAuthority}) => Flight(
+  aircraftRegistration: 'G-TEST',
+  route: const ['EGKA', 'EGKA'],
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
+  capacity: PilotCapacity(
+    commandAuthority: commandAuthority,
+    soleManipulator: commandAuthority,
+    soleOccupant: true,
+    multiPilotOperation: false,
+    additionalCrewRequiredByRule: false,
+    actingAsInstructor: false,
+    actingAsExaminer: false,
+    picusClaimed: false,
+    picInterventionNotRequired: false,
+  ),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  late JurisdictionProjection projection;
+
+  setUp(() {
+    final registry = JurisdictionRegistry([
+      const JurisdictionProfile(
+        id: 'test.fake',
+        rules: {'pic_rule': 'test.fake_rule'},
+      ),
+      const JurisdictionProfile(id: 'test.no-rules', rules: {}),
+    ]);
+    final primitives = PrimitiveRegistry({'test.fake_rule': _fakeRule});
+    projection = JurisdictionProjection(
+      registry: registry,
+      primitives: primitives,
+      jurisdictionId: 'test.fake',
+    );
+  });
+
+  group('JurisdictionProjection.project', () {
+    test('resolves the profile and dispatches to the named primitive', () {
+      final result = projection.project(
+        _flight(commandAuthority: true),
+        _aircraft(),
+      );
+
+      expect(result.jurisdictionId, 'test.fake');
+      expect(result['pic']?.value, const FlightDuration(90));
+      expect(result['pic']?.creditable, isTrue);
+    });
+
+    test('computes block time from offBlocks/onBlocks, not a stored field', () {
+      final result = projection.project(
+        _flight(commandAuthority: false),
+        _aircraft(),
+      );
+
+      // commandAuthority: false -> the fake rule reports zero, proving the
+      // engine actually passed the real flight through rather than some
+      // fixed value.
+      expect(result['pic']?.value, FlightDuration.zero);
+    });
+
+    test(
+      'a profile with no pic_rule set yields an empty result, not an error',
+      () {
+        final registry = JurisdictionRegistry([
+          const JurisdictionProfile(id: 'test.no-rules', rules: {}),
+        ]);
+        final bare = JurisdictionProjection(
+          registry: registry,
+          primitives: PrimitiveRegistry(const {}),
+          jurisdictionId: 'test.no-rules',
+        );
+
+        final result = bare.project(
+          _flight(commandAuthority: true),
+          _aircraft(),
+        );
+        expect(result.quantities, isEmpty);
+      },
+    );
+
+    test('an unregistered primitive id throws ArgumentError', () {
+      final registry = JurisdictionRegistry([
+        const JurisdictionProfile(
+          id: 'test.broken',
+          rules: {'pic_rule': 'nothing.registered'},
+        ),
+      ]);
+      final broken = JurisdictionProjection(
+        registry: registry,
+        primitives: PrimitiveRegistry(const {}),
+        jurisdictionId: 'test.broken',
+      );
+
+      expect(
+        () => broken.project(_flight(commandAuthority: true), _aircraft()),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('JurisdictionProjection.projectAggregate', () {
+    test('sums creditable contributions across the flight set', () {
+      final result = projection.projectAggregate([
+        (_flight(commandAuthority: true), _aircraft()),
+        (_flight(commandAuthority: true), _aircraft()),
+        (_flight(commandAuthority: false), _aircraft()),
+      ]);
+
+      // 90 + 90 + 0 minutes.
+      expect(result['pic']?.value, const FlightDuration(180));
+      expect(result['pic']?.explanation, contains('3 flight'));
+    });
+
+    test(
+      'excludes a non-creditable contribution from the total but names it',
+      () {
+        Map<String, DerivedQuantity> pendingRule(
+          Flight flight,
+          FlightDuration blockTime,
+        ) => {'pic': DerivedQuantity.notCreditable(blockTime, 'fake: pending')};
+
+        final registry = JurisdictionRegistry([
+          const JurisdictionProfile(
+            id: 'test.pending',
+            rules: {'pic_rule': 'test.pending_rule'},
+          ),
+        ]);
+        final pendingProjection = JurisdictionProjection(
+          registry: registry,
+          primitives: PrimitiveRegistry({'test.pending_rule': pendingRule}),
+          jurisdictionId: 'test.pending',
+        );
+
+        final result = pendingProjection.projectAggregate([
+          (_flight(commandAuthority: true), _aircraft()),
+        ]);
+
+        expect(
+          result['pic']?.value,
+          FlightDuration.zero,
+          reason:
+              'the one flight is not creditable, so it contributes nothing '
+              'to the reliable total',
+        );
+        expect(
+          result['pic']?.creditable,
+          isTrue,
+          reason: 'the total itself is reliable — it is honestly zero',
+        );
+        expect(result['pic']?.explanation, contains('excluded'));
+      },
+    );
+
+    test('an empty flight set yields an empty result', () {
+      final result = projection.projectAggregate(const []);
+      expect(result.quantities, isEmpty);
+    });
+  });
+}

--- a/test/domain/projection/projection_result_test.dart
+++ b/test/domain/projection/projection_result_test.dart
@@ -1,0 +1,38 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/projection/derived_quantity.dart';
+import 'package:easa_digital_log/domain/projection/projection_result.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ProjectionResult', () {
+    test('looks up a named quantity by []', () {
+      final pic = DerivedQuantity.creditable(const FlightDuration(90), 'PIC');
+      final result = ProjectionResult(
+        jurisdictionId: 'eu.easa.part-fcl',
+        quantities: {'pic': pic},
+      );
+
+      expect(result['pic'], pic);
+    });
+
+    test('an unpopulated name is null, not a missing-key throw', () {
+      final result = ProjectionResult(
+        jurisdictionId: 'eu.easa.part-fcl',
+        quantities: const {},
+      );
+
+      expect(result['pic'], isNull);
+    });
+
+    test('carries the jurisdiction id the result was computed under', () {
+      final result = ProjectionResult(
+        jurisdictionId: 'us.faa.part61',
+        quantities: const {},
+      );
+
+      expect(result.jurisdictionId, 'us.faa.part61');
+    });
+  });
+}


### PR DESCRIPTION
Closes #17, Closes #18, Closes #19

## Why three issues, one PR

They're the same shape of dependency as the M1 value types: an interface with nothing behind it can't really be validated, and #18/#19 are the first real consumers of #17's abstraction. Three commits, reviewable independently, but landing together so the canonical divergence test can prove the whole stack before any of it merges.

## #17 — the mechanism

`DerivedQuantity` carries a value, whether it's creditable, and why — so "PICUS pending countersignature" can be a real non-zero value that is neither silently 0 nor silently valid, which is a named acceptance criterion. `ProjectionResult` wraps `Map<String, DerivedQuantity>` rather than fixed fields, because EASA's and FAA's quantity vocabularies genuinely differ (six interrelated quantities vs. five independent ones — see below) and the interface has to survive that.

`JurisdictionProjection` is the one engine. It resolves a `JurisdictionRegistry` profile, reads `pic_rule`, and dispatches to whichever `PilotFunctionTimeRule` is registered under that name — and it never branches on which jurisdiction it's running. That's CLAUDE.md's own acceptance test for the abstraction ("adding Transport Canada should require a YAML profile and at most one new primitive"), and it's verified before any real regulatory logic exists to entangle the two: `jurisdiction_projection_test.dart` proves the mechanism with a synthetic fake primitive.

Went with the full YAML-driven registry now rather than a Dart-only stand-in — confirmed with the project owner given it's the harder, less reversible choice. `JurisdictionRegistry.resolve` walks the `extends` chain root-first (child wins), exercised against a synthetic three-generation lineage since neither real profile extends anything yet.

## #18 / #19 — the rules

Both were designed by reading every "Expected projections" comment already written into `test/fixtures/capacities/*.yaml` when #13 built that fixture set — sixteen scenarios, each with the exact EASA and FAA outcome pre-documented, specifically for this pair of issues to assert against. All sixteen matched on the first test run for both primitives.

**EASA** (`easaPilotFunctionTime`) computes six interdependent quantities — pic, dual, spic, picus, copilot, instructor — as one branching chain, since knowing whether a flight is SPIC changes what PIC is.

**FAA** (`faaPilotFunctionTime`) computes five *independent* quantities — a structurally different shape, not a stylistic choice: `pic_sole_occupant.yaml` has logged PIC, acting PIC and solo all non-zero simultaneously, because §61.51 answers five separate questions rather than sorting a flight into one bucket.

**`faa_easa_divergence_projection_test.dart`** is #18's own acceptance criterion literally: the same flight gives dual under EASA and PIC under FAA, run through the real shipped profiles and real registered primitives end to end — not the primitives called directly, so it fails if the wiring is wrong even when every unit test passes.

## Two discriminators confirmed with the project owner mid-implementation

Both surfaced while reading real regulation text, not guessed at:

- §61.51(j)'s exact four-category wording (already landed in #11/Flight, referenced here for context)
- The FAA `holding`/`tracking` split and `Approach.runway` needing an L/C/R suffix (also #11, same reasoning pattern)

Neither changed shape in this PR, but the pattern — stop and ask when a rule's exact text matters — held throughout the EASA/FAA rule design too.

## Mutation testing found two real gaps

Fixture-driven table tests passing isn't proof by itself — every branch was also mutation-tested, and two mutations went **uncaught** on the first attempt, both the same shape: a combination no capacity fixture happens to exercise, because every fixture where an instructor influences a flight also has `commandAuthority: false`, or the one examiner fixture has `influencedFlight: false`.

- **EASA**: loosening the SPIC branch to ignore `influencedFlight` (checking only "instructor present") passed all sixteen fixtures. Fixed by adding a directly-constructed `PilotCapacity` test for "command authority held while an instructor simultaneously influenced the flight" — command wins, per `mid_flight_takeover.yaml`'s own principle that EASA PIC doesn't depend on who was handling the controls.
- **FAA**: removing the `InstructorCapacity.flightInstructor` guard from dual-received (so an actively-flying examiner would count as "training received") also passed everything. Fixed the same way — a direct `PilotCapacity` with an examiner who influenced the flight.

Both fixes are new test-only `PilotCapacity` constructions, not new fixture files — narrow enough that a dedicated fixture felt like overkill, but real enough that leaving them uncovered would have been a compliance bug waiting to happen.

Also mutation-tested and confirmed: PICUS countersignature creditability gating (EASA), the SIC/PICUS distinction turning on `soleManipulator` (FAA), and `manipulationTime` crediting only the manipulated portion (FAA).

## Verification

178 tests passing, format/analyze/both layering guards clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)