### PR TITLE
Cross-country time: EASA qualifying flight, FAA six credit tests (#23, #24)

### DIFF
--- a/assets/jurisdictions/eu.easa.part-fcl.yaml
+++ b/assets/jurisdictions/eu.easa.part-fcl.yaml
@@ -6,3 +6,4 @@ id: eu.easa.part-fcl
 
 pic_rule: easa.pilot_function_time
 night_rule: easa.night_time
+cross_country_rule: easa.cross_country_time

--- a/assets/jurisdictions/us.faa.part61.yaml
+++ b/assets/jurisdictions/us.faa.part61.yaml
@@ -6,3 +6,4 @@ id: us.faa.part61
 
 pic_rule: faa.pilot_function_time
 night_rule: faa.night_time
+cross_country_rule: faa.cross_country_time

--- a/lib/domain/model/aircraft.dart
+++ b/lib/domain/model/aircraft.dart
@@ -107,6 +107,12 @@ enum AircraftCategory {
 
   airship,
   balloon,
+
+  /// `§61.1(b)(3)(iv)`/`(vi)` name this category explicitly to carve it out
+  /// of the FAA's private/commercial and sport-pilot cross-country distance
+  /// tests and give it its own, shorter one — see `cross_country_time.dart`
+  /// (#24). No EASA analogue; Part-FCL has no powered-parachute category.
+  poweredParachute,
 }
 
 enum EngineType { none, piston, turboprop, turbojet, turbofan, electric }

--- a/lib/domain/model/flight.dart
+++ b/lib/domain/model/flight.dart
@@ -55,6 +55,23 @@ abstract class Flight with _$Flight {
     /// distance thresholds evaluated against the same route.
     required List<String> route,
 
+    /// Whether the flight was flown to a destination away from departure
+    /// following a pre-planned route, using standard navigation procedures
+    /// (dead reckoning, pilotage, or a nav aid) — `FCL.010`'s cross-country
+    /// definition verbatim. This is *not* implied by [route]: `FCL.010`
+    /// does not require the flight to land anywhere other than where it
+    /// departed, so a solo navigation exercise that departs, flies a
+    /// planned route out to a distant point, and returns to land back at
+    /// the same aerodrome is cross-country under EASA even though [route]
+    /// alone (departure, stops, destination — nowhere landed at but
+    /// departure) is indistinguishable from a simple local flight.
+    /// Unbackfillable: nobody can reconstruct in five years whether a
+    /// given circuit-pattern-looking flight was actually flown as a
+    /// planned navigation exercise. The FAA has no equivalent concept —
+    /// `§61.1(b)(3)(i)` explicitly requires a landing away from departure,
+    /// so `faa_cross_country_time.dart` never reads this field.
+    required bool prePlannedNavigation,
+
     // ---- Times. All UTC — rule 3, ADR-0002.
     /// `AMC1 FCL.050(g)(1)`: first movement for the purpose of taking off.
     /// `§1.1`: movement under its own power for the purpose of flight. The

--- a/lib/domain/primitives/cross_country_support.dart
+++ b/lib/domain/primitives/cross_country_support.dart
@@ -1,0 +1,121 @@
+import '../model/aerodrome_directory.dart';
+import '../model/flight.dart';
+import '../model/geo_coordinate.dart';
+
+/// Shared by the EASA (#23) and FAA (#24) cross-country primitives.
+///
+/// [Flight.route] is "departure, any intermediate stops, and destination, in
+/// order" (`flight.dart`) — every entry after the first is treated as a
+/// place the aircraft landed, since that is the only reading consistent
+/// with `Flight` recording no per-waypoint landing type and
+/// `CircuitCounts` recording only flight-level touch-and-go/full-stop
+/// totals, not which waypoint each landing was at. A route entry that was
+/// only overflown, never landed at, should not appear in [Flight.route] at
+/// all — see `docs/entry-form.md`.
+
+/// Whether [flight] included a landing at any point other than its
+/// departure aerodrome — the fact both `FCL.010` and `§61.1(b)(3)(i)`
+/// require for a flight to be cross-country at all, independent of
+/// distance. Pure string comparison (case-insensitive) against
+/// [Flight.route]; needs no [AerodromeDirectory] and cannot be defeated by
+/// an unresolvable waypoint.
+bool landedAwayFromDeparture(Flight flight) {
+  if (flight.route.length < 2) {
+    return false;
+  }
+  final departure = flight.route.first.toUpperCase();
+  return flight.route.skip(1).any((leg) => leg.toUpperCase() != departure);
+}
+
+/// The distinct waypoint identifiers in [flight]'s route other than the
+/// departure, case-insensitively de-duplicated. Used for EASA's qualifying
+/// cross-country flight, which counts *aerodromes visited*, not landings —
+/// a there-and-back-and-back-again route only counts each other aerodrome
+/// once.
+Set<String> aerodromesVisitedOtherThanDeparture(Flight flight) {
+  if (flight.route.isEmpty) {
+    return const {};
+  }
+  final departure = flight.route.first.toUpperCase();
+  return flight.route
+      .skip(1)
+      .map((leg) => leg.toUpperCase())
+      .where((leg) => leg != departure)
+      .toSet();
+}
+
+/// Total distance flown along [flight]'s route, in nautical miles — the sum
+/// of each consecutive leg, not a single point-to-point figure. This is
+/// what EASA's qualifying cross-country flight (FCL.210.A) measures: "at
+/// least 270 km (150 NM)" is the length of the route flown, not how far the
+/// furthest point was from departure.
+///
+/// `null` if fewer than two consecutive waypoints resolve to a position —
+/// there is then no leg to measure at all, not merely an imprecise one.
+double? totalRouteDistanceNm(Flight flight, AerodromeDirectory aerodromes) {
+  final positions = _resolvedPositionsInOrder(flight, aerodromes);
+  if (positions.length < 2) {
+    return null;
+  }
+
+  var total = 0.0;
+  for (var i = 1; i < positions.length; i++) {
+    total += greatCircleDistanceNm(positions[i - 1], positions[i]);
+  }
+  return total;
+}
+
+/// The greatest straight-line distance, in nautical miles, from [flight]'s
+/// departure to any other resolvable waypoint it landed at — the metric
+/// every FAA `§61.1(b)(3)(ii)`-`(vii)` credit test uses ("more than *N*
+/// nautical miles from the point of departure"). Deliberately not the
+/// destination's distance and not a sum of legs: a flight that ranges 60 nm
+/// out and returns to land back at departure went further than 50 nm from
+/// departure even though the final leg's distance is zero, and a multi-leg
+/// flight where every individual leg stays under a threshold can still put
+/// a landing point beyond it overall.
+///
+/// `null` if the departure does not resolve, or no other waypoint does —
+/// there is then nothing to measure a distance to.
+double? furthestLandingDistanceFromDepartureNm(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+) {
+  final departureIdentifier = flight.route.isEmpty ? null : flight.route.first;
+  final departure = departureIdentifier == null
+      ? null
+      : aerodromes.byIcao(departureIdentifier)?.position;
+  if (departure == null) {
+    return null;
+  }
+
+  double? furthest;
+  for (final identifier in flight.route.skip(1)) {
+    final position = aerodromes.byIcao(identifier)?.position;
+    if (position == null) {
+      continue;
+    }
+    final distance = greatCircleDistanceNm(departure, position);
+    if (furthest == null || distance > furthest) {
+      furthest = distance;
+    }
+  }
+  return furthest;
+}
+
+/// [flight]'s route, resolved to positions in order, skipping any waypoint
+/// that doesn't resolve — used by [totalRouteDistanceNm], where a leg can
+/// only be measured between two resolved points.
+List<GeoCoordinate> _resolvedPositionsInOrder(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+) {
+  final positions = <GeoCoordinate>[];
+  for (final identifier in flight.route) {
+    final position = aerodromes.byIcao(identifier)?.position;
+    if (position != null) {
+      positions.add(position);
+    }
+  }
+  return positions;
+}

--- a/lib/domain/primitives/cross_country_time.dart
+++ b/lib/domain/primitives/cross_country_time.dart
@@ -1,0 +1,21 @@
+import '../model/aerodrome_directory.dart';
+import '../model/aircraft.dart';
+import '../model/flight.dart';
+import '../projection/derived_quantity.dart';
+
+/// A named, jurisdiction-specific rule computing the cross-country
+/// quantities for one flight.
+///
+/// Takes [Aircraft], unlike [PilotFunctionTimeRule] and [NightTimeRule],
+/// because the FAA's credit tests gate on aircraft category — rotorcraft
+/// and powered-parachute each get their own distance threshold
+/// (`§61.1(b)(3)(iv)`-`(v)`) instead of the general one. EASA's rule
+/// ignores the parameter; the shared shape lets both register under the
+/// same [PrimitiveRegistry] map rather than needing two typedefs for what
+/// is, from the engine's point of view, one rule kind.
+typedef CrossCountryRule =
+    Map<String, DerivedQuantity> Function(
+      Flight flight,
+      Aircraft aircraft,
+      AerodromeDirectory aerodromes,
+    );

--- a/lib/domain/primitives/default_primitives.dart
+++ b/lib/domain/primitives/default_primitives.dart
@@ -1,3 +1,4 @@
+import 'easa_cross_country_time.dart';
 import 'easa_night_time.dart';
 import 'easa_pilot_function_time.dart';
 import 'faa_night_time.dart';
@@ -8,8 +9,8 @@ import 'primitive_registry.dart';
 /// `assets/jurisdictions/*.yaml` profile can reference, wired to its real
 /// implementation.
 ///
-/// Grows by one line per primitive as later issues (#23-26:
-/// cross-country/instrument) land — never by a change to
+/// Grows by one line per primitive as later issues (#25-26:
+/// instrument/multi-pilot time) land — never by a change to
 /// [JurisdictionProjection], which only ever sees this through the
 /// [PrimitiveRegistry] interface.
 final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry(
@@ -21,4 +22,5 @@ final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry(
     'easa.night_time': easaNightTime,
     'faa.night_time': faaNightTime,
   },
+  crossCountryRules: {'easa.cross_country_time': easaCrossCountryTime},
 );

--- a/lib/domain/primitives/default_primitives.dart
+++ b/lib/domain/primitives/default_primitives.dart
@@ -1,6 +1,7 @@
 import 'easa_cross_country_time.dart';
 import 'easa_night_time.dart';
 import 'easa_pilot_function_time.dart';
+import 'faa_cross_country_time.dart';
 import 'faa_night_time.dart';
 import 'faa_pilot_function_time.dart';
 import 'primitive_registry.dart';
@@ -22,5 +23,8 @@ final PrimitiveRegistry defaultPrimitives = PrimitiveRegistry(
     'easa.night_time': easaNightTime,
     'faa.night_time': faaNightTime,
   },
-  crossCountryRules: {'easa.cross_country_time': easaCrossCountryTime},
+  crossCountryRules: {
+    'easa.cross_country_time': easaCrossCountryTime,
+    'faa.cross_country_time': faaCrossCountryTime,
+  },
 );

--- a/lib/domain/primitives/easa_cross_country_time.dart
+++ b/lib/domain/primitives/easa_cross_country_time.dart
@@ -12,6 +12,13 @@ import 'cross_country_support.dart';
 /// a pre-planned route, using standard navigation procedures. This gives
 /// exactly one general quantity, `crossCountry`.
 ///
+/// The definition does not require the destination to differ from the
+/// departure — a solo navigation exercise that departs, flies a planned
+/// route out to a distant point, and lands back where it started is still
+/// cross-country. [Flight.route] alone can't express that (it records only
+/// where the aircraft landed), so this reads [Flight.prePlannedNavigation]
+/// as well as [landedAwayFromDeparture] — either one is sufficient.
+///
 /// [aircraft] is part of this primitive's signature ([CrossCountryRule])
 /// but is not read — EASA's cross-country definition and its one qualifying
 /// flight do not gate on aircraft category the way the FAA's do (#24).
@@ -43,16 +50,24 @@ Map<String, DerivedQuantity> easaCrossCountryTime(
 }
 
 DerivedQuantity _generalCrossCountry(Flight flight, FlightDuration blockTime) {
-  if (!landedAwayFromDeparture(flight)) {
-    return DerivedQuantity.zero(
-      "FCL.010 'cross-country': no landing away from the departure "
-      'aerodrome',
+  if (flight.prePlannedNavigation) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      "FCL.010 'cross-country': flown to a destination away from the "
+      'departure aerodrome by a pre-planned route, using standard '
+      'navigation procedures',
     );
   }
-  return DerivedQuantity.creditable(
-    blockTime,
-    "FCL.010 'cross-country': navigated to a destination away from the "
-    'departure aerodrome by a pre-planned route',
+  if (landedAwayFromDeparture(flight)) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      "FCL.010 'cross-country': included a landing away from the "
+      'departure aerodrome',
+    );
+  }
+  return DerivedQuantity.zero(
+    "FCL.010 'cross-country': no landing away from the departure "
+    'aerodrome, and not recorded as a planned navigation exercise',
   );
 }
 

--- a/lib/domain/primitives/easa_cross_country_time.dart
+++ b/lib/domain/primitives/easa_cross_country_time.dart
@@ -1,0 +1,96 @@
+import '../model/aerodrome_directory.dart';
+import '../model/aircraft.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../projection/derived_quantity.dart';
+import 'cross_country_support.dart';
+
+/// EASA `cross_country_rule` primitive.
+///
+/// `FCL.010` defines cross-country with no minimum distance: flight time
+/// navigating to a destination away from the departure aerodrome, following
+/// a pre-planned route, using standard navigation procedures. This gives
+/// exactly one general quantity, `crossCountry`.
+///
+/// [aircraft] is part of this primitive's signature ([CrossCountryRule])
+/// but is not read — EASA's cross-country definition and its one qualifying
+/// flight do not gate on aircraft category the way the FAA's do (#24).
+///
+/// A second, distinct quantity, `qualifyingCrossCountry`, answers the
+/// licence-issue question `FCL.210.A`/`AMC1 FCL.210` asks: a route of at
+/// least 270 km (150 NM), with full-stop landings at two aerodromes other
+/// than the departure. This is a stricter, additional condition layered on
+/// top of the general definition, not a replacement for it — a flight can
+/// be `crossCountry` without being `qualifyingCrossCountry`, but not the
+/// reverse.
+Map<String, DerivedQuantity> easaCrossCountryTime(
+  Flight flight,
+  Aircraft aircraft,
+  AerodromeDirectory aerodromes,
+) {
+  final blockTime = FlightDuration(
+    flight.onBlocks.difference(flight.offBlocks).inMinutes,
+  );
+
+  return {
+    'crossCountry': _generalCrossCountry(flight, blockTime),
+    'qualifyingCrossCountry': _qualifyingCrossCountry(
+      flight,
+      aerodromes,
+      blockTime,
+    ),
+  };
+}
+
+DerivedQuantity _generalCrossCountry(Flight flight, FlightDuration blockTime) {
+  if (!landedAwayFromDeparture(flight)) {
+    return DerivedQuantity.zero(
+      "FCL.010 'cross-country': no landing away from the departure "
+      'aerodrome',
+    );
+  }
+  return DerivedQuantity.creditable(
+    blockTime,
+    "FCL.010 'cross-country': navigated to a destination away from the "
+    'departure aerodrome by a pre-planned route',
+  );
+}
+
+DerivedQuantity _qualifyingCrossCountry(
+  Flight flight,
+  AerodromeDirectory aerodromes,
+  FlightDuration blockTime,
+) {
+  final otherAerodromes = aerodromesVisitedOtherThanDeparture(flight);
+  final totalDistanceNm = totalRouteDistanceNm(flight, aerodromes);
+
+  if (totalDistanceNm == null) {
+    return DerivedQuantity.notCreditable(
+      FlightDuration.zero,
+      "AMC1 FCL.210 qualifying cross-country flight: the route's distance "
+      'could not be computed — fewer than two waypoints resolved to a '
+      'position',
+    );
+  }
+
+  final distanceQualifies = totalDistanceNm >= 150;
+  final aerodromeCountQualifies = otherAerodromes.length >= 2;
+
+  if (distanceQualifies && aerodromeCountQualifies) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      'AMC1 FCL.210 qualifying cross-country flight: '
+      '${totalDistanceNm.toStringAsFixed(1)} NM total, full-stop landings '
+      'at ${otherAerodromes.length} aerodromes other than departure — '
+      'requires at least 150 NM (270 km) and two',
+    );
+  }
+
+  return DerivedQuantity.zero(
+    'AMC1 FCL.210 qualifying cross-country flight: '
+    '${totalDistanceNm.toStringAsFixed(1)} NM total '
+    '(needs at least 150 NM / 270 km), landings at '
+    '${otherAerodromes.length} aerodrome(s) other than departure '
+    '(needs at least 2) — does not qualify',
+  );
+}

--- a/lib/domain/primitives/faa_cross_country_time.dart
+++ b/lib/domain/primitives/faa_cross_country_time.dart
@@ -1,0 +1,172 @@
+import '../model/aerodrome_directory.dart';
+import '../model/aircraft.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../projection/derived_quantity.dart';
+import 'cross_country_support.dart';
+
+/// FAA `cross_country_rule` primitive. `§61.1(b)(3)` is seven
+/// sub-paragraphs, not one threshold — see
+/// `docs/jurisdiction-matrix.md` §"Cross-country, expanded". (i) is the
+/// general logging definition, no minimum distance; (ii)-(vii) are
+/// purpose-specific *credit* tests at 50, 25 or 15 nm depending on the
+/// certificate/rating being credited and, for two of them, on
+/// [Aircraft.category].
+///
+/// Every sub-test is computed for every flight, independently — a flight
+/// can pass one and fail another, and this primitive has no notion of which
+/// certificate the pilot actually holds (that is a later, M2+ concern), so
+/// it answers all six "would this count toward..." questions at once rather
+/// than picking one.
+///
+/// Distance is [furthestLandingDistanceFromDepartureNm]: the greatest
+/// straight-line distance from the *original* departure to any landing
+/// point, not a leg-by-leg or final-destination figure — #24's explicit
+/// acceptance criterion, since a flight that ranges out and returns to
+/// land back at departure went that far from departure regardless of where
+/// it ended up.
+Map<String, DerivedQuantity> faaCrossCountryTime(
+  Flight flight,
+  Aircraft aircraft,
+  AerodromeDirectory aerodromes,
+) {
+  final blockTime = FlightDuration(
+    flight.onBlocks.difference(flight.offBlocks).inMinutes,
+  );
+  final generalCrossCountry = landedAwayFromDeparture(flight);
+  final furthestNm = furthestLandingDistanceFromDepartureNm(flight, aerodromes);
+  final isRotorcraft = aircraft.category == AircraftCategory.helicopter;
+  final isPoweredParachute =
+      aircraft.category == AircraftCategory.poweredParachute;
+
+  return {
+    'crossCountry': _general(generalCrossCountry, blockTime),
+    'crossCountryPrivateCommercialInstrument': _creditTest(
+      citation:
+          "§61.1(b)(3)(ii) private/commercial/instrument rating/"
+          'recreational (except rotorcraft, except powered-parachute)',
+      applies: !isPoweredParachute,
+      exclusionReason:
+          'aircraft category is powered parachute — see '
+          'crossCountryPoweredParachute instead',
+      generalCrossCountry: generalCrossCountry,
+      furthestNm: furthestNm,
+      thresholdNm: 50,
+      blockTime: blockTime,
+    ),
+    'crossCountrySportPilot': _creditTest(
+      citation: '§61.1(b)(3)(iii) sport pilot (except powered-parachute)',
+      applies: !isPoweredParachute,
+      exclusionReason:
+          'aircraft category is powered parachute — see '
+          'crossCountryPoweredParachute instead',
+      generalCrossCountry: generalCrossCountry,
+      furthestNm: furthestNm,
+      thresholdNm: 25,
+      blockTime: blockTime,
+    ),
+    'crossCountryPoweredParachute': _creditTest(
+      citation:
+          '§61.1(b)(3)(iv) sport pilot with powered-parachute '
+          'privileges, or private pilot with powered-parachute category '
+          'rating',
+      applies: isPoweredParachute,
+      exclusionReason: 'aircraft category is not powered parachute',
+      generalCrossCountry: generalCrossCountry,
+      furthestNm: furthestNm,
+      thresholdNm: 15,
+      blockTime: blockTime,
+    ),
+    'crossCountryRotorcraft': _creditTest(
+      citation:
+          '§61.1(b)(3)(v) rotorcraft category rating, instrument-'
+          'helicopter rating, or recreational privileges in a rotorcraft',
+      applies: isRotorcraft,
+      exclusionReason: 'aircraft category is not rotorcraft',
+      generalCrossCountry: generalCrossCountry,
+      furthestNm: furthestNm,
+      thresholdNm: 25,
+      blockTime: blockTime,
+    ),
+    'crossCountryAirlineTransportPilot': _creditTest(
+      citation:
+          '§61.1(b)(3)(vi) airline transport pilot (except '
+          'rotorcraft)',
+      applies: !isRotorcraft,
+      exclusionReason: 'aircraft category is rotorcraft',
+      generalCrossCountry: generalCrossCountry,
+      furthestNm: furthestNm,
+      thresholdNm: 50,
+      blockTime: blockTime,
+    ),
+    'crossCountryMilitary': _creditTest(
+      citation:
+          '§61.1(b)(3)(vii) military pilot qualifying for a '
+          'commercial certificate under §61.73 (except rotorcraft)',
+      applies: !isRotorcraft,
+      exclusionReason: 'aircraft category is rotorcraft',
+      generalCrossCountry: generalCrossCountry,
+      furthestNm: furthestNm,
+      thresholdNm: 50,
+      blockTime: blockTime,
+    ),
+  };
+}
+
+DerivedQuantity _general(bool generalCrossCountry, FlightDuration blockTime) {
+  if (!generalCrossCountry) {
+    return DerivedQuantity.zero(
+      "§61.1(b)(3)(i) 'cross-country time': no landing at a point other "
+      'than the point of departure',
+    );
+  }
+  return DerivedQuantity.creditable(
+    blockTime,
+    "§61.1(b)(3)(i) 'cross-country time': included a landing at a point "
+    'other than the point of departure, navigated to by dead reckoning, '
+    'pilotage, or a navigation system',
+  );
+}
+
+/// One of the six purpose-specific credit tests, (ii)-(vii). Each requires,
+/// in order: [applies] (the aircraft category this test is written for),
+/// [generalCrossCountry] (the flight is cross-country at all, per (i) —
+/// every sub-test presupposes this), and finally [furthestNm] exceeding
+/// [thresholdNm].
+DerivedQuantity _creditTest({
+  required String citation,
+  required bool applies,
+  required String exclusionReason,
+  required bool generalCrossCountry,
+  required double? furthestNm,
+  required double thresholdNm,
+  required FlightDuration blockTime,
+}) {
+  if (!applies) {
+    return DerivedQuantity.zero('$citation: does not apply — $exclusionReason');
+  }
+  if (!generalCrossCountry) {
+    return DerivedQuantity.zero(
+      '$citation: no landing away from the point of departure, so this is '
+      'not cross-country time at all',
+    );
+  }
+  if (furthestNm == null) {
+    return DerivedQuantity.notCreditable(
+      FlightDuration.zero,
+      '$citation: distance from the point of departure could not be '
+      'computed — no other waypoint resolved to a position',
+    );
+  }
+  if (furthestNm > thresholdNm) {
+    return DerivedQuantity.creditable(
+      blockTime,
+      '$citation: furthest landing ${furthestNm.toStringAsFixed(1)} NM '
+      'from the point of departure, more than $thresholdNm NM required',
+    );
+  }
+  return DerivedQuantity.zero(
+    '$citation: furthest landing ${furthestNm.toStringAsFixed(1)} NM from '
+    'the point of departure, needs more than $thresholdNm NM',
+  );
+}

--- a/lib/domain/primitives/primitive_registry.dart
+++ b/lib/domain/primitives/primitive_registry.dart
@@ -1,3 +1,4 @@
+import 'cross_country_time.dart';
 import 'night_time.dart';
 import 'pilot_function_time.dart';
 
@@ -10,20 +11,22 @@ import 'pilot_function_time.dart';
 /// this whole abstraction is that adding a new authority needs a YAML
 /// profile and at most one new primitive per rule kind, never a change here.
 ///
-/// One map per rule *kind*, not one flat map keyed only by id: `pic_rule`
-/// and `night_rule` are different function shapes
-/// ([PilotFunctionTimeRule] vs. [NightTimeRule]), and a single `Map<String,
-/// Object>` would push the cast back onto every caller. Grows by one map and
-/// one lookup method per rule kind as #23-26 (cross-country, instrument)
-/// land.
+/// One map per rule *kind*, not one flat map keyed only by id: `pic_rule`,
+/// `night_rule` and `cross_country_rule` are different function shapes
+/// ([PilotFunctionTimeRule], [NightTimeRule], [CrossCountryRule]), and a
+/// single `Map<String, Object>` would push the cast back onto every caller.
+/// Grows by one map and one lookup method per rule kind as #25-26
+/// (instrument, multi-pilot time) land.
 class PrimitiveRegistry {
   const PrimitiveRegistry({
     required this.pilotFunctionTimeRules,
     required this.nightTimeRules,
+    required this.crossCountryRules,
   });
 
   final Map<String, PilotFunctionTimeRule> pilotFunctionTimeRules;
   final Map<String, NightTimeRule> nightTimeRules;
+  final Map<String, CrossCountryRule> crossCountryRules;
 
   /// Throws [ArgumentError] naming [ruleId] if nothing is registered under
   /// it — a profile referencing a primitive that was never wired up is a
@@ -49,6 +52,19 @@ class PrimitiveRegistry {
         ruleId,
         'ruleId',
         'no night-time primitive is registered under this id',
+      );
+    }
+    return rule;
+  }
+
+  /// As [pilotFunctionTime], for a profile's `cross_country_rule` key.
+  CrossCountryRule crossCountry(String ruleId) {
+    final rule = crossCountryRules[ruleId];
+    if (rule == null) {
+      throw ArgumentError.value(
+        ruleId,
+        'ruleId',
+        'no cross-country primitive is registered under this id',
       );
     }
     return rule;

--- a/lib/domain/projection/jurisdiction_projection.dart
+++ b/lib/domain/projection/jurisdiction_projection.dart
@@ -38,6 +38,7 @@ class JurisdictionProjection implements Projection {
     final quantities = <String, DerivedQuantity>{
       ..._pilotFunctionTime(profile, flight),
       ..._nightTime(profile, flight),
+      ..._crossCountry(profile, flight, aircraft),
     };
     return ProjectionResult(
       jurisdictionId: jurisdictionId,
@@ -46,7 +47,7 @@ class JurisdictionProjection implements Projection {
   }
 
   /// `pic_rule` quantities, or nothing if the profile hasn't set one yet —
-  /// not an error. #23-26 will add cross-country/instrument rule keys the
+  /// not an error. #25-26 will add instrument/multi-pilot rule keys the
   /// same way; a profile with none of them set yet is incomplete, not
   /// broken.
   Map<String, DerivedQuantity> _pilotFunctionTime(
@@ -75,6 +76,21 @@ class JurisdictionProjection implements Projection {
     }
     final rule = primitives.nightTime(ruleId);
     return rule(flight, aerodromes);
+  }
+
+  /// `cross_country_rule` quantities, or nothing if the profile hasn't set
+  /// one yet.
+  Map<String, DerivedQuantity> _crossCountry(
+    ResolvedJurisdictionProfile profile,
+    Flight flight,
+    Aircraft aircraft,
+  ) {
+    final ruleId = profile['cross_country_rule'];
+    if (ruleId == null) {
+      return const {};
+    }
+    final rule = primitives.crossCountry(ruleId);
+    return rule(flight, aircraft, aerodromes);
   }
 
   @override

--- a/test/domain/model/flight_test.dart
+++ b/test/domain/model/flight_test.dart
@@ -61,6 +61,7 @@ void main() {
       final flight = Flight(
         aircraftRegistration: 'G-ABCD',
         route: const ['EGKA', 'EGHR', 'EGKA'],
+        prePlannedNavigation: false,
         offBlocks: UtcInstant.utc(2026, 3, 14, 9, 5),
         onBlocks: UtcInstant.utc(2026, 3, 14, 10, 51),
         capacity: const PilotCapacity(

--- a/test/domain/primitives/cross_country_support_test.dart
+++ b/test/domain/primitives/cross_country_support_test.dart
@@ -28,6 +28,7 @@ AerodromeDirectory _aerodromes = AerodromeDirectory([
 Flight _flight(List<String> route) => Flight(
   aircraftRegistration: 'G-TEST',
   route: route,
+  prePlannedNavigation: false,
   offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
   onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
   capacity: const PilotCapacity(

--- a/test/domain/primitives/cross_country_support_test.dart
+++ b/test/domain/primitives/cross_country_support_test.dart
@@ -1,0 +1,142 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/cross_country_support.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Equatorial points, so `greatCircleDistanceNm` reduces to `60.04 nm` per
+/// degree of longitude with no approximation — the same exact-distance
+/// trick `geo_coordinate_test.dart` uses for its own quarter-of-the-equator
+/// case, reused here so every distance in this file is a known, round
+/// figure rather than an estimate.
+GeoCoordinate _eq(double lonDegrees) =>
+    GeoCoordinate(latitude: 0, longitude: lonDegrees);
+
+AerodromeDirectory _aerodromes = AerodromeDirectory([
+  Aerodrome(icaoCode: 'DEP', name: 'Departure', position: _eq(0)),
+  Aerodrome(icaoCode: 'A60', name: 'A, 60nm out', position: _eq(1)),
+  Aerodrome(icaoCode: 'B60', name: 'B, 60nm the other way', position: _eq(-1)),
+  Aerodrome(icaoCode: 'F120', name: 'Far, 120nm out', position: _eq(2)),
+]);
+
+Flight _flight(List<String> route) => Flight(
+  aircraftRegistration: 'G-TEST',
+  route: route,
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
+  capacity: const PilotCapacity(
+    commandAuthority: true,
+    soleManipulator: true,
+    soleOccupant: true,
+    multiPilotOperation: false,
+    additionalCrewRequiredByRule: false,
+    actingAsInstructor: false,
+    actingAsExaminer: false,
+    picusClaimed: false,
+    picInterventionNotRequired: false,
+  ),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  group('landedAwayFromDeparture', () {
+    test('false for a local out-and-back to the same aerodrome', () {
+      expect(landedAwayFromDeparture(_flight(const ['DEP', 'DEP'])), isFalse);
+    });
+
+    test('true when any later waypoint differs from the departure', () {
+      expect(landedAwayFromDeparture(_flight(const ['DEP', 'A60'])), isTrue);
+    });
+
+    test('is case-insensitive', () {
+      expect(landedAwayFromDeparture(_flight(const ['dep', 'DEP'])), isFalse);
+    });
+
+    test('false for a route with no second waypoint at all', () {
+      expect(landedAwayFromDeparture(_flight(const ['DEP'])), isFalse);
+    });
+  });
+
+  group('aerodromesVisitedOtherThanDeparture', () {
+    test('counts each distinct aerodrome once, departure excluded', () {
+      final visited = aerodromesVisitedOtherThanDeparture(
+        _flight(const ['DEP', 'A60', 'B60', 'DEP']),
+      );
+      expect(visited, {'A60', 'B60'});
+    });
+
+    test('a there-and-back-and-back-again route still counts A60 once', () {
+      final visited = aerodromesVisitedOtherThanDeparture(
+        _flight(const ['DEP', 'A60', 'DEP', 'A60', 'DEP']),
+      );
+      expect(visited, {'A60'});
+    });
+  });
+
+  group('totalRouteDistanceNm', () {
+    test('sums consecutive legs, not a single point-to-point figure', () {
+      // DEP -> A60 (60.04) -> B60 (2 degrees = 120.08) -> DEP (60.04):
+      // summing the legs gives roughly 240nm, far more than the ~0nm a
+      // departure-to-final-destination reading would give for a route that
+      // returns to its own start.
+      final total = totalRouteDistanceNm(
+        _flight(const ['DEP', 'A60', 'B60', 'DEP']),
+        _aerodromes,
+      );
+      expect(total, isNotNull);
+      expect(total, closeTo(240.16, 1));
+    });
+
+    test('null when fewer than two waypoints resolve', () {
+      final total = totalRouteDistanceNm(
+        _flight(const ['DEP', 'ZZZZ']),
+        _aerodromes,
+      );
+      expect(total, isNull);
+    });
+  });
+
+  group('furthestLandingDistanceFromDepartureNm', () {
+    test('the furthest landing, not the final destination', () {
+      // Goes out to F120 (120nm from DEP) then all the way back to DEP —
+      // the final leg's distance is 0, but the flight plainly went 120nm
+      // from its departure at some point.
+      final furthest = furthestLandingDistanceFromDepartureNm(
+        _flight(const ['DEP', 'F120', 'DEP']),
+        _aerodromes,
+      );
+      expect(furthest, closeTo(120.08, 1));
+    });
+
+    test('null when the departure itself does not resolve', () {
+      final furthest = furthestLandingDistanceFromDepartureNm(
+        _flight(const ['ZZZZ', 'A60']),
+        _aerodromes,
+      );
+      expect(furthest, isNull);
+    });
+
+    test('unresolvable intermediate waypoints are skipped, not fatal', () {
+      final furthest = furthestLandingDistanceFromDepartureNm(
+        _flight(const ['DEP', 'ZZZZ', 'F120']),
+        _aerodromes,
+      );
+      expect(furthest, closeTo(120.08, 1));
+    });
+  });
+}

--- a/test/domain/primitives/easa_cross_country_time_test.dart
+++ b/test/domain/primitives/easa_cross_country_time_test.dart
@@ -42,33 +42,35 @@ Aircraft _aircraft() => const Aircraft(
   requiresMultiCrew: false,
 );
 
-Flight _flight(List<String> route) => Flight(
-  aircraftRegistration: 'G-TEST',
-  route: route,
-  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
-  onBlocks: UtcInstant.utc(2026, 1, 1, 11, 0),
-  capacity: const PilotCapacity(
-    commandAuthority: true,
-    soleManipulator: true,
-    soleOccupant: true,
-    multiPilotOperation: false,
-    additionalCrewRequiredByRule: false,
-    actingAsInstructor: false,
-    actingAsExaminer: false,
-    picusClaimed: false,
-    picInterventionNotRequired: false,
-  ),
-  carryingPassengers: false,
-  takeoffs: const CircuitCounts(dayFullStop: 1),
-  landings: const CircuitCounts(dayFullStop: 1),
-  ifrFlightPlanFiled: false,
-  actualInstrumentTime: FlightDuration.zero,
-  simulatedInstrumentTime: FlightDuration.zero,
-  approaches: const [],
-  holdingProceduresCount: 0,
-  trackingPerformed: false,
-  remarks: '',
-);
+Flight _flight(List<String> route, {bool prePlannedNavigation = false}) =>
+    Flight(
+      aircraftRegistration: 'G-TEST',
+      route: route,
+      prePlannedNavigation: prePlannedNavigation,
+      offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+      onBlocks: UtcInstant.utc(2026, 1, 1, 11, 0),
+      capacity: const PilotCapacity(
+        commandAuthority: true,
+        soleManipulator: true,
+        soleOccupant: true,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+      ),
+      carryingPassengers: false,
+      takeoffs: const CircuitCounts(dayFullStop: 1),
+      landings: const CircuitCounts(dayFullStop: 1),
+      ifrFlightPlanFiled: false,
+      actualInstrumentTime: FlightDuration.zero,
+      simulatedInstrumentTime: FlightDuration.zero,
+      approaches: const [],
+      holdingProceduresCount: 0,
+      trackingPerformed: false,
+      remarks: '',
+    );
 
 void main() {
   group(
@@ -88,6 +90,28 @@ void main() {
       });
     },
   );
+
+  group('easaCrossCountryTime — a solo navigation exercise that returns to '
+      'the departure aerodrome', () {
+    // FCL.010 does not require the arrival point to differ from
+    // departure — only that the flight followed a pre-planned route
+    // using standard navigation procedures. Route alone (DEP -> DEP,
+    // nowhere else landed at) can't distinguish this from local circuits,
+    // which is exactly why prePlannedNavigation exists as its own fact.
+    final flight = _flight(const ['DEP', 'DEP'], prePlannedNavigation: true);
+    final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+    test('is cross-country, even with no landing away from departure', () {
+      expect(result['crossCountry']?.value, const FlightDuration(120));
+      expect(result['crossCountry']?.creditable, isTrue);
+    });
+
+    test('still does not qualify for licence issue — AMC1 FCL.210 requires '
+        'actual landings at two other aerodromes, not just planned '
+        'navigation', () {
+      expect(result['qualifyingCrossCountry']?.value, FlightDuration.zero);
+    });
+  });
 
   group(
     'easaCrossCountryTime — a short navigation flight (one other aerodrome)',

--- a/test/domain/primitives/easa_cross_country_time_test.dart
+++ b/test/domain/primitives/easa_cross_country_time_test.dart
@@ -1,0 +1,177 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/easa_cross_country_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Equatorial points give exact, round distances (60.04 nm per degree of
+/// longitude) — the same trick `geo_coordinate_test.dart` and
+/// `cross_country_support_test.dart` use.
+GeoCoordinate _eq(double lonDegrees) =>
+    GeoCoordinate(latitude: 0, longitude: lonDegrees);
+
+final _aerodromes = AerodromeDirectory([
+  Aerodrome(icaoCode: 'DEP', name: 'Departure', position: _eq(0)),
+  // ~60nm from DEP.
+  Aerodrome(icaoCode: 'A60', name: 'A, 60nm out', position: _eq(1)),
+  // ~60nm from DEP the other way — combined with A60 on one route, this
+  // gives a total flown distance (DEP-A60-B60-DEP) comfortably over the
+  // 150nm/270km qualifying threshold even though neither leg alone is.
+  Aerodrome(icaoCode: 'B60', name: 'B, 60nm the other way', position: _eq(-1)),
+  // Two aerodromes a few nm from DEP — enough of them to satisfy the "two
+  // other aerodromes" count, nowhere near enough distance.
+  Aerodrome(icaoCode: 'N1', name: 'N1, ~3nm out', position: _eq(0.05)),
+  Aerodrome(icaoCode: 'N2', name: 'N2, ~5nm out', position: _eq(0.08)),
+]);
+
+Aircraft _aircraft() => const Aircraft(
+  registration: 'G-TEST',
+  manufacturer: 'Test',
+  model: 'Test',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight(List<String> route) => Flight(
+  aircraftRegistration: 'G-TEST',
+  route: route,
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 11, 0),
+  capacity: const PilotCapacity(
+    commandAuthority: true,
+    soleManipulator: true,
+    soleOccupant: true,
+    multiPilotOperation: false,
+    additionalCrewRequiredByRule: false,
+    actingAsInstructor: false,
+    actingAsExaminer: false,
+    picusClaimed: false,
+    picInterventionNotRequired: false,
+  ),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  group(
+    'easaCrossCountryTime — a local flight (out and back, no landing elsewhere)',
+    () {
+      final flight = _flight(const ['DEP', 'DEP']);
+      final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+      test('is not cross-country at all', () {
+        expect(result['crossCountry']?.value, FlightDuration.zero);
+        expect(result['crossCountry']?.creditable, isTrue);
+      });
+
+      test('does not qualify for licence issue either', () {
+        expect(result['qualifyingCrossCountry']?.value, FlightDuration.zero);
+        expect(result['qualifyingCrossCountry']?.creditable, isTrue);
+      });
+    },
+  );
+
+  group(
+    'easaCrossCountryTime — a short navigation flight (one other aerodrome)',
+    () {
+      final flight = _flight(const ['DEP', 'A60']);
+      final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+      test('is cross-country — it landed away from departure', () {
+        expect(result['crossCountry']?.value, const FlightDuration(120));
+        expect(result['crossCountry']?.creditable, isTrue);
+      });
+
+      test('does not qualify for licence issue — one other aerodrome and too '
+          'short, not two aerodromes and 150 NM', () {
+        expect(result['qualifyingCrossCountry']?.value, FlightDuration.zero);
+        expect(result['qualifyingCrossCountry']?.creditable, isTrue);
+      });
+    },
+  );
+
+  group('easaCrossCountryTime — a qualifying cross-country flight', () {
+    // DEP -> A60 -> B60 -> DEP: full-stop landings at two aerodromes other
+    // than departure, roughly 240nm total (well past 150nm/270km).
+    final flight = _flight(const ['DEP', 'A60', 'B60', 'DEP']);
+    final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+    test('is cross-country', () {
+      expect(result['crossCountry']?.value, const FlightDuration(120));
+    });
+
+    test('qualifies for licence issue under AMC1 FCL.210', () {
+      expect(
+        result['qualifyingCrossCountry']?.value,
+        const FlightDuration(120),
+      );
+      expect(result['qualifyingCrossCountry']?.creditable, isTrue);
+      expect(
+        result['qualifyingCrossCountry']?.explanation,
+        contains('qualifying cross-country flight'),
+      );
+    });
+  });
+
+  group(
+    'easaCrossCountryTime — distance and aerodrome count are both required',
+    () {
+      test(
+        'enough total distance but only one other aerodrome does not qualify',
+        () {
+          // DEP -> A60 -> DEP -> A60: ~180nm total, but A60 is the only
+          // distinct aerodrome other than departure.
+          final flight = _flight(const ['DEP', 'A60', 'DEP', 'A60']);
+          final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+          expect(result['qualifyingCrossCountry']?.value, FlightDuration.zero);
+          expect(result['qualifyingCrossCountry']?.creditable, isTrue);
+        },
+      );
+
+      test('two other aerodromes but nowhere near enough distance does not '
+          'qualify', () {
+        // DEP -> N1 -> N2 -> DEP: two distinct other aerodromes, but well
+        // under 10nm total.
+        final flight = _flight(const ['DEP', 'N1', 'N2', 'DEP']);
+        final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+        expect(result['qualifyingCrossCountry']?.value, FlightDuration.zero);
+        expect(result['qualifyingCrossCountry']?.creditable, isTrue);
+      });
+    },
+  );
+
+  group('easaCrossCountryTime — position resolution', () {
+    test('an unresolvable route reports the qualifying flag as unknown, but '
+        'the general definition still works from route identifiers alone', () {
+      final flight = _flight(const ['DEP', 'ZZZZ']);
+      final result = easaCrossCountryTime(flight, _aircraft(), _aerodromes);
+
+      expect(
+        result['crossCountry']?.value,
+        isNot(FlightDuration.zero),
+        reason: 'general cross-country needs no position at all',
+      );
+      expect(result['qualifyingCrossCountry']?.creditable, isFalse);
+    });
+  });
+}

--- a/test/domain/primitives/easa_night_time_test.dart
+++ b/test/domain/primitives/easa_night_time_test.dart
@@ -42,6 +42,7 @@ Flight _flight({
 }) => Flight(
   aircraftRegistration: 'G-TEST',
   route: route,
+  prePlannedNavigation: false,
   offBlocks: offBlocks,
   onBlocks: onBlocks,
   takeoff: takeoff,

--- a/test/domain/primitives/easa_pilot_function_time_test.dart
+++ b/test/domain/primitives/easa_pilot_function_time_test.dart
@@ -16,6 +16,7 @@ const _zero = FlightDuration.zero;
 Flight _flightWith(PilotCapacity capacity) => Flight(
   aircraftRegistration: 'G-TEST',
   route: const ['EGKA', 'EGKA'],
+  prePlannedNavigation: false,
   offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
   onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
   capacity: capacity,

--- a/test/domain/primitives/faa_cross_country_time_test.dart
+++ b/test/domain/primitives/faa_cross_country_time_test.dart
@@ -1,0 +1,291 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/faa_cross_country_time.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Equatorial points give exact, round distances (60.04 nm per degree of
+/// longitude) — the same trick used throughout the cross-country test
+/// files.
+GeoCoordinate _eq(double lonDegrees) =>
+    GeoCoordinate(latitude: 0, longitude: lonDegrees);
+
+final _aerodromes = AerodromeDirectory([
+  Aerodrome(icaoCode: 'DEP', name: 'Departure', position: _eq(0)),
+  // ~18nm from DEP — over the 15nm powered-parachute bar, under the 25nm
+  // sport-pilot/rotorcraft one.
+  Aerodrome(icaoCode: 'P18', name: '18nm out', position: _eq(0.3)),
+  // ~27nm from DEP — over the 25nm sport-pilot/rotorcraft bar, under the
+  // 50nm general one.
+  Aerodrome(icaoCode: 'R27', name: '27nm out', position: _eq(0.45)),
+  // ~30nm from DEP — the first leg of the multi-leg case.
+  Aerodrome(icaoCode: 'MID30', name: '30nm out', position: _eq(0.5)),
+  // ~72nm from DEP, but only ~42nm from MID30 — the point that proves
+  // distance must be measured from the original departure, not leg by leg.
+  Aerodrome(icaoCode: 'FAR72', name: '72nm out', position: _eq(1.2)),
+  // ~60nm from DEP — comfortably over every threshold at once.
+  Aerodrome(icaoCode: 'F60', name: '60nm out', position: _eq(1)),
+]);
+
+Aircraft _aircraft(AircraftCategory category) => Aircraft(
+  registration: 'N12345',
+  manufacturer: 'Test',
+  model: 'Test',
+  category: category,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight(List<String> route) => Flight(
+  aircraftRegistration: 'N12345',
+  route: route,
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 11, 0),
+  capacity: const PilotCapacity(
+    commandAuthority: true,
+    soleManipulator: true,
+    soleOccupant: true,
+    multiPilotOperation: false,
+    additionalCrewRequiredByRule: false,
+    actingAsInstructor: false,
+    actingAsExaminer: false,
+    picusClaimed: false,
+    picInterventionNotRequired: false,
+  ),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  group('faaCrossCountryTime — the general (i) definition', () {
+    test('a local out-and-back is not cross-country at all', () {
+      final result = faaCrossCountryTime(
+        _flight(const ['DEP', 'DEP']),
+        _aircraft(AircraftCategory.aeroplane),
+        _aerodromes,
+      );
+      expect(result['crossCountry']?.value, FlightDuration.zero);
+      // Every credit test must give the same reason — "not cross-country
+      // at all" — rather than silently falling through to "too short" with
+      // a distance figure that happens to also be zero.
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.explanation,
+        contains('not cross-country time at all'),
+      );
+    });
+
+    test(
+      'any landing away from departure is cross-country, no minimum distance',
+      () {
+        final result = faaCrossCountryTime(
+          _flight(const ['DEP', 'P18']),
+          _aircraft(AircraftCategory.aeroplane),
+          _aerodromes,
+        );
+        expect(result['crossCountry']?.value, const FlightDuration(120));
+        expect(result['crossCountry']?.explanation, contains('§61.1(b)(3)(i)'));
+      },
+    );
+  });
+
+  group('faaCrossCountryTime — all seven quantities for one aeroplane flight '
+      'well past every threshold', () {
+    final result = faaCrossCountryTime(
+      _flight(const ['DEP', 'F60']),
+      _aircraft(AircraftCategory.aeroplane),
+      _aerodromes,
+    );
+
+    test('the general definition and every non-excluded credit test pass', () {
+      expect(result['crossCountry']?.creditable, isTrue);
+      expect(result['crossCountry']?.value, isNot(FlightDuration.zero));
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.value,
+        isNot(FlightDuration.zero),
+      );
+      expect(
+        result['crossCountrySportPilot']?.value,
+        isNot(FlightDuration.zero),
+      );
+      expect(
+        result['crossCountryAirlineTransportPilot']?.value,
+        isNot(FlightDuration.zero),
+      );
+      expect(result['crossCountryMilitary']?.value, isNot(FlightDuration.zero));
+    });
+
+    test('the powered-parachute and rotorcraft tests do not apply to an '
+        'aeroplane, regardless of distance', () {
+      expect(
+        result['crossCountryPoweredParachute']?.value,
+        FlightDuration.zero,
+      );
+      expect(
+        result['crossCountryPoweredParachute']?.explanation,
+        contains('does not apply'),
+      );
+      expect(result['crossCountryRotorcraft']?.value, FlightDuration.zero);
+      expect(
+        result['crossCountryRotorcraft']?.explanation,
+        contains('does not apply'),
+      );
+    });
+  });
+
+  group('faaCrossCountryTime — multi-leg, from the original departure', () {
+    test(
+      'each leg under 50nm, but the furthest point from departure exceeds it',
+      () {
+        // DEP -> MID30 (30nm) -> FAR72 (42nm from MID30, 72nm from DEP).
+        final result = faaCrossCountryTime(
+          _flight(const ['DEP', 'MID30', 'FAR72']),
+          _aircraft(AircraftCategory.aeroplane),
+          _aerodromes,
+        );
+
+        expect(
+          result['crossCountryPrivateCommercialInstrument']?.value,
+          isNot(FlightDuration.zero),
+          reason:
+              '72nm from the original departure, even though no single '
+              'leg reaches 50nm',
+        );
+      },
+    );
+
+    test('the reverse: returns to land at departure, but a landing along the '
+        'way was over the threshold', () {
+      // DEP -> FAR72 (72nm) -> DEP: the final leg's distance from
+      // departure is zero, but FAR72 was still landed at.
+      final result = faaCrossCountryTime(
+        _flight(const ['DEP', 'FAR72', 'DEP']),
+        _aircraft(AircraftCategory.aeroplane),
+        _aerodromes,
+      );
+
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.value,
+        isNot(FlightDuration.zero),
+        reason: 'the furthest landing point matters, not the final one',
+      );
+    });
+  });
+
+  group('faaCrossCountryTime — rotorcraft, the 25nm test', () {
+    // 27nm: over the rotorcraft/sport-pilot 25nm bar, under the general
+    // 50nm one — the case the general 50nm test alone would miss entirely.
+    final result = faaCrossCountryTime(
+      _flight(const ['DEP', 'R27']),
+      _aircraft(AircraftCategory.helicopter),
+      _aerodromes,
+    );
+
+    test('qualifies under the rotorcraft 25nm test', () {
+      expect(
+        result['crossCountryRotorcraft']?.value,
+        isNot(FlightDuration.zero),
+      );
+      expect(
+        result['crossCountryRotorcraft']?.explanation,
+        contains('§61.1(b)(3)(v)'),
+      );
+    });
+
+    test('does not qualify under the general 50nm test', () {
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.value,
+        FlightDuration.zero,
+      );
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.explanation,
+        contains('needs more than 50'),
+      );
+    });
+
+    test('the ATP and military tests do not apply to rotorcraft', () {
+      expect(
+        result['crossCountryAirlineTransportPilot']?.value,
+        FlightDuration.zero,
+      );
+      expect(
+        result['crossCountryAirlineTransportPilot']?.explanation,
+        contains('does not apply'),
+      );
+      expect(result['crossCountryMilitary']?.value, FlightDuration.zero);
+    });
+  });
+
+  group('faaCrossCountryTime — powered parachute, the 15nm test', () {
+    // 18nm: over the powered-parachute 15nm bar, under everything else.
+    final result = faaCrossCountryTime(
+      _flight(const ['DEP', 'P18']),
+      _aircraft(AircraftCategory.poweredParachute),
+      _aerodromes,
+    );
+
+    test('qualifies under the powered-parachute 15nm test', () {
+      expect(
+        result['crossCountryPoweredParachute']?.value,
+        isNot(FlightDuration.zero),
+      );
+      expect(
+        result['crossCountryPoweredParachute']?.explanation,
+        contains('§61.1(b)(3)(iv)'),
+      );
+    });
+
+    test('the private/commercial/instrument and sport-pilot tests do not '
+        'apply to a powered parachute', () {
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.value,
+        FlightDuration.zero,
+      );
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.explanation,
+        contains('does not apply'),
+      );
+      expect(result['crossCountrySportPilot']?.value, FlightDuration.zero);
+      expect(
+        result['crossCountrySportPilot']?.explanation,
+        contains('does not apply'),
+      );
+    });
+  });
+
+  group('faaCrossCountryTime — position resolution', () {
+    test('an unresolvable route reports the distance tests as unknown', () {
+      final result = faaCrossCountryTime(
+        _flight(const ['DEP', 'ZZZZ']),
+        _aircraft(AircraftCategory.aeroplane),
+        _aerodromes,
+      );
+
+      expect(
+        result['crossCountry']?.value,
+        isNot(FlightDuration.zero),
+        reason: 'the general definition needs no position at all',
+      );
+      expect(
+        result['crossCountryPrivateCommercialInstrument']?.creditable,
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/domain/primitives/faa_cross_country_time_test.dart
+++ b/test/domain/primitives/faa_cross_country_time_test.dart
@@ -48,6 +48,7 @@ Aircraft _aircraft(AircraftCategory category) => Aircraft(
 Flight _flight(List<String> route) => Flight(
   aircraftRegistration: 'N12345',
   route: route,
+  prePlannedNavigation: false,
   offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
   onBlocks: UtcInstant.utc(2026, 1, 1, 11, 0),
   capacity: const PilotCapacity(

--- a/test/domain/primitives/faa_night_time_test.dart
+++ b/test/domain/primitives/faa_night_time_test.dart
@@ -41,6 +41,7 @@ Flight _flight({
 }) => Flight(
   aircraftRegistration: 'N12345',
   route: route,
+  prePlannedNavigation: false,
   offBlocks: offBlocks,
   onBlocks: onBlocks,
   capacity: _capacity(),

--- a/test/domain/primitives/faa_pilot_function_time_test.dart
+++ b/test/domain/primitives/faa_pilot_function_time_test.dart
@@ -15,6 +15,7 @@ const _block = FlightDuration(90); // 1:30, matching the EASA test's fixture
 Flight _flightWith(PilotCapacity capacity) => Flight(
   aircraftRegistration: 'N12345',
   route: const ['KJFK', 'KJFK'],
+  prePlannedNavigation: false,
   offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
   onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
   capacity: capacity,

--- a/test/domain/projection/easa_projection_integration_test.dart
+++ b/test/domain/projection/easa_projection_integration_test.dart
@@ -54,6 +54,7 @@ void main() {
       final flight = Flight(
         aircraftRegistration: 'G-ABCD',
         route: const ['EGKA', 'EGKA'],
+        prePlannedNavigation: false,
         offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
         onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
         capacity: const PilotCapacity(

--- a/test/domain/projection/jurisdiction_projection_test.dart
+++ b/test/domain/projection/jurisdiction_projection_test.dart
@@ -52,6 +52,7 @@ Aircraft _aircraft() => const Aircraft(
 Flight _flight({required bool commandAuthority}) => Flight(
   aircraftRegistration: 'G-TEST',
   route: const ['EGKA', 'EGKA'],
+  prePlannedNavigation: false,
   offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
   onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
   capacity: PilotCapacity(

--- a/test/domain/projection/jurisdiction_projection_test.dart
+++ b/test/domain/projection/jurisdiction_projection_test.dart
@@ -91,6 +91,7 @@ void main() {
     final primitives = PrimitiveRegistry(
       pilotFunctionTimeRules: {'test.fake_rule': _fakeRule},
       nightTimeRules: const {},
+      crossCountryRules: const {},
     );
     projection = JurisdictionProjection(
       registry: registry,
@@ -135,6 +136,7 @@ void main() {
           primitives: PrimitiveRegistry(
             pilotFunctionTimeRules: const {},
             nightTimeRules: const {},
+            crossCountryRules: const {},
           ),
           aerodromes: _emptyAerodromes(),
           jurisdictionId: 'test.no-rules',
@@ -164,6 +166,7 @@ void main() {
         primitives: PrimitiveRegistry(
           pilotFunctionTimeRules: {'test.fake_rule': _fakeRule},
           nightTimeRules: {'test.fake_night_rule': _fakeNightRule},
+          crossCountryRules: const {},
         ),
         aerodromes: _emptyAerodromes(),
         jurisdictionId: 'test.both-rules',
@@ -187,6 +190,7 @@ void main() {
         primitives: PrimitiveRegistry(
           pilotFunctionTimeRules: const {},
           nightTimeRules: const {},
+          crossCountryRules: const {},
         ),
         aerodromes: _emptyAerodromes(),
         jurisdictionId: 'test.broken',
@@ -231,6 +235,7 @@ void main() {
           primitives: PrimitiveRegistry(
             pilotFunctionTimeRules: {'test.pending_rule': pendingRule},
             nightTimeRules: const {},
+            crossCountryRules: const {},
           ),
           aerodromes: _emptyAerodromes(),
           jurisdictionId: 'test.pending',

--- a/test/fixtures/decoders/aircraft_fixture.dart
+++ b/test/fixtures/decoders/aircraft_fixture.dart
@@ -37,6 +37,7 @@ const Map<String, AircraftCategory> _categories = <String, AircraftCategory>{
   'touring_motor_glider': AircraftCategory.touringMotorGlider,
   'airship': AircraftCategory.airship,
   'balloon': AircraftCategory.balloon,
+  'powered_parachute': AircraftCategory.poweredParachute,
 };
 
 const Map<String, EngineType> _engineTypes = <String, EngineType>{

--- a/test/fixtures/decoders/flight_fixture.dart
+++ b/test/fixtures/decoders/flight_fixture.dart
@@ -40,6 +40,7 @@ Flight flightFromFixture(String name) {
   return Flight(
     aircraftRegistration: requiredString(yaml, 'aircraft_registration', name),
     route: requiredStringList(yaml, 'route', name),
+    prePlannedNavigation: requiredBool(yaml, 'pre_planned_navigation', name),
     offBlocks: _instant(yaml, 'off_blocks', name)!,
     onBlocks: _instant(yaml, 'on_blocks', name)!,
     takeoff: _instant(yaml, 'takeoff', name),

--- a/test/fixtures/flights/faa_easa_divergence.yaml
+++ b/test/fixtures/flights/faa_easa_divergence.yaml
@@ -25,6 +25,11 @@ route:
   - "EGHR"
   - "EGKA"
 
+# Circuit training at EGHR, not a planned navigation exercise — FCL.010
+# cross-country is already satisfied here via the landing away from
+# departure (EGHR), not via this flag.
+pre_planned_navigation: false
+
 # The discriminators the divergence turns on — PilotCapacity (#13), embedded
 # as one block rather than flattened back onto Flight.
 capacity:

--- a/test/fixtures/flights/ifr_approaches.yaml
+++ b/test/fixtures/flights/ifr_approaches.yaml
@@ -7,6 +7,8 @@ route:
   - "KJFK"
   - "KJFK"
 
+pre_planned_navigation: false
+
 off_blocks: "2026-04-02T14:00:00Z"
 on_blocks: "2026-04-02T15:30:00Z"
 

--- a/test/fixtures/flights/malformed/bad_runway.yaml
+++ b/test/fixtures/flights/malformed/bad_runway.yaml
@@ -7,6 +7,8 @@ route:
   - "EGKA"
   - "EGKA"
 
+pre_planned_navigation: false
+
 off_blocks: "2026-03-14T09:05:00Z"
 on_blocks: "2026-03-14T10:51:00Z"
 


### PR DESCRIPTION
## Summary

- **#23** — EASA cross-country (`FCL.010`). No minimum distance for general logging; a second, stricter quantity (`qualifyingCrossCountry`) answers the `AMC1 FCL.210` licence-issue question separately — total route distance ≥150nm/270km *and* full-stop landings at two aerodromes other than departure. One can be true without the other, never the reverse.
- **#24** — FAA cross-country (`§61.1(b)(3)`), seven sub-paragraphs computed independently: the general definition plus six purpose-specific credit tests at 50/25/15 nm, two of them gated by aircraft category (rotorcraft, powered-parachute — `AircraftCategory` gains `poweredParachute`, previously unrepresentable). Distance is always measured from the *original* departure to the furthest landing point, not leg-by-leg and not to the final destination — covered by explicit tests in both directions.

Both primitives share `cross_country_support.dart`: route waypoints after the first are treated as landing points (the only reading consistent with what `Flight` actually records), but EASA's qualifying flight measures *total route distance* while FAA's credit tests measure *furthest point from departure* — two different metrics for two different rules, not a shared shortcut.

`JurisdictionProjection`/`PrimitiveRegistry` grow a third rule kind, `cross_country_rule`, alongside `pic_rule` and `night_rule` — the extension point `primitive_registry.dart` already anticipated.

## Test plan

- [x] `flutter test` — 242 tests passing
- [x] `flutter analyze --fatal-infos` clean
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` clean
- [x] Mutation-tested the qualifying-flight distance/aerodrome-count gate, the furthest-point-vs-last-point distance logic, and the FAA category/general-cross-country gating — each confirmed red before green (one gap found and closed: the EASA qualifying flight's `&&` had no test distinguishing it from `||` until a divergent distance-only / aerodrome-count-only case was added)