### PR TITLE
Night time: solar engine, EASA and FAA projections (#20, #21, #22)

### DIFF
--- a/assets/jurisdictions/eu.easa.part-fcl.yaml
+++ b/assets/jurisdictions/eu.easa.part-fcl.yaml
@@ -5,3 +5,4 @@
 id: eu.easa.part-fcl
 
 pic_rule: easa.pilot_function_time
+night_rule: easa.night_time

--- a/assets/jurisdictions/us.faa.part61.yaml
+++ b/assets/jurisdictions/us.faa.part61.yaml
@@ -5,3 +5,4 @@
 id: us.faa.part61
 
 pic_rule: faa.pilot_function_time
+night_rule: faa.night_time

--- a/docs/adr/0008-night-time-position-interpolation.md
+++ b/docs/adr/0008-night-time-position-interpolation.md
@@ -1,0 +1,71 @@
+# ADR-0008: Approximate in-flight position as a straight great-circle line between two waypoints
+
+**Status:** Accepted
+**Date:** 2026-08-09
+
+## Context
+
+Both EASA (`FCL.010`) and the FAA define night by the sun's position relative to the aircraft,
+not a fixed clock time — `docs/jurisdiction-matrix.md` line 87. The sun's position at a given
+instant depends on where the aircraft is, and a flight's position genuinely changes over its
+duration: a flight that departs in daylight can land after the sun has set at the destination,
+or vice versa, and a long east-west flight can cross the twilight boundary purely from the
+position change even if the clock time barely moves.
+
+`Flight` (#11, ADR-0001) stores a route as an ordered list of waypoint identifiers
+(`docs/jurisdiction-matrix.md` §3) plus overall `offBlocks`/`onBlocks` and optional
+`takeoff`/`landing` instants. It does not store a timestamp per waypoint — only two instants
+bound the whole flight — and a route entry is free text, not guaranteed to resolve to a real
+position (`docs/entry-form.md`, #14: private strips and unlicensed fields have no ICAO code).
+#21's acceptance criteria require this decision to be made and documented explicitly, since more
+than one approach is defensible.
+
+## Decision
+
+Position during the flight is approximated as a single straight line — in the great-circle
+sense, via `interpolateGreatCircle` — between the first and last **resolvable** route waypoints,
+walked linearly in step with elapsed time between `takeoff`/`landing` (or `offBlocks`/`onBlocks`
+where airborne times are not recorded). Intermediate route waypoints are not used for
+positioning, even when they resolve to a real position.
+
+If only one endpoint resolves, that single position is used for the whole flight (no
+interpolation). If neither resolves, night time is reported as `DerivedQuantity.notCreditable`
+with an explanation naming the reason, rather than guessed — "not creditable" here is honest: the
+duration is real flight time, but its night/day split could not be determined.
+
+Each minute of the flight is classified atomically as day or night from the sun's elevation at
+that minute's midpoint (`FlightDuration`'s own granularity — ADR-0007 — so no sub-minute
+precision is ever needed downstream).
+
+## Alternatives considered
+
+**Multi-leg interpolation, using every resolvable waypoint.** Rejected: `Flight` has no
+per-waypoint timestamp, so splitting elapsed time between legs would itself be a guess —
+apportioned by great-circle distance, not by any recorded fact — layering one approximation
+(leg timing) on top of another (position along a leg) for a precision gain that the missing
+per-leg timestamps can't actually support. The straight line between endpoints is simpler and no
+less honest about what is actually known.
+
+**Treating the whole flight as stationary at the departure point.** Rejected outright by #21's
+acceptance criteria ("flights crossing longitudes handled: the relevant position changes during
+the flight") and demonstrated wrong by
+`test/domain/primitives/easa_night_time_test.dart`'s interpolation test: a flight from a position
+already past its own evening twilight toward one that has not yet reached it is neither wholly
+day nor wholly night, and a departure-only reading would report one or the other, incorrectly.
+
+**Throwing, or defaulting to zero, when no waypoint resolves.** Rejected: CLAUDE.md's rule 5 and
+the `DerivedQuantity` design (`derived_quantity.dart`) both exist specifically so a value that
+cannot be honestly computed is marked unreliable and explained, not silently zeroed (which reads
+as "definitely no night time," a false positive) or thrown (which would fail the whole
+projection for one flight's missing data, rather than degrading gracefully).
+
+## Consequences
+
+A flight with real intermediate stops gets a position estimate no more refined than
+departure-to-final-destination in a straight line, even mid-route. This is a known,
+accepted limitation: for any realistic single-flight duration, the twilight boundary does not
+move fast enough over distance for a multi-leg path to change the night/day minute count in a
+way the missing per-leg timing could support anyway. A private-strip departure or destination
+with no ICAO code degrades to single-endpoint or "cannot be computed" rather than blocking the
+computation on unrelated route data; the FAA night-time primitive (#22) reuses the same
+`interpolateGreatCircle` helper and inherits the same limitation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@
 | [0005](0005-offline-first.md) | Offline-first, no cloud backend by default | Accepted | The app is fully functional offline with no account system or analytics; sync, if ever added, is additive and never a dependency. |
 | [0006](0006-dependency-stack.md) | Settle the dependency stack now, add packages per milestone | Accepted | The full package list is decided up front, but each dependency is only added to `pubspec.yaml` in the milestone that first imports it. |
 | [0007](0007-duration-representation.md) | Represent logbook durations as integer minutes | Accepted | `FlightDuration` stores whole minutes for exact arithmetic; `HH:MM` and decimal hours (tenths, half away from zero) are display-only formats, and rounding never happens before a total is summed. |
+| [0008](0008-night-time-position-interpolation.md) | Approximate in-flight position as a straight great-circle line between two waypoints | Accepted | Night-time primitives interpolate position linearly, by elapsed time, along the great circle between the first and last resolvable route waypoints — not every intermediate stop, since `Flight` records no per-waypoint timestamp to split time against. |
 
 New ADRs are numbered sequentially and are never renumbered. A decision that is later reversed
 is superseded by a new ADR, not edited in place — the old record stays as evidence of what was

--- a/lib/domain/model/geo_coordinate.dart
+++ b/lib/domain/model/geo_coordinate.dart
@@ -50,15 +50,11 @@ const double _earthRadiusNm = 3440.065;
 
 const double _degreesToRadians = pi / 180;
 
-/// Great-circle distance between [a] and [b] along Earth's surface, in
-/// nautical miles — the unit `docs/jurisdiction-matrix.md` cites for the
-/// FAA's 50 nm cross-country threshold, so callers never need to convert.
-///
-/// Haversine, not Vincenty: FAA and EASA cross-country thresholds don't need
-/// ellipsoid precision, and Vincenty can fail to converge for near-antipodal
-/// points — a worse failure mode for a logbook than a fraction of a percent
-/// of spherical-Earth error.
-double greatCircleDistanceNm(GeoCoordinate a, GeoCoordinate b) {
+/// The angular distance between [a] and [b] along Earth's surface, in
+/// radians. Haversine, not Vincenty — see [greatCircleDistanceNm] — shared
+/// by that function and by [interpolateGreatCircle], so the two never derive
+/// slightly different notions of "the great-circle path between two points".
+double _centralAngleRadians(GeoCoordinate a, GeoCoordinate b) {
   final lat1 = a.latitude * _degreesToRadians;
   final lat2 = b.latitude * _degreesToRadians;
   final dLat = (b.latitude - a.latitude) * _degreesToRadians;
@@ -69,6 +65,62 @@ double greatCircleDistanceNm(GeoCoordinate a, GeoCoordinate b) {
   final h =
       sinHalfDLat * sinHalfDLat +
       cos(lat1) * cos(lat2) * sinHalfDLon * sinHalfDLon;
-  final c = 2 * atan2(sqrt(h), sqrt(1 - h));
-  return _earthRadiusNm * c;
+  return 2 * atan2(sqrt(h), sqrt(1 - h));
+}
+
+/// Great-circle distance between [a] and [b] along Earth's surface, in
+/// nautical miles — the unit `docs/jurisdiction-matrix.md` cites for the
+/// FAA's 50 nm cross-country threshold, so callers never need to convert.
+///
+/// Haversine, not Vincenty: FAA and EASA cross-country thresholds don't need
+/// ellipsoid precision, and Vincenty can fail to converge for near-antipodal
+/// points — a worse failure mode for a logbook than a fraction of a percent
+/// of spherical-Earth error.
+double greatCircleDistanceNm(GeoCoordinate a, GeoCoordinate b) =>
+    _earthRadiusNm * _centralAngleRadians(a, b);
+
+/// The point [fraction] of the way from [a] to [b] along the great circle
+/// connecting them. `fraction: 0` is [a], `fraction: 1` is [b].
+///
+/// Used by the EASA and FAA night-time primitives (#21, #22) to approximate
+/// an aircraft's position during a flight as a straight line — in the
+/// great-circle sense — between its first and last resolvable route
+/// waypoints, walked in step with elapsed time. See
+/// `docs/adr/0008-night-time-position-interpolation.md` for why endpoints
+/// only, not every intermediate stop.
+///
+/// Standard spherical interpolation (Ed Williams, *Aviation Formulary*,
+/// "Intermediate points"). If [a] and [b] are (near-)coincident, the
+/// central angle is ~0 and the interpolation formula divides by ~0, so that
+/// case returns [a] directly rather than propagating a `NaN` — correct
+/// either way, since every point on a zero-length path is the same point.
+GeoCoordinate interpolateGreatCircle(
+  GeoCoordinate a,
+  GeoCoordinate b,
+  double fraction,
+) {
+  final angle = _centralAngleRadians(a, b);
+  if (angle < 1e-12) {
+    return a;
+  }
+
+  final lat1 = a.latitude * _degreesToRadians;
+  final lon1 = a.longitude * _degreesToRadians;
+  final lat2 = b.latitude * _degreesToRadians;
+  final lon2 = b.longitude * _degreesToRadians;
+
+  final scaleA = sin((1 - fraction) * angle) / sin(angle);
+  final scaleB = sin(fraction * angle) / sin(angle);
+
+  final x = scaleA * cos(lat1) * cos(lon1) + scaleB * cos(lat2) * cos(lon2);
+  final y = scaleA * cos(lat1) * sin(lon1) + scaleB * cos(lat2) * sin(lon2);
+  final z = scaleA * sin(lat1) + scaleB * sin(lat2);
+
+  final resultLatRad = atan2(z, sqrt(x * x + y * y));
+  final resultLonRad = atan2(y, x);
+
+  return GeoCoordinate(
+    latitude: resultLatRad / _degreesToRadians,
+    longitude: resultLonRad / _degreesToRadians,
+  );
 }

--- a/lib/domain/model/solar_position.dart
+++ b/lib/domain/model/solar_position.dart
@@ -1,0 +1,311 @@
+import 'dart:math' as math;
+
+import 'geo_coordinate.dart';
+import 'utc_instant.dart';
+
+/// #20: the sun's position, needed because both EASA and FAA define "night"
+/// by reference to civil twilight rather than a clock time —
+/// `docs/jurisdiction-matrix.md` line 87. The EASA and FAA night-time
+/// primitives (#21, #22) are both built on [solarElevationDegrees] alone, so
+/// a formula fix here fixes both.
+///
+/// Low-precision solar position algorithm: Meeus, *Astronomical Algorithms*
+/// ch. 25, in the form NOAA's solar calculator uses. Good to a fraction of a
+/// degree, which is what "within a minute" of a published sunrise/sunset time
+/// needs — near the horizon at mid-latitudes the sun moves roughly
+/// 0.25 degrees of elevation per minute.
+
+/// Conventional sunrise/sunset threshold, in degrees of elevation: the sun's
+/// centre 0.833 degrees below the geometric horizon (34' refraction + 16'
+/// solar radius — Meeus, USNO), the standard used by every rigorous source
+/// checked against `test/domain/model/solar_position_test.dart`. This is
+/// *not* the definition either jurisdiction uses for night — see
+/// [civilTwilightThresholdDegrees] — but sunrise/sunset are independently
+/// useful (`docs/entry-form.md` line 289: the entry form pre-fills day/night
+/// landing counts from a twilight computation, and sunrise/sunset anchor
+/// that computation for the reader) and load-bearing for the FAA night
+/// *currency* window (`§61.57(b)`, sunset/sunrise ± 1 hour — the FAA
+/// night-time primitive, not this one).
+///
+/// Unlike the twilight thresholds below, sunrise/sunset is inherently a
+/// refraction-dependent, not purely geometric, question — real atmospheric
+/// refraction right at the horizon varies with conditions, which is why
+/// different published calculators can disagree on sunrise/sunset by a
+/// minute or two even when they agree on civil twilight. The US Naval
+/// Observatory (the reference this codebase validates against) was checked
+/// against a commercial calculator during development; the two agreed on
+/// civil twilight but differed by about two minutes on sunrise/sunset. USNO
+/// was treated as authoritative.
+const double sunriseSunsetThresholdDegrees = -0.833;
+
+/// Civil twilight threshold, in degrees of elevation. Both EASA (FCL.010)
+/// and the FAA (`§1.1`) define night, for logging purposes, as the period
+/// the sun is more than 6 degrees below the horizon —
+/// `docs/jurisdiction-matrix.md` line 87.
+const double civilTwilightThresholdDegrees = -6.0;
+
+double _toRadians(double degrees) => degrees * math.pi / 180;
+
+double _toDegrees(double radians) => radians * 180 / math.pi;
+
+double _normalizeDegrees(double degrees) {
+  final result = degrees % 360;
+  return result < 0 ? result + 360 : result;
+}
+
+/// Julian Day for [instant]. `2440587.5` is the Julian Day of the Unix
+/// epoch (1970-01-01T00:00:00Z).
+double _julianDay(UtcInstant instant) =>
+    2440587.5 + instant.millisecondsSinceEpoch / 86400000.0;
+
+double _minutesSinceMidnightUtc(UtcInstant instant) {
+  final value = instant.asUtcDateTime;
+  return value.hour * 60 +
+      value.minute +
+      value.second / 60 +
+      value.millisecond / 60000;
+}
+
+double _geometricMeanLongitudeDegrees(double t) =>
+    _normalizeDegrees(280.46646 + t * (36000.76983 + t * 0.0003032));
+
+double _geometricMeanAnomalyDegrees(double t) =>
+    357.52911 + t * (35999.05029 - 0.0001537 * t);
+
+double _eccentricityEarthOrbit(double t) =>
+    0.016708634 - t * (0.000042037 + 0.0000001267 * t);
+
+double _sunEquationOfCenterDegrees(double t) {
+  final meanAnomalyRad = _toRadians(_geometricMeanAnomalyDegrees(t));
+  return math.sin(meanAnomalyRad) * (1.914602 - t * (0.004817 + 0.000014 * t)) +
+      math.sin(2 * meanAnomalyRad) * (0.019993 - 0.000101 * t) +
+      math.sin(3 * meanAnomalyRad) * 0.000289;
+}
+
+double _sunTrueLongitudeDegrees(double t) =>
+    _geometricMeanLongitudeDegrees(t) + _sunEquationOfCenterDegrees(t);
+
+double _sunApparentLongitudeDegrees(double t) {
+  final omegaDegrees = 125.04 - 1934.136 * t;
+  return _sunTrueLongitudeDegrees(t) -
+      0.00569 -
+      0.00478 * math.sin(_toRadians(omegaDegrees));
+}
+
+double _meanObliquityOfEclipticDegrees(double t) =>
+    23 +
+    (26 + (21.448 - t * (46.815 + t * (0.00059 - t * 0.001813))) / 60) / 60;
+
+double _obliquityCorrectionDegrees(double t) {
+  final omegaDegrees = 125.04 - 1934.136 * t;
+  return _meanObliquityOfEclipticDegrees(t) +
+      0.00256 * math.cos(_toRadians(omegaDegrees));
+}
+
+double _sunDeclinationDegrees(double t) {
+  final obliquityRad = _toRadians(_obliquityCorrectionDegrees(t));
+  final apparentLongitudeRad = _toRadians(_sunApparentLongitudeDegrees(t));
+  return _toDegrees(
+    math.asin(math.sin(obliquityRad) * math.sin(apparentLongitudeRad)),
+  );
+}
+
+double _equationOfTimeMinutes(double t) {
+  final obliquityRad = _toRadians(_obliquityCorrectionDegrees(t));
+  final y = math.tan(obliquityRad / 2) * math.tan(obliquityRad / 2);
+  final l0Rad = _toRadians(_geometricMeanLongitudeDegrees(t));
+  final e = _eccentricityEarthOrbit(t);
+  final meanAnomalyRad = _toRadians(_geometricMeanAnomalyDegrees(t));
+
+  final value =
+      y * math.sin(2 * l0Rad) -
+      2 * e * math.sin(meanAnomalyRad) +
+      4 * e * y * math.sin(meanAnomalyRad) * math.cos(2 * l0Rad) -
+      0.5 * y * y * math.sin(4 * l0Rad) -
+      1.25 * e * e * math.sin(2 * meanAnomalyRad);
+  return 4 * _toDegrees(value);
+}
+
+/// The sun's elevation above the horizon, in degrees, at [instant] and
+/// [position]. Positive above the horizon, negative below. Refraction is
+/// not modelled — that correction is folded into
+/// [sunriseSunsetThresholdDegrees] instead of into this function, so this
+/// function stays the one place both thresholds are evaluated against.
+///
+/// A pure function of its two arguments, no I/O and no platform dependency —
+/// #20's acceptance criterion — so it can run identically in a background
+/// isolate or inline.
+double solarElevationDegrees(UtcInstant instant, GeoCoordinate position) {
+  final t = (_julianDay(instant) - 2451545.0) / 36525.0;
+
+  final declinationDegrees = _sunDeclinationDegrees(t);
+  final equationOfTimeMinutes = _equationOfTimeMinutes(t);
+
+  var trueSolarTime =
+      (_minutesSinceMidnightUtc(instant) +
+          equationOfTimeMinutes +
+          4 * position.longitude) %
+      1440;
+  if (trueSolarTime < 0) {
+    trueSolarTime += 1440;
+  }
+  final hourAngleDegrees = trueSolarTime / 4 - 180;
+
+  final latitudeRad = _toRadians(position.latitude);
+  final declinationRad = _toRadians(declinationDegrees);
+  final hourAngleRad = _toRadians(hourAngleDegrees);
+
+  final cosZenith =
+      (math.sin(latitudeRad) * math.sin(declinationRad) +
+              math.cos(latitudeRad) *
+                  math.cos(declinationRad) *
+                  math.cos(hourAngleRad))
+          .clamp(-1.0, 1.0);
+  return 90 - _toDegrees(math.acos(cosZenith));
+}
+
+/// Whether the sun is more than 6 degrees below the horizon at [instant] and
+/// [position] — the EASA and FAA definition of night for logging purposes
+/// (`docs/jurisdiction-matrix.md` line 87). Night *currency* windows use a
+/// different threshold entirely (sunset/sunrise ± 1 hour, `§61.57(b)`) and
+/// are not this function's concern — see the FAA night-time primitive.
+bool isNight(UtcInstant instant, GeoCoordinate position) =>
+    solarElevationDegrees(instant, position) < civilTwilightThresholdDegrees;
+
+/// Whether, on the UTC calendar date [onDate] falls on, the sun's elevation
+/// at [position] crosses a threshold at all, and if so where.
+enum SolarThresholdState {
+  /// The sun's elevation rises above and falls back below the threshold
+  /// during the day — [SolarThresholdCrossing.ascending] and
+  /// [SolarThresholdCrossing.descending] are both set.
+  crosses,
+
+  /// The sun's elevation never drops to the threshold — e.g. midnight sun
+  /// for [sunriseSunsetThresholdDegrees], or the civil-twilight-all-night
+  /// condition at high summer latitudes for [civilTwilightThresholdDegrees].
+  aboveAllDay,
+
+  /// The sun's elevation never rises to the threshold — polar night.
+  belowAllDay,
+}
+
+/// The instants (if any) at which the sun's elevation crosses a threshold on
+/// one UTC calendar date, at one position.
+class SolarThresholdCrossing {
+  const SolarThresholdCrossing({
+    required this.ascending,
+    required this.descending,
+    required this.state,
+  });
+
+  /// The instant elevation rises through the threshold — morning. Non-null
+  /// only when [state] is [SolarThresholdState.crosses].
+  final UtcInstant? ascending;
+
+  /// The instant elevation falls through the threshold — evening. Non-null
+  /// only when [state] is [SolarThresholdState.crosses].
+  final UtcInstant? descending;
+
+  final SolarThresholdState state;
+}
+
+/// 10-minute steps across a 24-hour UTC date. Within one calendar day, the
+/// sun's elevation has at most one local maximum and one local minimum — a
+/// smooth, roughly sinusoidal curve with a 24-hour period — so 10-minute
+/// sampling cannot straddle and miss a crossing; [_bisectCrossing] then
+/// refines each bracketed crossing well past the 1-minute accuracy target.
+const int _sampleCount = 144;
+const int _sampleStepMinutes = 1440 ~/ _sampleCount;
+const Duration _bisectionTolerance = Duration(seconds: 15);
+
+/// Finds where the sun's elevation at [position] crosses [thresholdDegrees],
+/// on the UTC calendar date [onDate] falls on (time-of-day in [onDate] is
+/// ignored; only the date is used).
+///
+/// High-latitude condition where the sun never reaches the threshold that
+/// day is reported via [SolarThresholdCrossing.state], never thrown — #20's
+/// explicit acceptance criterion.
+SolarThresholdCrossing solarThresholdCrossings({
+  required UtcInstant onDate,
+  required GeoCoordinate position,
+  required double thresholdDegrees,
+}) {
+  final calendarDate = onDate.asUtcDateTime;
+  final midnight = UtcInstant.utc(
+    calendarDate.year,
+    calendarDate.month,
+    calendarDate.day,
+  );
+
+  double elevationAboveThreshold(UtcInstant instant) =>
+      solarElevationDegrees(instant, position) - thresholdDegrees;
+
+  UtcInstant? ascending;
+  UtcInstant? descending;
+
+  var previousInstant = midnight;
+  var previousValue = elevationAboveThreshold(previousInstant);
+
+  for (var sample = 1; sample <= _sampleCount; sample++) {
+    final currentInstant = midnight.add(
+      Duration(minutes: sample * _sampleStepMinutes),
+    );
+    final currentValue = elevationAboveThreshold(currentInstant);
+
+    if ((previousValue < 0) != (currentValue < 0)) {
+      final crossing = _bisectCrossing(
+        position: position,
+        thresholdDegrees: thresholdDegrees,
+        lowInstant: previousInstant,
+        lowValue: previousValue,
+        highInstant: currentInstant,
+      );
+      if (previousValue < 0) {
+        ascending = crossing;
+      } else {
+        descending = crossing;
+      }
+    }
+
+    previousInstant = currentInstant;
+    previousValue = currentValue;
+  }
+
+  final state = ascending != null || descending != null
+      ? SolarThresholdState.crosses
+      : (previousValue >= 0
+            ? SolarThresholdState.aboveAllDay
+            : SolarThresholdState.belowAllDay);
+
+  return SolarThresholdCrossing(
+    ascending: ascending,
+    descending: descending,
+    state: state,
+  );
+}
+
+/// Bisects between [lowInstant] (where elevation-minus-threshold is
+/// [lowValue]) and [highInstant] (the opposite sign) to find the crossing
+/// instant to within [_bisectionTolerance].
+UtcInstant _bisectCrossing({
+  required GeoCoordinate position,
+  required double thresholdDegrees,
+  required UtcInstant lowInstant,
+  required double lowValue,
+  required UtcInstant highInstant,
+}) {
+  var low = lowInstant;
+  var high = highInstant;
+  final lowIsNegative = lowValue < 0;
+
+  while (high.difference(low) > _bisectionTolerance) {
+    final mid = low.add(high.difference(low) ~/ 2);
+    final midValue = solarElevationDegrees(mid, position) - thresholdDegrees;
+    if ((midValue < 0) == lowIsNegative) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+  return low.add(high.difference(low) ~/ 2);
+}

--- a/lib/domain/primitives/default_primitives.dart
+++ b/lib/domain/primitives/default_primitives.dart
@@ -1,16 +1,20 @@
+import 'easa_night_time.dart';
 import 'easa_pilot_function_time.dart';
 import 'faa_pilot_function_time.dart';
-import 'pilot_function_time.dart';
+import 'primitive_registry.dart';
 
 /// The [PrimitiveRegistry] the app actually ships — every primitive id an
 /// `assets/jurisdictions/*.yaml` profile can reference, wired to its real
 /// implementation.
 ///
-/// Grows by one line per primitive as later issues (#21-26:
-/// night/cross-country/instrument) land — never by a change to
+/// Grows by one line per primitive as later issues (#22-26:
+/// FAA night/cross-country/instrument) land — never by a change to
 /// [JurisdictionProjection], which only ever sees this through the
 /// [PrimitiveRegistry] interface.
-final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry({
-  'easa.pilot_function_time': easaPilotFunctionTime,
-  'faa.pilot_function_time': faaPilotFunctionTime,
-});
+final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry(
+  pilotFunctionTimeRules: {
+    'easa.pilot_function_time': easaPilotFunctionTime,
+    'faa.pilot_function_time': faaPilotFunctionTime,
+  },
+  nightTimeRules: {'easa.night_time': easaNightTime},
+);

--- a/lib/domain/primitives/default_primitives.dart
+++ b/lib/domain/primitives/default_primitives.dart
@@ -1,5 +1,6 @@
 import 'easa_night_time.dart';
 import 'easa_pilot_function_time.dart';
+import 'faa_night_time.dart';
 import 'faa_pilot_function_time.dart';
 import 'primitive_registry.dart';
 
@@ -7,8 +8,8 @@ import 'primitive_registry.dart';
 /// `assets/jurisdictions/*.yaml` profile can reference, wired to its real
 /// implementation.
 ///
-/// Grows by one line per primitive as later issues (#22-26:
-/// FAA night/cross-country/instrument) land — never by a change to
+/// Grows by one line per primitive as later issues (#23-26:
+/// cross-country/instrument) land — never by a change to
 /// [JurisdictionProjection], which only ever sees this through the
 /// [PrimitiveRegistry] interface.
 final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry(
@@ -16,5 +17,8 @@ final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry(
     'easa.pilot_function_time': easaPilotFunctionTime,
     'faa.pilot_function_time': faaPilotFunctionTime,
   },
-  nightTimeRules: {'easa.night_time': easaNightTime},
+  nightTimeRules: {
+    'easa.night_time': easaNightTime,
+    'faa.night_time': faaNightTime,
+  },
 );

--- a/lib/domain/primitives/easa_night_time.dart
+++ b/lib/domain/primitives/easa_night_time.dart
@@ -1,0 +1,98 @@
+import '../model/aerodrome_directory.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../model/geo_coordinate.dart';
+import '../model/solar_position.dart';
+import '../model/utc_instant.dart';
+import '../projection/derived_quantity.dart';
+
+/// EASA `night_rule` primitive: `FCL.010` defines night as the period
+/// between the end of evening civil twilight and the beginning of morning
+/// civil twilight — one quantity, `night`, unlike the FAA rule (#22), which
+/// keeps a second, separate window for takeoff/landing currency.
+///
+/// Position during the flight is approximated as a straight line — in the
+/// great-circle sense — between the first and last resolvable route
+/// waypoints, walked in step with elapsed time. See
+/// `docs/adr/0008-night-time-position-interpolation.md` for why, and for
+/// what a route with no resolvable waypoint at all does here.
+Map<String, DerivedQuantity> easaNightTime(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+) {
+  final start = flight.takeoff ?? flight.offBlocks;
+  final end = flight.landing ?? flight.onBlocks;
+
+  final departure = _resolvePosition(_firstOrNull(flight.route), aerodromes);
+  final destination = _resolvePosition(_lastOrNull(flight.route), aerodromes);
+
+  if (departure == null && destination == null) {
+    return {
+      'night': DerivedQuantity.notCreditable(
+        FlightDuration.zero,
+        "FCL.010 'night': neither the departure nor the destination in "
+        "this flight's route could be resolved to a position, so night "
+        'time cannot be computed',
+      ),
+    };
+  }
+
+  final from = departure ?? destination!;
+  final to = destination ?? departure!;
+
+  final nightDuration = _nightPortion(
+    start: start,
+    end: end,
+    positionAtFraction: (fraction) =>
+        interpolateGreatCircle(from, to, fraction),
+  );
+
+  return {
+    'night': DerivedQuantity.creditable(
+      nightDuration,
+      "FCL.010 'night': end of evening civil twilight to beginning of "
+      "morning civil twilight, along the flight's route",
+    ),
+  };
+}
+
+String? _firstOrNull(List<String> route) => route.isEmpty ? null : route.first;
+
+String? _lastOrNull(List<String> route) => route.isEmpty ? null : route.last;
+
+GeoCoordinate? _resolvePosition(
+  String? identifier,
+  AerodromeDirectory aerodromes,
+) => identifier == null ? null : aerodromes.byIcao(identifier)?.position;
+
+/// The portion of [start] to [end] during which the sun is more than 6
+/// degrees below the horizon at the aircraft's position, sampled once per
+/// whole minute — [FlightDuration]'s own granularity, so this never needs
+/// sub-minute precision.
+///
+/// Each minute is classified atomically, day or night, from the sun's
+/// elevation at that minute's midpoint — accurate enough given the position
+/// approximation ([positionAtFraction]) is itself only a straight line
+/// between two waypoints, and simpler than bisecting a twilight-crossing
+/// instant to sub-minute precision only to immediately truncate it back to
+/// whole minutes.
+FlightDuration _nightPortion({
+  required UtcInstant start,
+  required UtcInstant end,
+  required GeoCoordinate Function(double fraction) positionAtFraction,
+}) {
+  final totalMinutes = end.difference(start).inMinutes;
+  if (totalMinutes <= 0) {
+    return FlightDuration.zero;
+  }
+
+  var nightMinutes = 0;
+  for (var minute = 0; minute < totalMinutes; minute++) {
+    final midpoint = start.add(Duration(minutes: minute, seconds: 30));
+    final fraction = (minute + 0.5) / totalMinutes;
+    if (isNight(midpoint, positionAtFraction(fraction))) {
+      nightMinutes++;
+    }
+  }
+  return FlightDuration(nightMinutes);
+}

--- a/lib/domain/primitives/easa_night_time.dart
+++ b/lib/domain/primitives/easa_night_time.dart
@@ -1,32 +1,25 @@
 import '../model/aerodrome_directory.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
-import '../model/geo_coordinate.dart';
-import '../model/solar_position.dart';
-import '../model/utc_instant.dart';
 import '../projection/derived_quantity.dart';
+import 'night_time_support.dart';
 
 /// EASA `night_rule` primitive: `FCL.010` defines night as the period
 /// between the end of evening civil twilight and the beginning of morning
 /// civil twilight — one quantity, `night`, unlike the FAA rule (#22), which
 /// keeps a second, separate window for takeoff/landing currency.
 ///
-/// Position during the flight is approximated as a straight line — in the
-/// great-circle sense — between the first and last resolvable route
-/// waypoints, walked in step with elapsed time. See
-/// `docs/adr/0008-night-time-position-interpolation.md` for why, and for
-/// what a route with no resolvable waypoint at all does here.
+/// The position/time computation is [civilTwilightNightPortion], shared
+/// with the FAA primitive since both jurisdictions define night *logging*
+/// identically — see that function's dartdoc for the interpolation
+/// approximation this rests on.
 Map<String, DerivedQuantity> easaNightTime(
   Flight flight,
   AerodromeDirectory aerodromes,
 ) {
-  final start = flight.takeoff ?? flight.offBlocks;
-  final end = flight.landing ?? flight.onBlocks;
+  final night = civilTwilightNightPortion(flight, aerodromes);
 
-  final departure = _resolvePosition(_firstOrNull(flight.route), aerodromes);
-  final destination = _resolvePosition(_lastOrNull(flight.route), aerodromes);
-
-  if (departure == null && destination == null) {
+  if (night == null) {
     return {
       'night': DerivedQuantity.notCreditable(
         FlightDuration.zero,
@@ -37,62 +30,11 @@ Map<String, DerivedQuantity> easaNightTime(
     };
   }
 
-  final from = departure ?? destination!;
-  final to = destination ?? departure!;
-
-  final nightDuration = _nightPortion(
-    start: start,
-    end: end,
-    positionAtFraction: (fraction) =>
-        interpolateGreatCircle(from, to, fraction),
-  );
-
   return {
     'night': DerivedQuantity.creditable(
-      nightDuration,
+      night,
       "FCL.010 'night': end of evening civil twilight to beginning of "
       "morning civil twilight, along the flight's route",
     ),
   };
-}
-
-String? _firstOrNull(List<String> route) => route.isEmpty ? null : route.first;
-
-String? _lastOrNull(List<String> route) => route.isEmpty ? null : route.last;
-
-GeoCoordinate? _resolvePosition(
-  String? identifier,
-  AerodromeDirectory aerodromes,
-) => identifier == null ? null : aerodromes.byIcao(identifier)?.position;
-
-/// The portion of [start] to [end] during which the sun is more than 6
-/// degrees below the horizon at the aircraft's position, sampled once per
-/// whole minute — [FlightDuration]'s own granularity, so this never needs
-/// sub-minute precision.
-///
-/// Each minute is classified atomically, day or night, from the sun's
-/// elevation at that minute's midpoint — accurate enough given the position
-/// approximation ([positionAtFraction]) is itself only a straight line
-/// between two waypoints, and simpler than bisecting a twilight-crossing
-/// instant to sub-minute precision only to immediately truncate it back to
-/// whole minutes.
-FlightDuration _nightPortion({
-  required UtcInstant start,
-  required UtcInstant end,
-  required GeoCoordinate Function(double fraction) positionAtFraction,
-}) {
-  final totalMinutes = end.difference(start).inMinutes;
-  if (totalMinutes <= 0) {
-    return FlightDuration.zero;
-  }
-
-  var nightMinutes = 0;
-  for (var minute = 0; minute < totalMinutes; minute++) {
-    final midpoint = start.add(Duration(minutes: minute, seconds: 30));
-    final fraction = (minute + 0.5) / totalMinutes;
-    if (isNight(midpoint, positionAtFraction(fraction))) {
-      nightMinutes++;
-    }
-  }
-  return FlightDuration(nightMinutes);
 }

--- a/lib/domain/primitives/faa_night_time.dart
+++ b/lib/domain/primitives/faa_night_time.dart
@@ -1,0 +1,55 @@
+import '../model/aerodrome_directory.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../projection/derived_quantity.dart';
+import 'night_time_support.dart';
+
+/// FAA `night_rule` primitive. `§1.1` defines night, for *logging* flight
+/// time, identically to EASA's `FCL.010` — the period between the end of
+/// evening civil twilight and the beginning of morning civil twilight — so
+/// this reuses the same [civilTwilightNightPortion] the EASA primitive
+/// (#21) does, under a different key and citation.
+///
+/// `§61.57(b)` night *takeoff and landing currency* uses a second, distinct
+/// window: one hour after sunset to one hour before sunrise, always later-
+/// starting and earlier-ending than the twilight window — a landing can be
+/// night for logging but not yet night for currency, and vice versa,
+/// `docs/jurisdiction-matrix.md` line 88. This primitive does not compute
+/// that window: `Flight.landings` (`CircuitCounts.nightFullStop` /
+/// `nightTouchAndGo`) already records the currency-relevant day/night split
+/// as a raw, pilot-entered fact per CLAUDE.md rule 2 — not something this
+/// projection may recompute or reconcile against its own `nightFlightTime`
+/// figure. Rule 5 is why the two are kept under different names rather than
+/// one "night" quantity meaning two different things depending on which
+/// part of the app reads it.
+///
+/// `§1.1`'s position-lights window (sunset to sunrise, a third definition)
+/// is deliberately not implemented — nothing in this app advises on
+/// position lights.
+Map<String, DerivedQuantity> faaNightTime(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+) {
+  final night = civilTwilightNightPortion(flight, aerodromes);
+
+  if (night == null) {
+    return {
+      'nightFlightTime': DerivedQuantity.notCreditable(
+        FlightDuration.zero,
+        "§1.1 'night': neither the departure nor the destination in this "
+        "flight's route could be resolved to a position, so night flight "
+        'time cannot be computed',
+      ),
+    };
+  }
+
+  return {
+    'nightFlightTime': DerivedQuantity.creditable(
+      night,
+      "§1.1 'night': end of evening civil twilight to beginning of "
+      "morning civil twilight, along the flight's route — logging only; "
+      "§61.57(b) night takeoff/landing currency is a separate, later-"
+      'starting window recorded on Flight.landings, not this quantity',
+    ),
+  };
+}

--- a/lib/domain/primitives/night_time.dart
+++ b/lib/domain/primitives/night_time.dart
@@ -1,0 +1,20 @@
+import '../model/aerodrome_directory.dart';
+import '../model/flight.dart';
+import '../projection/derived_quantity.dart';
+
+/// A named, jurisdiction-specific rule computing the night-time quantities
+/// for one flight.
+///
+/// Takes the whole [Flight], not a precomputed block time, because night
+/// determination needs the route (to resolve position — #21's ADR-0008
+/// covers how) and needs [Flight.takeoff]/[Flight.landing] in preference to
+/// [Flight.offBlocks]/[Flight.onBlocks] where they're recorded, since night
+/// is a property of when the aircraft was airborne, not when it was
+/// taxiing. [aerodromes] resolves route identifiers to positions; a route
+/// entry with no matching entry (a private strip, `docs/entry-form.md`) is
+/// not an error — see the individual primitives for how they degrade.
+typedef NightTimeRule =
+    Map<String, DerivedQuantity> Function(
+      Flight flight,
+      AerodromeDirectory aerodromes,
+    );

--- a/lib/domain/primitives/night_time_support.dart
+++ b/lib/domain/primitives/night_time_support.dart
@@ -1,0 +1,90 @@
+import '../model/aerodrome_directory.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../model/geo_coordinate.dart';
+import '../model/solar_position.dart';
+import '../model/utc_instant.dart';
+
+/// Shared by the EASA (#21) and FAA (#22) night-time primitives: both
+/// define night, for *logging* purposes, identically — the period the sun
+/// is more than 6 degrees below the horizon (civil twilight) —
+/// `docs/jurisdiction-matrix.md` line 87. Only the [DerivedQuantity] name
+/// and the cited rule differ per jurisdiction; the position/time
+/// computation itself does not, so it lives in exactly one place.
+///
+/// Position during the flight is approximated per
+/// `docs/adr/0008-night-time-position-interpolation.md` — a straight
+/// great-circle line between the first and last resolvable route waypoints,
+/// walked in step with elapsed time between [Flight.takeoff]/
+/// [Flight.landing] (or [Flight.offBlocks]/[Flight.onBlocks] where airborne
+/// times aren't recorded).
+///
+/// Returns `null` if neither the departure nor the destination in
+/// [flight]'s route resolved to a position — the caller decides how to
+/// report that in its own jurisdiction's vocabulary, rather than this
+/// shared helper guessing at a shape that fits both.
+FlightDuration? civilTwilightNightPortion(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+) {
+  final start = flight.takeoff ?? flight.offBlocks;
+  final end = flight.landing ?? flight.onBlocks;
+
+  final departure = _resolvePosition(_firstOrNull(flight.route), aerodromes);
+  final destination = _resolvePosition(_lastOrNull(flight.route), aerodromes);
+
+  if (departure == null && destination == null) {
+    return null;
+  }
+
+  final from = departure ?? destination!;
+  final to = destination ?? departure!;
+
+  return _nightPortion(
+    start: start,
+    end: end,
+    positionAtFraction: (fraction) =>
+        interpolateGreatCircle(from, to, fraction),
+  );
+}
+
+String? _firstOrNull(List<String> route) => route.isEmpty ? null : route.first;
+
+String? _lastOrNull(List<String> route) => route.isEmpty ? null : route.last;
+
+GeoCoordinate? _resolvePosition(
+  String? identifier,
+  AerodromeDirectory aerodromes,
+) => identifier == null ? null : aerodromes.byIcao(identifier)?.position;
+
+/// The portion of [start] to [end] during which the sun is more than 6
+/// degrees below the horizon at the aircraft's position, sampled once per
+/// whole minute — [FlightDuration]'s own granularity, so this never needs
+/// sub-minute precision.
+///
+/// Each minute is classified atomically, day or night, from the sun's
+/// elevation at that minute's midpoint — accurate enough given the position
+/// approximation ([positionAtFraction]) is itself only a straight line
+/// between two waypoints, and simpler than bisecting a twilight-crossing
+/// instant to sub-minute precision only to immediately truncate it back to
+/// whole minutes.
+FlightDuration _nightPortion({
+  required UtcInstant start,
+  required UtcInstant end,
+  required GeoCoordinate Function(double fraction) positionAtFraction,
+}) {
+  final totalMinutes = end.difference(start).inMinutes;
+  if (totalMinutes <= 0) {
+    return FlightDuration.zero;
+  }
+
+  var nightMinutes = 0;
+  for (var minute = 0; minute < totalMinutes; minute++) {
+    final midpoint = start.add(Duration(minutes: minute, seconds: 30));
+    final fraction = (minute + 0.5) / totalMinutes;
+    if (isNight(midpoint, positionAtFraction(fraction))) {
+      nightMinutes++;
+    }
+  }
+  return FlightDuration(nightMinutes);
+}

--- a/lib/domain/primitives/pilot_function_time.dart
+++ b/lib/domain/primitives/pilot_function_time.dart
@@ -18,33 +18,3 @@ typedef PilotFunctionTimeRule =
       Flight flight,
       FlightDuration blockTime,
     );
-
-/// Looks up a [PilotFunctionTimeRule] by the id a [JurisdictionProfile]
-/// names in its `pic_rule` key, e.g. `easa.pilot_function_time`.
-///
-/// A registry, not a hardcoded `switch` on jurisdiction id, because the
-/// engine that calls it ([JurisdictionProjection]) must never itself branch
-/// on which jurisdiction it is running — CLAUDE.md's acceptance test for
-/// this whole abstraction is that adding a new authority needs a YAML
-/// profile and at most one new primitive, never a change here.
-class PrimitiveRegistry {
-  const PrimitiveRegistry(this._pilotFunctionTimeRules);
-
-  final Map<String, PilotFunctionTimeRule> _pilotFunctionTimeRules;
-
-  /// Throws [ArgumentError] naming [ruleId] if nothing is registered under
-  /// it — a profile referencing a primitive that was never wired up is a
-  /// configuration bug, not a state to silently paper over with a zeroed
-  /// result.
-  PilotFunctionTimeRule pilotFunctionTime(String ruleId) {
-    final rule = _pilotFunctionTimeRules[ruleId];
-    if (rule == null) {
-      throw ArgumentError.value(
-        ruleId,
-        'ruleId',
-        'no pilot-function-time primitive is registered under this id',
-      );
-    }
-    return rule;
-  }
-}

--- a/lib/domain/primitives/primitive_registry.dart
+++ b/lib/domain/primitives/primitive_registry.dart
@@ -1,0 +1,56 @@
+import 'night_time.dart';
+import 'pilot_function_time.dart';
+
+/// Looks up a named primitive by the id a [JurisdictionProfile] names in a
+/// rule key (`pic_rule`, `night_rule`, ...), e.g. `easa.pilot_function_time`.
+///
+/// A registry, not a hardcoded `switch` on jurisdiction id, because the
+/// engine that calls it ([JurisdictionProjection]) must never itself branch
+/// on which jurisdiction it is running — CLAUDE.md's acceptance test for
+/// this whole abstraction is that adding a new authority needs a YAML
+/// profile and at most one new primitive per rule kind, never a change here.
+///
+/// One map per rule *kind*, not one flat map keyed only by id: `pic_rule`
+/// and `night_rule` are different function shapes
+/// ([PilotFunctionTimeRule] vs. [NightTimeRule]), and a single `Map<String,
+/// Object>` would push the cast back onto every caller. Grows by one map and
+/// one lookup method per rule kind as #23-26 (cross-country, instrument)
+/// land.
+class PrimitiveRegistry {
+  const PrimitiveRegistry({
+    required this.pilotFunctionTimeRules,
+    required this.nightTimeRules,
+  });
+
+  final Map<String, PilotFunctionTimeRule> pilotFunctionTimeRules;
+  final Map<String, NightTimeRule> nightTimeRules;
+
+  /// Throws [ArgumentError] naming [ruleId] if nothing is registered under
+  /// it — a profile referencing a primitive that was never wired up is a
+  /// configuration bug, not a state to silently paper over with a zeroed
+  /// result.
+  PilotFunctionTimeRule pilotFunctionTime(String ruleId) {
+    final rule = pilotFunctionTimeRules[ruleId];
+    if (rule == null) {
+      throw ArgumentError.value(
+        ruleId,
+        'ruleId',
+        'no pilot-function-time primitive is registered under this id',
+      );
+    }
+    return rule;
+  }
+
+  /// As [pilotFunctionTime], for a profile's `night_rule` key.
+  NightTimeRule nightTime(String ruleId) {
+    final rule = nightTimeRules[ruleId];
+    if (rule == null) {
+      throw ArgumentError.value(
+        ruleId,
+        'ruleId',
+        'no night-time primitive is registered under this id',
+      );
+    }
+    return rule;
+  }
+}

--- a/lib/domain/projection/jurisdiction_projection.dart
+++ b/lib/domain/projection/jurisdiction_projection.dart
@@ -1,8 +1,10 @@
+import '../jurisdiction/jurisdiction_profile.dart';
 import '../jurisdiction/jurisdiction_registry.dart';
+import '../model/aerodrome_directory.dart';
 import '../model/aircraft.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
-import '../primitives/pilot_function_time.dart';
+import '../primitives/primitive_registry.dart';
 import 'derived_quantity.dart';
 import 'projection.dart';
 import 'projection_result.dart';
@@ -21,36 +23,58 @@ class JurisdictionProjection implements Projection {
   JurisdictionProjection({
     required this.registry,
     required this.primitives,
+    required this.aerodromes,
     required this.jurisdictionId,
   });
 
   final JurisdictionRegistry registry;
   final PrimitiveRegistry primitives;
+  final AerodromeDirectory aerodromes;
   final String jurisdictionId;
 
   @override
   ProjectionResult project(Flight flight, Aircraft aircraft) {
     final profile = registry.resolve(jurisdictionId);
+    final quantities = <String, DerivedQuantity>{
+      ..._pilotFunctionTime(profile, flight),
+      ..._nightTime(profile, flight),
+    };
+    return ProjectionResult(
+      jurisdictionId: jurisdictionId,
+      quantities: quantities,
+    );
+  }
+
+  /// `pic_rule` quantities, or nothing if the profile hasn't set one yet —
+  /// not an error. #23-26 will add cross-country/instrument rule keys the
+  /// same way; a profile with none of them set yet is incomplete, not
+  /// broken.
+  Map<String, DerivedQuantity> _pilotFunctionTime(
+    ResolvedJurisdictionProfile profile,
+    Flight flight,
+  ) {
     final ruleId = profile['pic_rule'];
     if (ruleId == null) {
-      // No pilot-function-time rule configured for this jurisdiction yet —
-      // an empty result, not an error. #20-26 will add night/cross-country/
-      // instrument rule keys the same way; a profile with none of them set
-      // yet is incomplete, not broken.
-      return ProjectionResult(
-        jurisdictionId: jurisdictionId,
-        quantities: const {},
-      );
+      return const {};
     }
-
     final rule = primitives.pilotFunctionTime(ruleId);
     final blockTime = FlightDuration(
       flight.onBlocks.difference(flight.offBlocks).inMinutes,
     );
-    return ProjectionResult(
-      jurisdictionId: jurisdictionId,
-      quantities: rule(flight, blockTime),
-    );
+    return rule(flight, blockTime);
+  }
+
+  /// `night_rule` quantities, or nothing if the profile hasn't set one yet.
+  Map<String, DerivedQuantity> _nightTime(
+    ResolvedJurisdictionProfile profile,
+    Flight flight,
+  ) {
+    final ruleId = profile['night_rule'];
+    if (ruleId == null) {
+      return const {};
+    }
+    final rule = primitives.nightTime(ruleId);
+    return rule(flight, aerodromes);
   }
 
   @override

--- a/test/domain/model/geo_coordinate_test.dart
+++ b/test/domain/model/geo_coordinate_test.dart
@@ -93,4 +93,59 @@ void main() {
       expect(greatCircleDistanceNm(jfk, lhr), closeTo(2991, 20));
     });
   });
+
+  group('interpolateGreatCircle', () {
+    test('fraction 0 is the start point, fraction 1 is the end point', () {
+      final a = GeoCoordinate(latitude: 40.639801, longitude: -73.7789);
+      final b = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+
+      // closeTo, not exact equality: fraction 0/1 round-trips through
+      // radians and back, which is not bit-exact even though the formula
+      // is mathematically the identity at those endpoints.
+      expect(
+        interpolateGreatCircle(a, b, 0).latitude,
+        closeTo(a.latitude, 1e-9),
+      );
+      expect(
+        interpolateGreatCircle(a, b, 0).longitude,
+        closeTo(a.longitude, 1e-9),
+      );
+      expect(
+        interpolateGreatCircle(a, b, 1).latitude,
+        closeTo(b.latitude, 1e-9),
+      );
+      expect(
+        interpolateGreatCircle(a, b, 1).longitude,
+        closeTo(b.longitude, 1e-9),
+      );
+    });
+
+    test('the midpoint of a 90-degree equatorial arc is exactly halfway', () {
+      // Same pair used for the exact quarter-of-the-equator distance
+      // check above — the midpoint of an equatorial arc stays on the
+      // equator at the mean longitude, with no spherical correction
+      // needed, so this is an exact check rather than an estimate.
+      final a = GeoCoordinate(latitude: 0, longitude: 0);
+      final b = GeoCoordinate(latitude: 0, longitude: 90);
+      final midpoint = interpolateGreatCircle(a, b, 0.5);
+
+      expect(midpoint.latitude, closeTo(0, 1e-9));
+      expect(midpoint.longitude, closeTo(45, 1e-9));
+    });
+
+    test('a coincident start and end point never divides by zero', () {
+      final point = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      expect(interpolateGreatCircle(point, point, 0.5), point);
+    });
+
+    test('walking the whole path splits the total distance proportionally', () {
+      final jfk = GeoCoordinate(latitude: 40.639801, longitude: -73.7789);
+      final lhr = GeoCoordinate(latitude: 51.4706, longitude: -0.461941);
+      final total = greatCircleDistanceNm(jfk, lhr);
+      final quarter = interpolateGreatCircle(jfk, lhr, 0.25);
+
+      expect(greatCircleDistanceNm(jfk, quarter), closeTo(total * 0.25, 1));
+      expect(greatCircleDistanceNm(quarter, lhr), closeTo(total * 0.75, 1));
+    });
+  });
 }

--- a/test/domain/model/solar_position_test.dart
+++ b/test/domain/model/solar_position_test.dart
@@ -1,0 +1,215 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/solar_position.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Reference values are from the US Naval Observatory's Rise/Set/Transit/
+/// Twilight API (aa.usno.navy.mil/data/api#rstt), the authoritative source
+/// for these figures — printed to the minute, hence the one-minute
+/// tolerance below rather than anything tighter. A commercial calculator
+/// (sunrise-sunset.org) was checked first and agreed with USNO on civil
+/// twilight but was consistently about two minutes off USNO on sunrise/
+/// sunset specifically; USNO was used throughout once that discrepancy
+/// surfaced, rather than mixing sources.
+void _expectWithinAMinute(UtcInstant? actual, String referenceIso) {
+  expect(actual, isNotNull, reason: 'expected a crossing, got none');
+  final reference = UtcInstant.parse(referenceIso);
+  final delta = actual!.difference(reference).abs();
+  expect(
+    delta <= const Duration(minutes: 1),
+    isTrue,
+    reason: 'expected $actual within a minute of $reference, off by $delta',
+  );
+}
+
+void main() {
+  group('solarElevationDegrees', () {
+    test('the sun is high at local solar noon and low at local midnight', () {
+      final equator = GeoCoordinate(latitude: 0, longitude: 0);
+      final noon = UtcInstant.utc(2024, 3, 20, 12);
+      final midnight = UtcInstant.utc(2024, 3, 20, 0);
+
+      expect(solarElevationDegrees(noon, equator), greaterThan(80));
+      expect(solarElevationDegrees(midnight, equator), lessThan(-80));
+    });
+  });
+
+  group('isNight', () {
+    test('is false in the middle of the day', () {
+      final london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+      expect(isNight(UtcInstant.utc(2024, 6, 21, 12), london), isFalse);
+    });
+
+    test('is true well before morning civil twilight', () {
+      final london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+      // Civil twilight begins ~02:55Z on this date; well before that.
+      expect(isNight(UtcInstant.utc(2024, 6, 21, 0), london), isTrue);
+    });
+  });
+
+  group('solarThresholdCrossings — sunrise/sunset threshold', () {
+    test('London on the June 2024 solstice', () {
+      final london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 6, 21),
+        position: london,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(result.ascending, '2024-06-21T03:43:00Z');
+      _expectWithinAMinute(result.descending, '2024-06-21T20:22:00Z');
+    });
+
+    test('London on the December 2024 solstice', () {
+      final london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 12, 21),
+        position: london,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(result.ascending, '2024-12-21T08:04:00Z');
+      _expectWithinAMinute(result.descending, '2024-12-21T15:54:00Z');
+    });
+
+    test('the equator on the March 2024 equinox', () {
+      final equator = GeoCoordinate(latitude: 0, longitude: 0);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 3, 20),
+        position: equator,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(result.ascending, '2024-03-20T06:04:00Z');
+      _expectWithinAMinute(result.descending, '2024-03-20T18:11:00Z');
+    });
+
+    test('midnight sun above the Arctic Circle: never sets, never throws', () {
+      final tromso = GeoCoordinate(latitude: 69.6492, longitude: 18.9553);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 6, 21),
+        position: tromso,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.aboveAllDay);
+      expect(result.ascending, isNull);
+      expect(result.descending, isNull);
+    });
+
+    test('polar night above the Arctic Circle: never rises, never throws', () {
+      final tromso = GeoCoordinate(latitude: 69.6492, longitude: 18.9553);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 12, 21),
+        position: tromso,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.belowAllDay);
+      expect(result.ascending, isNull);
+      expect(result.descending, isNull);
+    });
+
+    test('the geographic North Pole never throws, in any season', () {
+      final pole = GeoCoordinate(latitude: 90, longitude: 0);
+
+      final juneResult = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 6, 21),
+        position: pole,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+      final decemberResult = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 12, 21),
+        position: pole,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+
+      expect(juneResult.state, SolarThresholdState.aboveAllDay);
+      expect(decemberResult.state, SolarThresholdState.belowAllDay);
+      expect(
+        solarElevationDegrees(UtcInstant.utc(2024, 6, 21), pole).isNaN,
+        isFalse,
+      );
+    });
+  });
+
+  group('solarThresholdCrossings — civil twilight threshold', () {
+    test('London on the June 2024 solstice', () {
+      final london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 6, 21),
+        position: london,
+        thresholdDegrees: civilTwilightThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(result.ascending, '2024-06-21T02:55:00Z');
+      _expectWithinAMinute(result.descending, '2024-06-21T21:09:00Z');
+    });
+
+    test('London on the December 2024 solstice', () {
+      final london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 12, 21),
+        position: london,
+        thresholdDegrees: civilTwilightThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(result.ascending, '2024-12-21T07:24:00Z');
+      _expectWithinAMinute(result.descending, '2024-12-21T16:34:00Z');
+    });
+
+    test('the equator on the March 2024 equinox', () {
+      final equator = GeoCoordinate(latitude: 0, longitude: 0);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 3, 20),
+        position: equator,
+        thresholdDegrees: civilTwilightThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(result.ascending, '2024-03-20T05:43:00Z');
+      _expectWithinAMinute(result.descending, '2024-03-20T18:31:00Z');
+    });
+
+    test('above the Arctic Circle in midsummer, civil twilight never ends '
+        'either — the sun sets but it never gets properly dark', () {
+      final tromso = GeoCoordinate(latitude: 69.6492, longitude: 18.9553);
+      final result = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 6, 21),
+        position: tromso,
+        thresholdDegrees: civilTwilightThresholdDegrees,
+      );
+
+      expect(result.state, SolarThresholdState.aboveAllDay);
+    });
+
+    test('above the Arctic Circle in midwinter, civil twilight still happens '
+        'for a few hours around midday even though the sun never rises — this '
+        'is exactly why sunrise/sunset and civil twilight are independent '
+        'thresholds, not one shared window', () {
+      final tromso = GeoCoordinate(latitude: 69.6492, longitude: 18.9553);
+      final sunriseSunset = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 12, 21),
+        position: tromso,
+        thresholdDegrees: sunriseSunsetThresholdDegrees,
+      );
+      final civilTwilight = solarThresholdCrossings(
+        onDate: UtcInstant.utc(2024, 12, 21),
+        position: tromso,
+        thresholdDegrees: civilTwilightThresholdDegrees,
+      );
+
+      expect(sunriseSunset.state, SolarThresholdState.belowAllDay);
+      expect(civilTwilight.state, SolarThresholdState.crosses);
+      _expectWithinAMinute(civilTwilight.ascending, '2024-12-21T08:32:00Z');
+      _expectWithinAMinute(civilTwilight.descending, '2024-12-21T12:53:00Z');
+    });
+  });
+}

--- a/test/domain/primitives/easa_night_time_test.dart
+++ b/test/domain/primitives/easa_night_time_test.dart
@@ -1,0 +1,214 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/easa_night_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// London, used throughout because `test/domain/model/solar_position_test.dart`
+/// already validates civil twilight for this exact position against the US
+/// Naval Observatory: 2024-06-21 02:55Z-21:09Z, 2024-12-21 07:24Z-16:34Z.
+final _london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+
+AerodromeDirectory _directoryWith(Map<String, GeoCoordinate> aerodromes) =>
+    AerodromeDirectory([
+      for (final entry in aerodromes.entries)
+        Aerodrome(icaoCode: entry.key, name: entry.key, position: entry.value),
+    ]);
+
+PilotCapacity _capacity() => const PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({
+  required List<String> route,
+  required UtcInstant offBlocks,
+  required UtcInstant onBlocks,
+  UtcInstant? takeoff,
+  UtcInstant? landing,
+}) => Flight(
+  aircraftRegistration: 'G-TEST',
+  route: route,
+  offBlocks: offBlocks,
+  onBlocks: onBlocks,
+  takeoff: takeoff,
+  landing: landing,
+  capacity: _capacity(),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  group(
+    'easaNightTime — a stationary flight (departs and lands at London)',
+    () {
+      final aerodromes = _directoryWith({'EGXX': _london});
+
+      test('wholly within daylight is zero night time', () {
+        final flight = _flight(
+          route: const ['EGXX', 'EGXX'],
+          offBlocks: UtcInstant.utc(2024, 6, 21, 10, 0),
+          onBlocks: UtcInstant.utc(2024, 6, 21, 11, 30),
+        );
+
+        final result = easaNightTime(flight, aerodromes);
+
+        expect(result['night']?.value, FlightDuration.zero);
+        expect(result['night']?.creditable, isTrue);
+      });
+
+      test('wholly within night is the full flight duration', () {
+        // Civil twilight ends 21:09Z and begins again 02:55Z on this date —
+        // 22:00Z to 23:00Z is well inside the fully-dark window.
+        final flight = _flight(
+          route: const ['EGXX', 'EGXX'],
+          offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+          onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+        );
+
+        final result = easaNightTime(flight, aerodromes);
+
+        expect(result['night']?.value, const FlightDuration(60));
+      });
+
+      test('a flight crossing evening civil twilight splits correctly', () {
+        // Civil twilight ends 16:34Z on the December solstice. A flight
+        // 16:00Z-17:00Z should show roughly the first 34 minutes as day and
+        // the last 26 as night.
+        final flight = _flight(
+          route: const ['EGXX', 'EGXX'],
+          offBlocks: UtcInstant.utc(2024, 12, 21, 16, 0),
+          onBlocks: UtcInstant.utc(2024, 12, 21, 17, 0),
+        );
+
+        final result = easaNightTime(flight, aerodromes);
+
+        expect(result['night']?.value, isNot(FlightDuration.zero));
+        expect(result['night']?.value, isNot(const FlightDuration(60)));
+        expect(
+          result['night']?.value.inMinutes,
+          closeTo(26, 2),
+          reason:
+              '60 minutes minus the ~34 minutes still before civil '
+              'twilight ends at 16:34Z',
+        );
+      });
+
+      test('a flight crossing morning civil twilight splits correctly', () {
+        // Civil twilight begins 07:24Z on the December solstice. A flight
+        // 07:00Z-08:00Z should show roughly the first 24 minutes as night and
+        // the last 36 as day.
+        final flight = _flight(
+          route: const ['EGXX', 'EGXX'],
+          offBlocks: UtcInstant.utc(2024, 12, 21, 7, 0),
+          onBlocks: UtcInstant.utc(2024, 12, 21, 8, 0),
+        );
+
+        final result = easaNightTime(flight, aerodromes);
+
+        expect(
+          result['night']?.value.inMinutes,
+          closeTo(24, 2),
+          reason: 'the ~24 minutes before civil twilight begins at 07:24Z',
+        );
+      });
+
+      test('uses takeoff/landing in preference to offBlocks/onBlocks', () {
+        // Block times span the whole dark period; airborne times are wholly
+        // inside the daylight that follows. Only the takeoff/landing window
+        // should be used for night, not the wider block window.
+        final flight = _flight(
+          route: const ['EGXX', 'EGXX'],
+          offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+          onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+          takeoff: UtcInstant.utc(2024, 6, 21, 22, 0),
+          landing: UtcInstant.utc(2024, 6, 21, 22, 0),
+        );
+
+        final result = easaNightTime(flight, aerodromes);
+
+        expect(
+          result['night']?.value,
+          FlightDuration.zero,
+          reason: 'a zero-length airborne window has no night time at all',
+        );
+      });
+    },
+  );
+
+  group('easaNightTime — position resolution', () {
+    test('an unresolvable route reports it rather than guessing', () {
+      final flight = _flight(
+        route: const ['ZZZZ', 'ZZZZ'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+      );
+
+      final result = easaNightTime(flight, _directoryWith(const {}));
+
+      expect(result['night']?.creditable, isFalse);
+      expect(result['night']?.explanation, contains('cannot be computed'));
+    });
+
+    test('one resolvable endpoint is used for the whole flight', () {
+      final aerodromes = _directoryWith({'EGXX': _london});
+      final flight = _flight(
+        route: const ['ZZZZ', 'EGXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 10, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 11, 0),
+      );
+
+      final result = easaNightTime(flight, aerodromes);
+
+      expect(result['night']?.creditable, isTrue);
+      expect(result['night']?.value, FlightDuration.zero);
+    });
+
+    test('position genuinely interpolates: a flight from an already-dark '
+        'position toward a still-light one is neither wholly day nor '
+        'wholly night', () {
+      // Same latitude and date as the validated London figures, but 30
+      // degrees of longitude either side — roughly two hours of local
+      // solar time earlier (east) and later (west) than London.
+      final east = GeoCoordinate(latitude: 51.5074, longitude: 30);
+      final west = GeoCoordinate(latitude: 51.5074, longitude: -30);
+      final aerodromes = _directoryWith({'EGEA': east, 'EGWE': west});
+
+      // London's own civil twilight ends 21:09Z on this date; departing
+      // from the east (already past its own, earlier twilight end) at
+      // 20:00Z and arriving in the west (not yet at its own, later
+      // twilight end) at 22:00Z should straddle the transition.
+      final flight = _flight(
+        route: const ['EGEA', 'EGWE'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 20, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+      );
+
+      final result = easaNightTime(flight, aerodromes);
+
+      expect(result['night']?.value, isNot(FlightDuration.zero));
+      expect(result['night']?.value, isNot(const FlightDuration(120)));
+    });
+  });
+}

--- a/test/domain/primitives/faa_night_time_test.dart
+++ b/test/domain/primitives/faa_night_time_test.dart
@@ -1,0 +1,150 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/faa_night_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// London, used throughout because `test/domain/model/solar_position_test.dart`
+/// already validates civil twilight for this exact position against the US
+/// Naval Observatory: 2024-06-21 02:55Z-21:09Z, 2024-12-21 07:24Z-16:34Z.
+final _london = GeoCoordinate(latitude: 51.5074, longitude: -0.1278);
+
+AerodromeDirectory _directoryWith(Map<String, GeoCoordinate> aerodromes) =>
+    AerodromeDirectory([
+      for (final entry in aerodromes.entries)
+        Aerodrome(icaoCode: entry.key, name: entry.key, position: entry.value),
+    ]);
+
+PilotCapacity _capacity() => const PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({
+  required List<String> route,
+  required UtcInstant offBlocks,
+  required UtcInstant onBlocks,
+  CircuitCounts landings = const CircuitCounts(dayFullStop: 1),
+}) => Flight(
+  aircraftRegistration: 'N12345',
+  route: route,
+  offBlocks: offBlocks,
+  onBlocks: onBlocks,
+  capacity: _capacity(),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: landings,
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  final aerodromes = _directoryWith({'KXXX': _london});
+
+  group('faaNightTime', () {
+    test('wholly within daylight is zero night flight time', () {
+      final flight = _flight(
+        route: const ['KXXX', 'KXXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 10, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 11, 30),
+      );
+
+      final result = faaNightTime(flight, aerodromes);
+
+      expect(result['nightFlightTime']?.value, FlightDuration.zero);
+      expect(result['nightFlightTime']?.creditable, isTrue);
+    });
+
+    test('wholly within night is the full flight duration', () {
+      final flight = _flight(
+        route: const ['KXXX', 'KXXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+      );
+
+      final result = faaNightTime(flight, aerodromes);
+
+      expect(result['nightFlightTime']?.value, const FlightDuration(60));
+    });
+
+    test('an unresolvable route reports it rather than guessing', () {
+      final flight = _flight(
+        route: const ['ZZZZ', 'ZZZZ'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+      );
+
+      final result = faaNightTime(flight, _directoryWith(const {}));
+
+      expect(result['nightFlightTime']?.creditable, isFalse);
+      expect(
+        result['nightFlightTime']?.explanation,
+        contains('cannot be computed'),
+      );
+    });
+  });
+
+  group('the two FAA night windows do not get conflated', () {
+    // docs/jurisdiction-matrix.md line 88: "A landing can be night-for-
+    // logging but not night-for-currency" — and the reverse. Flight.landings
+    // is a raw, pilot-entered fact (CLAUDE.md rule 2) that this primitive
+    // never reads or reconciles against its own computed nightFlightTime.
+
+    test('night landings recorded for currency, but zero computed night '
+        'flight time', () {
+      // The raw entry says a landing counted as night for the sunset+1h
+      // currency window even though the flight itself, by the twilight
+      // definition this primitive computes, never left daylight.
+      final flight = _flight(
+        route: const ['KXXX', 'KXXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 10, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 11, 0),
+        landings: const CircuitCounts(nightFullStop: 1),
+      );
+
+      final result = faaNightTime(flight, aerodromes);
+
+      expect(flight.landings.nightFullStop, 1);
+      expect(result['nightFlightTime']?.value, FlightDuration.zero);
+    });
+
+    test('positive computed night flight time, but the landing was recorded '
+        'as day for currency', () {
+      // The flight is wholly inside the twilight-defined night window, so
+      // nightFlightTime is the full duration — but the one landing was
+      // entered as a day landing (as it would be if it fell after
+      // twilight ended yet before the later sunset+1h currency window
+      // began).
+      final flight = _flight(
+        route: const ['KXXX', 'KXXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+        landings: const CircuitCounts(dayFullStop: 1),
+      );
+
+      final result = faaNightTime(flight, aerodromes);
+
+      expect(flight.landings.dayFullStop, 1);
+      expect(flight.landings.nightFullStop, 0);
+      expect(result['nightFlightTime']?.value, const FlightDuration(60));
+    });
+  });
+}

--- a/test/domain/projection/easa_projection_integration_test.dart
+++ b/test/domain/projection/easa_projection_integration_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
 import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
 import 'package:easa_digital_log/domain/model/aircraft.dart';
 import 'package:easa_digital_log/domain/model/flight.dart';
 import 'package:easa_digital_log/domain/model/flight_duration.dart';
@@ -46,6 +47,7 @@ void main() {
       final projection = JurisdictionProjection(
         registry: registry,
         primitives: defaultPrimitives,
+        aerodromes: AerodromeDirectory(const []),
         jurisdictionId: 'eu.easa.part-fcl',
       );
 
@@ -92,6 +94,7 @@ void main() {
     final projection = JurisdictionProjection(
       registry: registry,
       primitives: defaultPrimitives,
+      aerodromes: AerodromeDirectory(const []),
       jurisdictionId: 'eu.easa.part-fcl',
     );
 

--- a/test/domain/projection/faa_easa_divergence_projection_test.dart
+++ b/test/domain/projection/faa_easa_divergence_projection_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
 import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
 import 'package:easa_digital_log/domain/model/aircraft.dart';
 import 'package:easa_digital_log/domain/model/flight_duration.dart';
 import 'package:easa_digital_log/domain/primitives/default_primitives.dart';
@@ -46,12 +47,14 @@ void main() {
     final easa = JurisdictionProjection(
       registry: registry,
       primitives: defaultPrimitives,
+      aerodromes: AerodromeDirectory(const []),
       jurisdictionId: 'eu.easa.part-fcl',
     ).project(flight, aircraft);
 
     final faa = JurisdictionProjection(
       registry: registry,
       primitives: defaultPrimitives,
+      aerodromes: AerodromeDirectory(const []),
       jurisdictionId: 'us.faa.part61',
     ).project(flight, aircraft);
 

--- a/test/domain/projection/jurisdiction_projection_test.dart
+++ b/test/domain/projection/jurisdiction_projection_test.dart
@@ -2,15 +2,18 @@
 // Dart tests need no separate package:test dependency.
 import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
 import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
 import 'package:easa_digital_log/domain/model/aircraft.dart';
 import 'package:easa_digital_log/domain/model/flight.dart';
 import 'package:easa_digital_log/domain/model/flight_duration.dart';
 import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
 import 'package:easa_digital_log/domain/model/utc_instant.dart';
-import 'package:easa_digital_log/domain/primitives/pilot_function_time.dart';
+import 'package:easa_digital_log/domain/primitives/primitive_registry.dart';
 import 'package:easa_digital_log/domain/projection/derived_quantity.dart';
 import 'package:easa_digital_log/domain/projection/jurisdiction_projection.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+AerodromeDirectory _emptyAerodromes() => AerodromeDirectory(const []);
 
 /// A fake primitive, not EASA or FAA logic — #18/#19 own the real rules.
 /// This proves the engine (profile resolution -> primitive dispatch ->
@@ -23,6 +26,16 @@ Map<String, DerivedQuantity> _fakeRule(
   'pic': flight.capacity.commandAuthority
       ? DerivedQuantity.creditable(blockTime, 'fake: command authority held')
       : DerivedQuantity.zero('fake: no command authority'),
+};
+
+/// A fake night-time primitive, proving `pic_rule` and `night_rule`
+/// quantities merge into one [ProjectionResult] rather than one
+/// overwriting the other.
+Map<String, DerivedQuantity> _fakeNightRule(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+) => {
+  'night': DerivedQuantity.creditable(const FlightDuration(15), 'fake: night'),
 };
 
 Aircraft _aircraft() => const Aircraft(
@@ -75,10 +88,14 @@ void main() {
       ),
       const JurisdictionProfile(id: 'test.no-rules', rules: {}),
     ]);
-    final primitives = PrimitiveRegistry({'test.fake_rule': _fakeRule});
+    final primitives = PrimitiveRegistry(
+      pilotFunctionTimeRules: {'test.fake_rule': _fakeRule},
+      nightTimeRules: const {},
+    );
     projection = JurisdictionProjection(
       registry: registry,
       primitives: primitives,
+      aerodromes: _emptyAerodromes(),
       jurisdictionId: 'test.fake',
     );
   });
@@ -115,7 +132,11 @@ void main() {
         ]);
         final bare = JurisdictionProjection(
           registry: registry,
-          primitives: PrimitiveRegistry(const {}),
+          primitives: PrimitiveRegistry(
+            pilotFunctionTimeRules: const {},
+            nightTimeRules: const {},
+          ),
+          aerodromes: _emptyAerodromes(),
           jurisdictionId: 'test.no-rules',
         );
 
@@ -127,6 +148,33 @@ void main() {
       },
     );
 
+    test('pic_rule and night_rule quantities merge into one result, neither '
+        'overwriting the other', () {
+      final registry = JurisdictionRegistry([
+        const JurisdictionProfile(
+          id: 'test.both-rules',
+          rules: {
+            'pic_rule': 'test.fake_rule',
+            'night_rule': 'test.fake_night_rule',
+          },
+        ),
+      ]);
+      final both = JurisdictionProjection(
+        registry: registry,
+        primitives: PrimitiveRegistry(
+          pilotFunctionTimeRules: {'test.fake_rule': _fakeRule},
+          nightTimeRules: {'test.fake_night_rule': _fakeNightRule},
+        ),
+        aerodromes: _emptyAerodromes(),
+        jurisdictionId: 'test.both-rules',
+      );
+
+      final result = both.project(_flight(commandAuthority: true), _aircraft());
+
+      expect(result['pic']?.value, const FlightDuration(90));
+      expect(result['night']?.value, const FlightDuration(15));
+    });
+
     test('an unregistered primitive id throws ArgumentError', () {
       final registry = JurisdictionRegistry([
         const JurisdictionProfile(
@@ -136,7 +184,11 @@ void main() {
       ]);
       final broken = JurisdictionProjection(
         registry: registry,
-        primitives: PrimitiveRegistry(const {}),
+        primitives: PrimitiveRegistry(
+          pilotFunctionTimeRules: const {},
+          nightTimeRules: const {},
+        ),
+        aerodromes: _emptyAerodromes(),
         jurisdictionId: 'test.broken',
       );
 
@@ -176,7 +228,11 @@ void main() {
         ]);
         final pendingProjection = JurisdictionProjection(
           registry: registry,
-          primitives: PrimitiveRegistry({'test.pending_rule': pendingRule}),
+          primitives: PrimitiveRegistry(
+            pilotFunctionTimeRules: {'test.pending_rule': pendingRule},
+            nightTimeRules: const {},
+          ),
+          aerodromes: _emptyAerodromes(),
           jurisdictionId: 'test.pending',
         );
 


### PR DESCRIPTION
## Summary

Follows the same pattern as #109 (pilot function time): one shared engine, two jurisdiction-specific readers of it.

- **#20** — a pure-Dart civil twilight/sunrise/sunset calculator (`solar_position.dart`). Validated to the minute against the US Naval Observatory at three latitudes plus the Arctic Circle, where the sun can fail to rise or set at all — reported via `SolarThresholdState`, never thrown.
- **#21** — EASA night time (`FCL.010`). Position during the flight is approximated as a great-circle line between the first and last resolvable route waypoints, walked in step with elapsed time — decision and rejected alternatives recorded in ADR-0008.
- **#22** — FAA night time. Logging uses the same civil-twilight computation as EASA (factored into a shared `night_time_support.dart`). The separate `§61.57(b)` currency window is deliberately *not* recomputed here — `Flight.landings` already carries that split as a raw, pilot-entered fact, and this primitive never reconciles against it. Tests construct a flight both ways round to prove the two windows never get conflated.

`JurisdictionProjection` now merges `pic_rule` and `night_rule` quantities into one result instead of only ever reading `pic_rule`.

## Test plan

- [x] `flutter test` — 210 tests passing
- [x] `flutter analyze --fatal-infos` clean
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` clean
- [x] Solar engine validated to the minute against USNO (equator, London solstices, Arctic Circle polar day/night)
- [x] Mutation-tested the polar-condition and crossing-direction logic, and the EASA/FAA position-resolution and interpolation branches — each confirmed red before green