### PR TITLE
M0 housekeeping: coverage gate, layering-guard fix, CI hygiene, inert lint (#7, #98, #99, #100)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,4 +60,11 @@ jobs:
         run: dart run tool/check_domain_types.dart
 
       - name: Test
-        run: flutter test
+        run: flutter test --coverage
+
+      # #7: lib/domain/ computes the numbers that go in a legal document and
+      # is held to a higher bar than the rest of the app — a blanket
+      # repo-wide threshold would be gamed by widget tests, so this is
+      # scoped to the one layer that matters.
+      - name: Check domain coverage
+        run: dart run tool/check_domain_coverage.dart coverage/lcov.info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# #100: a rapid run of pushes to the same PR queues redundant full runs
+# otherwise — cancel a superseded one rather than let it finish.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     # ubuntu is sufficient: analysis and unit tests need no iOS/Android toolchain.
@@ -12,9 +18,12 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      # #100: SHA-pinned, not tag-pinned — a tag is mutable, and this check
+      # is a required status check on main. v4.4.0.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: subosito/flutter-action@v2
+      # #100: SHA-pinned, same reasoning. v2.23.0.
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           # Pinned deliberately, not `stable`. A silent SDK bump breaking the
           # build is a bad way to lose an evening. Matches the local puro env.
@@ -31,8 +40,15 @@ jobs:
       - name: Check formatting
         run: dart format --set-exit-if-changed .
 
+      # #100: --delete-conflicting-outputs was dropped — build_runner 2.15.1
+      # made conflict deletion the default and logged
+      # "These options have been removed and were ignored" on every run.
+      # Deferred rather than removed during M0, on the grounds that codegen
+      # wasn't doing anything real yet; M1 now regenerates a freezed model
+      # on nearly every commit, so the flag has had its chance to matter and
+      # hasn't needed to.
       - name: Generate code
-        run: dart run build_runner build --delete-conflicting-outputs
+        run: dart run build_runner build
 
       - name: Analyze
         run: flutter analyze --fatal-infos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,8 +191,10 @@ Easy to get wrong:
   fields that a hand-written `==` would be easy to get wrong.
 - Run `dart format .`, `flutter analyze` and `flutter test` before committing; all must be clean.
 - `flutter` and `dart` are puro shims that work under PowerShell only, not Git Bash. Locally,
-  code generation is `flutter pub run build_runner build --delete-conflicting-outputs` — plain
-  `dart run build_runner` cannot find the Flutter SDK.
+  code generation is `flutter pub run build_runner build` — plain `dart run build_runner` cannot
+  find the Flutter SDK. `--delete-conflicting-outputs` is no longer passed: build_runner 2.15.1
+  made conflict deletion the default, and the flag only produced a removed-and-ignored warning
+  (issue #100).
 - Domain logic needs unit tests. Where two jurisdictions disagree, test both sides of the
   disagreement against the same input.
 - Prefer adding a fixture to `test/fixtures/` over inventing test data inline.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,4 +16,10 @@ linter:
     - always_declare_return_types
     - prefer_final_locals
     - avoid_dynamic_calls
-    - require_trailing_commas
+    # require_trailing_commas is NOT enforced by this rule on the current
+    # analyzer — verified during the M0 whole-branch review: a multi-line
+    # invocation missing its trailing comma produces no lint. `dart format`
+    # already reformats that same code and exits non-zero, and runs before
+    # `flutter analyze` in CI, so the outcome is covered without this line.
+    # See issue #99. Left out rather than kept, since a rule that silently
+    # does nothing is more misleading here than its absence.

--- a/test/tool/check_domain_coverage_test.dart
+++ b/test/tool/check_domain_coverage_test.dart
@@ -1,0 +1,177 @@
+// flutter_test re-exports test/group/expect from package:test_api, so plain
+// Dart tests need no separate package:test dependency.
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/check_domain_coverage.dart';
+
+void main() {
+  group('parseLcov', () {
+    test('parses one record', () {
+      const lcov = '''
+SF:lib/domain/model/flight.dart
+DA:1,3
+DA:2,0
+DA:3,1
+LF:3
+LH:2
+end_of_record
+''';
+      final records = parseLcov(lcov);
+
+      expect(records, hasLength(1));
+      expect(records.single.path, 'lib/domain/model/flight.dart');
+      expect(records.single.linesFound, 3);
+      expect(records.single.linesHit, 2);
+    });
+
+    test('parses several records', () {
+      const lcov = '''
+SF:lib/domain/model/flight.dart
+DA:1,1
+LF:1
+LH:1
+end_of_record
+SF:lib/domain/model/aircraft.dart
+DA:1,0
+LF:1
+LH:0
+end_of_record
+''';
+      final records = parseLcov(lcov);
+
+      expect(records, hasLength(2));
+      expect(records[0].path, 'lib/domain/model/flight.dart');
+      expect(records[1].path, 'lib/domain/model/aircraft.dart');
+    });
+
+    // #98/#7: flutter test --coverage writes backslash-separated SF: paths
+    // on Windows — the same footgun check_layering.dart has for its own
+    // reported paths, and the reason recordsUnder's prefix match would
+    // silently match nothing on a Windows-generated trace file without this.
+    test('normalises backslash-separated paths', () {
+      const lcov = '''
+SF:lib\\domain\\model\\flight.dart
+DA:1,1
+LF:1
+LH:1
+end_of_record
+''';
+      final records = parseLcov(lcov);
+
+      expect(records.single.path, 'lib/domain/model/flight.dart');
+    });
+
+    test(
+      'prefers LF:/LH: over the derived DA: count when both are present',
+      () {
+        // LF:/LH: are lcov's own authoritative summary; deliberately mismatched
+        // from what counting DA: lines would give (2 found, 1 hit), so a
+        // parser that ignores LF:/LH: in favour of always deriving from DA:
+        // is caught here rather than only in the "absent" case.
+        const lcov = '''
+SF:lib/domain/model/flight.dart
+DA:1,1
+DA:2,0
+LF:9
+LH:9
+end_of_record
+''';
+        final records = parseLcov(lcov);
+
+        expect(records.single.linesFound, 9);
+        expect(records.single.linesHit, 9);
+      },
+    );
+
+    test('falls back to counting DA: lines when LF:/LH: are absent', () {
+      const lcov = '''
+SF:lib/domain/model/flight.dart
+DA:1,1
+DA:2,0
+DA:3,4
+end_of_record
+''';
+      final records = parseLcov(lcov);
+
+      expect(records.single.linesFound, 3);
+      expect(records.single.linesHit, 2);
+    });
+
+    test('tolerates a trace file missing its final end_of_record', () {
+      const lcov = '''
+SF:lib/domain/model/flight.dart
+DA:1,1
+LF:1
+LH:1''';
+      final records = parseLcov(lcov);
+
+      expect(records, hasLength(1));
+    });
+  });
+
+  group('recordsUnder', () {
+    final all = [
+      const FileCoverage(
+        path: 'lib/domain/model/flight.dart',
+        linesFound: 10,
+        linesHit: 10,
+      ),
+      const FileCoverage(
+        path: 'lib/domain/model/flight.freezed.dart',
+        linesFound: 100,
+        linesHit: 0,
+      ),
+      const FileCoverage(
+        path: 'lib/ui/screens/entry_form.dart',
+        linesFound: 50,
+        linesHit: 5,
+      ),
+    ];
+
+    test('excludes a record outside the target directory', () {
+      final domain = recordsUnder(all, 'lib/domain/');
+
+      expect(domain.any((r) => r.path.startsWith('lib/ui/')), isFalse);
+    });
+
+    test('excludes generated files even under the target directory', () {
+      // The fixture's flight.freezed.dart has 100 uncovered lines. If it
+      // were not excluded, its 0% would drag the aggregate figure down —
+      // it is not reachable code anyone wrote or is expected to test
+      // directly (ADR-0006).
+      final domain = recordsUnder(all, 'lib/domain/');
+
+      expect(domain.any((r) => r.path.endsWith('.freezed.dart')), isFalse);
+      expect(domain.map((r) => r.path), ['lib/domain/model/flight.dart']);
+    });
+  });
+
+  group('aggregatePercent', () {
+    test('weights by summed lines, not by averaging per-file percentages', () {
+      // A naive average of (100%, 0%) is 50%. Weighted by lines, this is
+      // 1000/1010 ≈ 99% — a large well-tested file cannot be dragged down
+      // to look like a coin flip by one tiny untested one.
+      final records = [
+        const FileCoverage(
+          path: 'lib/domain/a.dart',
+          linesFound: 1000,
+          linesHit: 1000,
+        ),
+        const FileCoverage(
+          path: 'lib/domain/b.dart',
+          linesFound: 10,
+          linesHit: 0,
+        ),
+      ];
+
+      final percent = aggregatePercent(records);
+
+      expect(percent, closeTo(99.0, 0.1));
+      expect(percent, isNot(closeTo(50.0, 1)));
+    });
+
+    test('an empty record set is 100%, not a division by zero', () {
+      expect(aggregatePercent(const []), 100);
+    });
+  });
+}

--- a/test/tool/check_layering_test.dart
+++ b/test/tool/check_layering_test.dart
@@ -59,6 +59,20 @@ import 'dart:ui';
       expect(violations.single.line, 3);
     });
 
+    // #98: Directory.listSync returns backslash-separated paths on Windows,
+    // so a violation reported there must still read with forward slashes —
+    // the same normalisation _escapesDomain already relies on internally.
+    test('normalises Windows-style path separators in the reported path', () {
+      const source = "import 'dart:io';\n";
+      final violations = findViolations(
+        r'lib\domain\primitives\thing.dart',
+        source,
+      );
+
+      expect(violations.single.filePath, 'lib/domain/primitives/thing.dart');
+      expect(violations.single.toString(), isNot(contains(r'\')));
+    });
+
     test(
       'strips a banned import written inside a multi-line block comment',
       () {

--- a/tool/check_domain_coverage.dart
+++ b/tool/check_domain_coverage.dart
@@ -1,0 +1,167 @@
+/// Enforces issue #7: `lib/domain/` computes the numbers that go in a legal
+/// document and is held to a higher bar than the rest of the app — a
+/// blanket repo-wide coverage threshold would be gamed by widget tests, so
+/// this is scoped to the one layer that matters.
+///
+/// Run: `dart run tool/check_domain_coverage.dart <path-to-lcov.info> [threshold%]`
+/// after `flutter test --coverage` has produced the trace file. Exits 1 if
+/// coverage under [defaultTarget] falls below the threshold (default 90%).
+library;
+
+import 'dart:io';
+
+const String defaultTarget = 'lib/domain/';
+const double defaultThresholdPercent = 90;
+
+/// `analysis_options.yaml` excludes generated code from analysis for the
+/// same reason — it is not ours to lint or to hold to a coverage bar. See
+/// ADR-0006 and `tool/check_layering.dart`'s own `generatedSuffixes`.
+const List<String> generatedSuffixes = <String>['.freezed.dart', '.g.dart'];
+
+/// One `SF:`...`end_of_record` block's totals for a single source file, from
+/// an lcov trace file.
+class FileCoverage {
+  const FileCoverage({
+    required this.path,
+    required this.linesFound,
+    required this.linesHit,
+  });
+
+  final String path;
+  final int linesFound;
+  final int linesHit;
+}
+
+/// Parses an lcov trace file (the format `flutter test --coverage` writes to
+/// `coverage/lcov.info`) into one [FileCoverage] per `SF:` record.
+///
+/// Paths are normalised to forward slashes — `flutter test --coverage`
+/// writes backslash-separated `SF:` paths on Windows, the same footgun
+/// `check_layering.dart` (#98) has for its own reported paths.
+///
+/// Falls back to counting `DA:` lines directly when a record has no `LF:`/
+/// `LH:` summary line, since some lcov producers omit them for a record
+/// with zero coverable lines.
+List<FileCoverage> parseLcov(String content) {
+  final records = <FileCoverage>[];
+  String? currentPath;
+  var daFound = 0;
+  var daHit = 0;
+  int? lf;
+  int? lh;
+
+  void flush() {
+    if (currentPath == null) {
+      return;
+    }
+    records.add(
+      FileCoverage(
+        path: currentPath!.replaceAll(r'\', '/'),
+        linesFound: lf ?? daFound,
+        linesHit: lh ?? daHit,
+      ),
+    );
+    currentPath = null;
+    daFound = 0;
+    daHit = 0;
+    lf = null;
+    lh = null;
+  }
+
+  for (final rawLine in content.split('\n')) {
+    final line = rawLine.trim();
+    if (line.startsWith('SF:')) {
+      currentPath = line.substring(3);
+    } else if (line.startsWith('DA:')) {
+      final hits = int.parse(line.substring(3).split(',')[1]);
+      daFound++;
+      if (hits > 0) {
+        daHit++;
+      }
+    } else if (line.startsWith('LF:')) {
+      lf = int.parse(line.substring(3));
+    } else if (line.startsWith('LH:')) {
+      lh = int.parse(line.substring(3));
+    } else if (line == 'end_of_record') {
+      flush();
+    }
+  }
+  flush(); // Tolerate a trace file that doesn't end with end_of_record.
+
+  return records;
+}
+
+/// The records that count toward [target]'s coverage figure: under [target],
+/// and not a generated file.
+List<FileCoverage> recordsUnder(List<FileCoverage> all, String target) => [
+  for (final record in all)
+    if (record.path.startsWith(target) &&
+        !generatedSuffixes.any(record.path.endsWith))
+      record,
+];
+
+/// The aggregate percentage across [records], by summed lines — not an
+/// average of per-file percentages, so one large well-tested file cannot be
+/// outweighed by several tiny untested ones.
+double aggregatePercent(List<FileCoverage> records) {
+  final linesFound = records.fold<int>(0, (sum, r) => sum + r.linesFound);
+  final linesHit = records.fold<int>(0, (sum, r) => sum + r.linesHit);
+  return linesFound == 0 ? 100 : (linesHit / linesFound) * 100;
+}
+
+void main(List<String> args) {
+  if (args.isEmpty) {
+    stderr.writeln(
+      'usage: dart run tool/check_domain_coverage.dart <lcov.info> [threshold%]',
+    );
+    exit(2);
+  }
+
+  final lcovFile = File(args[0]);
+  final threshold = args.length > 1
+      ? double.parse(args[1])
+      : defaultThresholdPercent;
+
+  if (!lcovFile.existsSync()) {
+    stderr.writeln(
+      'check_domain_coverage: ${args[0]} not found — run `flutter test '
+      '--coverage` first.',
+    );
+    exit(2);
+  }
+
+  final all = parseLcov(lcovFile.readAsStringSync());
+  final domain = recordsUnder(all, defaultTarget);
+
+  if (domain.isEmpty) {
+    stderr.writeln(
+      'check_domain_coverage: no coverage records under $defaultTarget — '
+      'is the target path right, or did the trace file come from a '
+      'partial test run?',
+    );
+    exit(2);
+  }
+
+  final linesFound = domain.fold<int>(0, (sum, r) => sum + r.linesFound);
+  final linesHit = domain.fold<int>(0, (sum, r) => sum + r.linesHit);
+  final percent = aggregatePercent(domain);
+
+  final summary =
+      'check_domain_coverage: $defaultTarget ${percent.toStringAsFixed(1)}% '
+      '($linesHit/$linesFound lines) across ${domain.length} file(s), '
+      'threshold ${threshold.toStringAsFixed(0)}%.';
+  stdout.writeln(summary);
+
+  final summaryPath = Platform.environment['GITHUB_STEP_SUMMARY'];
+  if (summaryPath != null) {
+    File(summaryPath).writeAsStringSync(
+      '### Domain coverage\n\n$summary\n',
+      mode: FileMode.append,
+    );
+  }
+
+  if (percent < threshold) {
+    stderr.writeln('check_domain_coverage: below threshold, failing.');
+    exit(1);
+  }
+}

--- a/tool/check_layering.dart
+++ b/tool/check_layering.dart
@@ -187,6 +187,11 @@ bool _escapesDomain(String uri, String filePath) {
 /// doesn't overstate what slips past every check, not because it needs its
 /// own defence here.
 List<Violation> findViolations(String filePath, String source) {
+  // #98: normalised once here so a violation printed on Windows (where
+  // Directory.listSync returns backslash-separated paths) reads identically
+  // to one printed in CI (Linux). Irrelevant to CI itself, relevant to the
+  // pre-commit hook (#10) a contributor might run locally on Windows.
+  filePath = filePath.replaceAll(r'\', '/');
   final stripped = stripComments(source);
   final violations = <Violation>[];
 


### PR DESCRIPTION
## Summary
Clears the four leftover M0 tooling issues while #28 (FSTD sessions) is on hold.

- **#7** — a domain-scoped coverage gate (`tool/check_domain_coverage.dart`), parsing `flutter test --coverage`'s lcov output, excluding generated files, failing CI below 90%. Currently 97.2%.
- **#98** — `check_layering.dart` now normalizes Windows-style path separators in its reported violations. The other two known gaps (documented in its own doc comment) are reviewed and kept as accepted, documented limitations — not touched.
- **#99** — removed the `require_trailing_commas` lint rule, which does nothing on the current analyzer (`dart format` already covers the same outcome and runs earlier in CI). The M0 spec document that also made this claim no longer exists in the repo.
- **#100** — CI concurrency group (cancels a superseded run), SHA-pinned `actions/checkout`/`subosito/flutter-action` (both now current enough to resolve the Node 20 deprecation), and dropped `--delete-conflicting-outputs`, which build_runner 2.15.1 made a no-op. Also updated CLAUDE.md's documented local command to match.

Closes #7
Closes #98
Closes #99
Closes #100

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `flutter test` (290 passing)
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 97.2%, well above the 90% threshold
- [x] Mutation-tested: the layering guard's path normalization, and the coverage parser's path normalization, LF:/LH:-vs-DA: precedence (found and closed a real gap here — nothing proved LF:/LH: actually took priority), generated-file filter, and weighted-vs-averaged aggregation — each confirmed red before green