### PR TITLE
Block/airborne time and date-boundary policy (#27, #29)

### DIFF
--- a/docs/adr/0009-date-boundary-policy.md
+++ b/docs/adr/0009-date-boundary-policy.md
@@ -1,0 +1,68 @@
+# ADR-0009: A flight's logbook date is the UTC calendar date of departure
+
+**Status:** Accepted
+**Date:** 2026-08-09
+
+## Context
+
+A flight departing 23:40 UTC and arriving 01:10 UTC crosses a UTC calendar-day boundary mid-flight.
+It is one row of raw facts (rule 1) — never split into two — but list ordering, PDF pagination and
+any currency rule with a calendar-window condition (`docs/jurisdiction-matrix.md` §5's "FAA windows
+are frequently calendar months") all need a single, unambiguous answer to "which date does this
+flight belong to?" #29's acceptance criteria require that answer to be decided, documented, and
+applied from one place, since more than one convention is defensible and getting it wrong would
+misfile a flight for currency purposes without any exception or test failure to reveal it.
+
+Rule 3 (ADR-0002) already narrows the question: every stored instant is UTC, and no local
+timestamp is ever persisted. There is therefore no stored "local date" to fall back on, and no
+timezone lookup available in `lib/domain/` to derive one — the IANA-database boundary is
+deliberately deferred to M4 (`UtcInstant`'s own dartdoc, "the M4 boundary").
+
+## Decision
+
+A flight's logbook date is the **UTC calendar date of `Flight.offBlocks`** — the date of
+departure, always, regardless of the date `Flight.onBlocks` falls on. Implemented as
+`Flight.logbookDate` (`flight_logbook_date.dart`), returning a new `CalendarDate` value
+(`calendar_date.dart`): year/month/day only, no time-of-day component, so it cannot be confused
+with an instant the way a truncated `DateTime` could be.
+
+`CalendarDate` is deliberately general-purpose, not flight-specific — `PilotCapacity`'s
+`credentialExpiry` and `signatoryCredentialExpiry` fields are provisionally typed as `UtcInstant`
+with a note that a proper calendar-date type was #29's territory; they are candidates to migrate
+to `CalendarDate` later, though that migration is out of scope for this issue.
+
+This is the one place the UTC-date truncation happens. Every future consumer — list sort key, PDF
+page break, currency-window bucketing — must call `Flight.logbookDate` rather than reading
+`offBlocks` and truncating it independently, so the policy cannot quietly diverge between them.
+None of those consumers exist yet as of M1; this ADR and the accompanying getter exist so the
+single correct answer is available before they're built, not invented separately by each one.
+
+## Alternatives considered
+
+**Date of arrival.** Rejected: less conventional, and less intuitive for a pilot who is filling in
+the entry as they depart rather than after they land — the departure date is the one they already
+know before the flight even starts.
+
+**Split the entry into two rows at the UTC date boundary.** Rejected outright by rule 1: a flight
+is one row of raw facts. Splitting a single continuous flight into two logbook entries because it
+happened to straddle midnight would misrepresent block time, landings and every derived quantity
+that reads the flight as a whole.
+
+**Local date of departure, at the departure aerodrome's timezone.** Rejected: resolving a named
+timezone to a UTC offset — including historical DST rules — requires the IANA database, which
+`lib/domain/` does not have access to until M4. It would also make the logbook date depend on
+*where* the aircraft was, which is precisely what rule 3 exists to avoid: UTC storage means the
+domain layer never needs to know or guess a location's offset to answer a question about time.
+
+## Consequences
+
+A flight logged 23:40Z-01:10Z UTC files under 2026-06-15, even though a pilot reading their own
+wall clock at a foreign aerodrome might reach for a different date. That mismatch is real and will
+need a UI-level explanation once M4 adds timezone-aware display, but the *stored and computed*
+logbook date itself never changes based on which timezone is used to view it — only the display
+layer's rendering of it can.
+
+Every later milestone that needs to group or order flights by date (M2's list view, M5's PDF page
+breaks, M6's currency-window evaluation) reads `Flight.logbookDate` rather than reimplementing the
+truncation, so a future change to this policy is a one-line edit to `flight_logbook_date.dart`,
+not a hunt across the codebase.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,7 @@
 | [0006](0006-dependency-stack.md) | Settle the dependency stack now, add packages per milestone | Accepted | The full package list is decided up front, but each dependency is only added to `pubspec.yaml` in the milestone that first imports it. |
 | [0007](0007-duration-representation.md) | Represent logbook durations as integer minutes | Accepted | `FlightDuration` stores whole minutes for exact arithmetic; `HH:MM` and decimal hours (tenths, half away from zero) are display-only formats, and rounding never happens before a total is summed. |
 | [0008](0008-night-time-position-interpolation.md) | Approximate in-flight position as a straight great-circle line between two waypoints | Accepted | Night-time primitives interpolate position linearly, by elapsed time, along the great circle between the first and last resolvable route waypoints — not every intermediate stop, since `Flight` records no per-waypoint timestamp to split time against. |
+| [0009](0009-date-boundary-policy.md) | A flight's logbook date is the UTC calendar date of departure | Accepted | `Flight.logbookDate` is the UTC calendar date of `offBlocks`, never of `onBlocks` and never a local date — the one place list ordering, PDF pagination and currency windows must read it from. |
 
 New ADRs are numbered sequentially and are never renumbered. A decision that is later reversed
 is superseded by a new ADR, not edited in place — the old record stays as evidence of what was

--- a/lib/domain/model/calendar_date.dart
+++ b/lib/domain/model/calendar_date.dart
@@ -1,0 +1,61 @@
+import 'utc_instant.dart';
+
+/// A calendar date with no time-of-day component — year, month, day only.
+///
+/// Exists because `lib/domain/` bans a raw `DateTime` (rule 3,
+/// `tool/check_domain_types.dart`) and several facts genuinely are dates,
+/// not instants: a flight's logbook date (#29 — see
+/// `flight_logbook_date.dart` and `docs/adr/0009-date-boundary-policy.md`),
+/// and, eventually, a licence or countersignature's credential expiry,
+/// today provisionally typed as [UtcInstant] with a "a proper calendar-date
+/// type is #29's territory" note on it.
+class CalendarDate implements Comparable<CalendarDate> {
+  const CalendarDate(this.year, this.month, this.day);
+
+  /// [instant]'s calendar date **in UTC** — the only timezone `lib/domain/`
+  /// ever reads a date against (rule 3, ADR-0002). Never a local date:
+  /// nothing in this codebase stores one to read.
+  factory CalendarDate.fromUtcInstant(UtcInstant instant) {
+    final utc = instant.asUtcDateTime;
+    return CalendarDate(utc.year, utc.month, utc.day);
+  }
+
+  final int year;
+  final int month;
+  final int day;
+
+  @override
+  int compareTo(CalendarDate other) {
+    if (year != other.year) {
+      return year.compareTo(other.year);
+    }
+    if (month != other.month) {
+      return month.compareTo(other.month);
+    }
+    return day.compareTo(other.day);
+  }
+
+  bool operator <(CalendarDate other) => compareTo(other) < 0;
+
+  bool operator <=(CalendarDate other) => compareTo(other) <= 0;
+
+  bool operator >(CalendarDate other) => compareTo(other) > 0;
+
+  bool operator >=(CalendarDate other) => compareTo(other) >= 0;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CalendarDate &&
+      year == other.year &&
+      month == other.month &&
+      day == other.day;
+
+  @override
+  int get hashCode => Object.hash(year, month, day);
+
+  @override
+  String toString() =>
+      '${year.toString().padLeft(4, '0')}-'
+      '${month.toString().padLeft(2, '0')}-'
+      '${day.toString().padLeft(2, '0')}';
+}

--- a/lib/domain/model/flight_logbook_date.dart
+++ b/lib/domain/model/flight_logbook_date.dart
@@ -1,0 +1,16 @@
+import 'calendar_date.dart';
+import 'flight.dart';
+
+/// #29: which calendar date a flight belongs to in the logbook — the answer
+/// to "a flight departing 23:40 UTC and arriving 01:10 UTC belongs to which
+/// date?" See `docs/adr/0009-date-boundary-policy.md`: the date of
+/// departure, in UTC — never the date of arrival, and never a local date,
+/// since none is stored (rule 3).
+///
+/// The single place this truncation happens. List ordering, PDF pagination
+/// and currency-window bucketing (none of which exist yet as of M1) must
+/// all call this rather than reading [Flight.offBlocks] and truncating it
+/// themselves, so the policy can never quietly diverge between them.
+extension FlightLogbookDate on Flight {
+  CalendarDate get logbookDate => CalendarDate.fromUtcInstant(offBlocks);
+}

--- a/lib/domain/model/flight_times.dart
+++ b/lib/domain/model/flight_times.dart
@@ -1,0 +1,36 @@
+import 'flight.dart';
+import 'flight_duration.dart';
+
+/// Block time and airborne time — #27's two distinct total-time readings.
+///
+/// Neither is stored: [Flight.onBlocks]'s own dartdoc already promises block
+/// time is "not stored — it is `onBlocks.difference(offBlocks)`, computed on
+/// read" (CLAUDE.md rule 1), and airborne time is the same idea applied to
+/// [Flight.takeoff]/[Flight.landing]. This extension is the one place both
+/// computations happen, so every caller reads the same arithmetic rather
+/// than re-deriving it.
+extension FlightTimes on Flight {
+  /// `AMC1 FCL.050(g)(1)`; `§1.1`. First movement for the purpose of
+  /// departure to finally coming to rest. Always available —
+  /// [Flight.offBlocks] and [Flight.onBlocks] are both required fields.
+  FlightDuration get blockTime =>
+      FlightDuration(onBlocks.difference(offBlocks).inMinutes);
+
+  /// Time actually airborne, from [Flight.takeoff] to [Flight.landing].
+  ///
+  /// `null` whenever either instant was not recorded. That is the ordinary
+  /// case, not an error — #27's own acceptance criteria note "many pilots
+  /// record only block times" — so a caller that needs airborne time and
+  /// gets `null` back must say so explicitly in its own result rather than
+  /// silently substituting [blockTime] for it. `night_time_support.dart`
+  /// used to do exactly that substitution without disclosing it; this
+  /// getter exists so that mistake can't happen again by accident.
+  FlightDuration? get airborneTime {
+    final start = takeoff;
+    final end = landing;
+    if (start == null || end == null) {
+      return null;
+    }
+    return FlightDuration(end.difference(start).inMinutes);
+  }
+}

--- a/lib/domain/primitives/easa_cross_country_time.dart
+++ b/lib/domain/primitives/easa_cross_country_time.dart
@@ -2,6 +2,7 @@ import '../model/aerodrome_directory.dart';
 import '../model/aircraft.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
+import '../model/flight_times.dart';
 import '../projection/derived_quantity.dart';
 import 'cross_country_support.dart';
 
@@ -35,9 +36,7 @@ Map<String, DerivedQuantity> easaCrossCountryTime(
   Aircraft aircraft,
   AerodromeDirectory aerodromes,
 ) {
-  final blockTime = FlightDuration(
-    flight.onBlocks.difference(flight.offBlocks).inMinutes,
-  );
+  final blockTime = flight.blockTime;
 
   return {
     'crossCountry': _generalCrossCountry(flight, blockTime),

--- a/lib/domain/primitives/easa_night_time.dart
+++ b/lib/domain/primitives/easa_night_time.dart
@@ -30,11 +30,19 @@ Map<String, DerivedQuantity> easaNightTime(
     };
   }
 
+  // #27: a caller must never present a block-time-substituted reading as
+  // indistinguishable from one measured against real airborne instants.
+  final caveat = night.airborneTimesUsed
+      ? ''
+      : ' — takeoff/landing were not recorded, so off-blocks/on-blocks '
+            'were used instead; this may overstate night time by including '
+            'ground time';
+
   return {
     'night': DerivedQuantity.creditable(
-      night,
+      night.value,
       "FCL.010 'night': end of evening civil twilight to beginning of "
-      "morning civil twilight, along the flight's route",
+      "morning civil twilight, along the flight's route$caveat",
     ),
   };
 }

--- a/lib/domain/primitives/faa_cross_country_time.dart
+++ b/lib/domain/primitives/faa_cross_country_time.dart
@@ -2,6 +2,7 @@ import '../model/aerodrome_directory.dart';
 import '../model/aircraft.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
+import '../model/flight_times.dart';
 import '../projection/derived_quantity.dart';
 import 'cross_country_support.dart';
 
@@ -30,9 +31,7 @@ Map<String, DerivedQuantity> faaCrossCountryTime(
   Aircraft aircraft,
   AerodromeDirectory aerodromes,
 ) {
-  final blockTime = FlightDuration(
-    flight.onBlocks.difference(flight.offBlocks).inMinutes,
-  );
+  final blockTime = flight.blockTime;
   final generalCrossCountry = landedAwayFromDeparture(flight);
   final furthestNm = furthestLandingDistanceFromDepartureNm(flight, aerodromes);
   final isRotorcraft = aircraft.category == AircraftCategory.helicopter;

--- a/lib/domain/primitives/faa_night_time.dart
+++ b/lib/domain/primitives/faa_night_time.dart
@@ -43,13 +43,22 @@ Map<String, DerivedQuantity> faaNightTime(
     };
   }
 
+  // #27: a caller must never present a block-time-substituted reading as
+  // indistinguishable from one measured against real airborne instants.
+  final caveat = night.airborneTimesUsed
+      ? ''
+      : ' — takeoff/landing were not recorded, so off-blocks/on-blocks '
+            'were used instead; this may overstate night flight time by '
+            'including ground time';
+
   return {
     'nightFlightTime': DerivedQuantity.creditable(
-      night,
+      night.value,
       "§1.1 'night': end of evening civil twilight to beginning of "
       "morning civil twilight, along the flight's route — logging only; "
       "§61.57(b) night takeoff/landing currency is a separate, later-"
-      'starting window recorded on Flight.landings, not this quantity',
+      'starting window recorded on Flight.landings, not this '
+      'quantity$caveat',
     ),
   };
 }

--- a/lib/domain/primitives/night_time_support.dart
+++ b/lib/domain/primitives/night_time_support.dart
@@ -1,9 +1,18 @@
 import '../model/aerodrome_directory.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
+import '../model/flight_times.dart';
 import '../model/geo_coordinate.dart';
 import '../model/solar_position.dart';
 import '../model/utc_instant.dart';
+
+/// [civilTwilightNightPortion]'s result: the computed night duration, plus
+/// whether it was measured against the flight's real airborne instants or
+/// fell back to block times because [Flight.takeoff]/[Flight.landing]
+/// weren't both recorded (#27) — a fact the caller must disclose in its own
+/// explanation rather than silently produce the same shape of result either
+/// way, per #27's acceptance criteria.
+typedef NightPortion = ({FlightDuration value, bool airborneTimesUsed});
 
 /// Shared by the EASA (#21) and FAA (#22) night-time primitives: both
 /// define night, for *logging* purposes, identically — the period the sun
@@ -17,16 +26,18 @@ import '../model/utc_instant.dart';
 /// great-circle line between the first and last resolvable route waypoints,
 /// walked in step with elapsed time between [Flight.takeoff]/
 /// [Flight.landing] (or [Flight.offBlocks]/[Flight.onBlocks] where airborne
-/// times aren't recorded).
+/// times aren't recorded — see [FlightTimes.airborneTime] and
+/// [NightPortion.airborneTimesUsed]).
 ///
 /// Returns `null` if neither the departure nor the destination in
 /// [flight]'s route resolved to a position — the caller decides how to
 /// report that in its own jurisdiction's vocabulary, rather than this
 /// shared helper guessing at a shape that fits both.
-FlightDuration? civilTwilightNightPortion(
+NightPortion? civilTwilightNightPortion(
   Flight flight,
   AerodromeDirectory aerodromes,
 ) {
+  final airborneTimesUsed = flight.airborneTime != null;
   final start = flight.takeoff ?? flight.offBlocks;
   final end = flight.landing ?? flight.onBlocks;
 
@@ -40,12 +51,13 @@ FlightDuration? civilTwilightNightPortion(
   final from = departure ?? destination!;
   final to = destination ?? departure!;
 
-  return _nightPortion(
+  final value = _nightPortion(
     start: start,
     end: end,
     positionAtFraction: (fraction) =>
         interpolateGreatCircle(from, to, fraction),
   );
+  return (value: value, airborneTimesUsed: airborneTimesUsed);
 }
 
 String? _firstOrNull(List<String> route) => route.isEmpty ? null : route.first;

--- a/lib/domain/projection/jurisdiction_projection.dart
+++ b/lib/domain/projection/jurisdiction_projection.dart
@@ -4,6 +4,7 @@ import '../model/aerodrome_directory.dart';
 import '../model/aircraft.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
+import '../model/flight_times.dart';
 import '../primitives/primitive_registry.dart';
 import 'derived_quantity.dart';
 import 'projection.dart';
@@ -61,10 +62,7 @@ class JurisdictionProjection implements Projection {
       return const {};
     }
     final rule = primitives.pilotFunctionTime(ruleId);
-    final blockTime = FlightDuration(
-      flight.onBlocks.difference(flight.offBlocks).inMinutes,
-    );
-    return rule(flight, blockTime);
+    return rule(flight, flight.blockTime);
   }
 
   /// `night_rule` quantities, or nothing if the profile hasn't set one yet.
@@ -106,10 +104,7 @@ class JurisdictionProjection implements Projection {
       return const {};
     }
     final rule = primitives.instrumentTime(ruleId);
-    final blockTime = FlightDuration(
-      flight.onBlocks.difference(flight.offBlocks).inMinutes,
-    );
-    return rule(flight, blockTime);
+    return rule(flight, flight.blockTime);
   }
 
   /// `multi_pilot_rule` quantities, or nothing if the profile hasn't set
@@ -125,10 +120,7 @@ class JurisdictionProjection implements Projection {
       return const {};
     }
     final rule = primitives.multiPilotTime(ruleId);
-    final blockTime = FlightDuration(
-      flight.onBlocks.difference(flight.offBlocks).inMinutes,
-    );
-    return rule(flight, aircraft, blockTime);
+    return rule(flight, aircraft, flight.blockTime);
   }
 
   @override

--- a/test/domain/model/calendar_date_test.dart
+++ b/test/domain/model/calendar_date_test.dart
@@ -1,0 +1,64 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CalendarDate.fromUtcInstant', () {
+    test('takes the UTC calendar date, ignoring time of day', () {
+      final date = CalendarDate.fromUtcInstant(
+        UtcInstant.utc(2026, 6, 15, 23, 40),
+      );
+
+      expect(date, const CalendarDate(2026, 6, 15));
+    });
+  });
+
+  group('CalendarDate', () {
+    test('orders, compares and de-duplicates by value', () {
+      const a = CalendarDate(2026, 6, 15);
+      const b = CalendarDate(2026, 6, 15);
+      const c = CalendarDate(2026, 6, 16);
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      // `a` and `b` are equal by value on purpose -- this is the
+      // de-duplication behaviour under test, not an accidental duplicate.
+      // ignore: equal_elements_in_set
+      expect(<CalendarDate>{a, b, c}, hasLength(2));
+      expect(a < c, isTrue);
+      expect(c > a, isTrue);
+      expect(a <= b, isTrue);
+      expect(a >= b, isTrue);
+      expect(<CalendarDate>[c, a].toList()..sort(), <CalendarDate>[a, c]);
+    });
+
+    test('compares across month and year boundaries, not just the day', () {
+      const endOfYear = CalendarDate(2025, 12, 31);
+      const startOfNextYear = CalendarDate(2026, 1, 1);
+      const midMonth = CalendarDate(2026, 1, 15);
+
+      expect(endOfYear < startOfNextYear, isTrue);
+      expect(startOfNextYear < midMonth, isTrue);
+    });
+
+    test('month outranks day within the same year — a later month with an '
+        'earlier day-of-month is still later', () {
+      const earlyInApril = CalendarDate(2026, 4, 5);
+      const lateInMarch = CalendarDate(2026, 3, 20);
+
+      expect(
+        lateInMarch < earlyInApril,
+        isTrue,
+        reason:
+            'comparing day-of-month alone (20 vs 5) would wrongly say '
+            'the March date is later',
+      );
+    });
+
+    test('formats as zero-padded ISO-8601 date', () {
+      expect(const CalendarDate(2026, 1, 5).toString(), '2026-01-05');
+    });
+  });
+}

--- a/test/domain/model/flight_logbook_date_test.dart
+++ b/test/domain/model/flight_logbook_date_test.dart
@@ -1,0 +1,88 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/flight_logbook_date.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+PilotCapacity _capacity() => const PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({required UtcInstant offBlocks, required UtcInstant onBlocks}) =>
+    Flight(
+      aircraftRegistration: 'G-ABCD',
+      route: const ['EGKA', 'EGLL'],
+      prePlannedNavigation: false,
+      offBlocks: offBlocks,
+      onBlocks: onBlocks,
+      capacity: _capacity(),
+      carryingPassengers: false,
+      takeoffs: const CircuitCounts(dayFullStop: 1),
+      landings: const CircuitCounts(dayFullStop: 1),
+      ifrFlightPlanFiled: false,
+      actualInstrumentTime: FlightDuration.zero,
+      simulatedInstrumentTime: FlightDuration.zero,
+      approaches: const [],
+      holdingProceduresCount: 0,
+      trackingPerformed: false,
+      remarks: '',
+    );
+
+void main() {
+  group('Flight.logbookDate', () {
+    test('a flight crossing the UTC midnight boundary files under the date '
+        'of departure, not arrival', () {
+      // docs/adr/0009-date-boundary-policy.md's own example: departs
+      // 23:40Z, arrives 01:10Z the next UTC day.
+      final flight = _flight(
+        offBlocks: UtcInstant.utc(2026, 6, 15, 23, 40),
+        onBlocks: UtcInstant.utc(2026, 6, 16, 1, 10),
+      );
+
+      expect(flight.logbookDate, const CalendarDate(2026, 6, 15));
+    });
+
+    test('a flight wholly within one UTC date files under that date, the '
+        'ordinary case', () {
+      final flight = _flight(
+        offBlocks: UtcInstant.utc(2026, 6, 15, 9, 0),
+        onBlocks: UtcInstant.utc(2026, 6, 15, 10, 30),
+      );
+
+      expect(flight.logbookDate, const CalendarDate(2026, 6, 15));
+    });
+
+    test('uses the UTC date even where a local wall clock at departure would '
+        'read a different date entirely', () {
+      // A departure at 2026-06-15T23:40 local time five hours behind UTC
+      // (e.g. US Eastern, UTC-5) is stored — per rule 3 — as the UTC
+      // instant 2026-06-16T04:40Z. The policy reads that stored UTC
+      // instant only: it never attempts to reconstruct "what the pilot's
+      // wall clock said," which nothing in this codebase records.
+      final flight = _flight(
+        offBlocks: UtcInstant.utc(2026, 6, 16, 4, 40),
+        onBlocks: UtcInstant.utc(2026, 6, 16, 6, 10),
+      );
+
+      expect(
+        flight.logbookDate,
+        const CalendarDate(2026, 6, 16),
+        reason:
+            'the UTC date of off-blocks, not the 2026-06-15 a local '
+            'wall clock at the departure point would have shown',
+      );
+    });
+  });
+}

--- a/test/domain/model/flight_times_test.dart
+++ b/test/domain/model/flight_times_test.dart
@@ -1,0 +1,82 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/flight_times.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+PilotCapacity _capacity() => const PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({UtcInstant? takeoff, UtcInstant? landing}) => Flight(
+  aircraftRegistration: 'G-ABCD',
+  route: const ['EGKA', 'EGKA'],
+  prePlannedNavigation: false,
+  offBlocks: UtcInstant.utc(2026, 1, 1, 9, 0),
+  onBlocks: UtcInstant.utc(2026, 1, 1, 10, 30),
+  takeoff: takeoff,
+  landing: landing,
+  capacity: _capacity(),
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  group('FlightTimes.blockTime', () {
+    test('is off-blocks to on-blocks, always available', () {
+      final flight = _flight();
+
+      expect(flight.blockTime, const FlightDuration(90));
+    });
+  });
+
+  group('FlightTimes.airborneTime', () {
+    test('is null when neither takeoff nor landing is recorded', () {
+      final flight = _flight();
+
+      expect(flight.airborneTime, isNull);
+    });
+
+    test('is null when only takeoff is recorded', () {
+      final flight = _flight(takeoff: UtcInstant.utc(2026, 1, 1, 9, 5));
+
+      expect(flight.airborneTime, isNull);
+    });
+
+    test('is null when only landing is recorded', () {
+      final flight = _flight(landing: UtcInstant.utc(2026, 1, 1, 10, 25));
+
+      expect(flight.airborneTime, isNull);
+    });
+
+    test('is takeoff to landing when both are recorded, distinct from '
+        'block time', () {
+      final flight = _flight(
+        takeoff: UtcInstant.utc(2026, 1, 1, 9, 5),
+        landing: UtcInstant.utc(2026, 1, 1, 10, 25),
+      );
+
+      expect(flight.airborneTime, const FlightDuration(80));
+      expect(flight.airborneTime, isNot(flight.blockTime));
+    });
+  });
+}

--- a/test/domain/primitives/easa_night_time_test.dart
+++ b/test/domain/primitives/easa_night_time_test.dart
@@ -154,6 +154,27 @@ void main() {
           FlightDuration.zero,
           reason: 'a zero-length airborne window has no night time at all',
         );
+        expect(
+          result['night']?.explanation,
+          isNot(contains('were not recorded')),
+          reason: 'real airborne instants were used, so no caveat is owed',
+        );
+      });
+
+      // #27: a missing takeoff/landing must not be silently blended into a
+      // reading that looks identical to one measured against real airborne
+      // instants.
+      test('discloses the block-time substitution when takeoff/landing are '
+          'not recorded', () {
+        final flight = _flight(
+          route: const ['EGXX', 'EGXX'],
+          offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+          onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+        );
+
+        final result = easaNightTime(flight, aerodromes);
+
+        expect(result['night']?.explanation, contains('were not recorded'));
       });
     },
   );

--- a/test/domain/primitives/faa_night_time_test.dart
+++ b/test/domain/primitives/faa_night_time_test.dart
@@ -37,6 +37,8 @@ Flight _flight({
   required List<String> route,
   required UtcInstant offBlocks,
   required UtcInstant onBlocks,
+  UtcInstant? takeoff,
+  UtcInstant? landing,
   CircuitCounts landings = const CircuitCounts(dayFullStop: 1),
 }) => Flight(
   aircraftRegistration: 'N12345',
@@ -44,6 +46,8 @@ Flight _flight({
   prePlannedNavigation: false,
   offBlocks: offBlocks,
   onBlocks: onBlocks,
+  takeoff: takeoff,
+  landing: landing,
   capacity: _capacity(),
   carryingPassengers: false,
   takeoffs: const CircuitCounts(dayFullStop: 1),
@@ -99,6 +103,42 @@ void main() {
       expect(
         result['nightFlightTime']?.explanation,
         contains('cannot be computed'),
+      );
+    });
+
+    // #27: a missing takeoff/landing must not be silently blended into a
+    // reading that looks identical to one measured against real airborne
+    // instants.
+    test('discloses the block-time substitution when takeoff/landing are not '
+        'recorded', () {
+      final flight = _flight(
+        route: const ['KXXX', 'KXXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+      );
+
+      final result = faaNightTime(flight, aerodromes);
+
+      expect(
+        result['nightFlightTime']?.explanation,
+        contains('were not recorded'),
+      );
+    });
+
+    test('no caveat when takeoff/landing are both recorded', () {
+      final flight = _flight(
+        route: const ['KXXX', 'KXXX'],
+        offBlocks: UtcInstant.utc(2024, 6, 21, 22, 0),
+        onBlocks: UtcInstant.utc(2024, 6, 21, 23, 0),
+        takeoff: UtcInstant.utc(2024, 6, 21, 22, 5),
+        landing: UtcInstant.utc(2024, 6, 21, 22, 55),
+      );
+
+      final result = faaNightTime(flight, aerodromes);
+
+      expect(
+        result['nightFlightTime']?.explanation,
+        isNot(contains('were not recorded')),
       );
     });
   });


### PR DESCRIPTION
## Summary
- `Flight.blockTime`/`Flight.airborneTime` (new `FlightTimes` extension) as the one canonical derivation, replacing five duplicated inline computations across the pilot-function-time, instrument-time, multi-pilot-time and cross-country primitives.
- Fixes a real silent-substitution bug: `civilTwilightNightPortion` fell back from takeoff/landing to off-blocks/on-blocks with no indication a substitution had happened — exactly the failure mode #27's acceptance criteria warn about ("Silent substitution here would corrupt night time computation in a way that is very hard to notice"). Both night-time primitives now disclose the fallback in their explanation text.
- `Flight.logbookDate` (new `CalendarDate` value type + `FlightLogbookDate` extension): the UTC calendar date of departure, never arrival, never a local date. Policy recorded in ADR-0009.

Closes #27
Closes #29

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart` (confirms `CalendarDate`'s `.asUtcDateTime` usage doesn't trip the raw-`DateTime` ban)
- [x] `flutter test` (271 passing)
- [x] Mutation-tested: the airborne-times-used disclosure flag (both EASA and FAA night time), the airborne-time null-check (caught at compile time via null-safety promotion), the logbook-date departure-vs-arrival choice, and `CalendarDate.compareTo`'s month-vs-day priority — the last one found and closed a real gap (initial test suite didn't exercise same-year/different-month ordering) before merge