### PR TITLE
M0 housekeeping: README, LICENSE, templates, pre-commit hook (#2, #9, #10)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# tool/hooks/pre-commit is a #!/bin/sh script git's own bundled sh executes
+# directly (#10). A CRLF line ending on the shebang line breaks that
+# interpreter lookup on Windows, so this must stay LF regardless of a
+# contributor's core.autocrlf setting.
+tool/hooks/pre-commit text eol=lf
+*.sh text eol=lf

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: A computed figure, currency status, or export is wrong
+title: ""
+labels: type:bug
+---
+
+"The hours are wrong" is not actionable on its own — this app computes different numbers for the
+same flight under different jurisdictions on purpose (CLAUDE.md rule 5), so a report needs enough
+raw facts to tell a real bug apart from a correct-but-surprising divergence.
+
+## Jurisdiction
+
+Which authority's number is wrong — EASA, FAA, UK CAA? If more than one, say so; a bug that hits
+every jurisdiction identically usually has a different cause than one that hits only one.
+
+## The flight's raw facts
+
+The inputs, not the output — route, off-blocks/on-blocks (and takeoff/landing if recorded),
+capacity (command authority, sole manipulator, instructor presence and capacity, PICUS/SPIC
+claim, countersignature state), and anything else that could plausibly affect the figure in
+question. If you can attach or paste the flight as it would appear in a fixture (see
+`test/fixtures/README.md`), that's ideal.
+
+## Expected vs. actual
+
+- **Expected:** what the figure should be, and why (cite the rule if you can — `FCL.010`,
+  `§61.51(e)(1)(i)`, etc.)
+- **Actual:** what the app shows
+
+## Where you saw it
+
+Screen or export (entry form, totals, currency page, PDF export), and app version / build if
+known.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest something the app should do
+title: ""
+labels: type:feat
+---
+
+## What and why
+
+What the app should do, and the problem it solves — not just "add X," but why X matters for
+logging or tracking currency.
+
+## Milestone
+
+Which milestone (see the repo's milestones) this most naturally belongs to, if you have a guess.
+Not required — just helps triage.
+
+## Non-goals check
+
+`CLAUDE.md`'s "Deliberately out of scope" section lists things intentionally not being built yet
+(background flight recording, cloud sync, an account system, analytics, instructor
+countersignature *workflow*). If this request is adjacent to one of those, say which one and why
+this is different — it may already be a deliberate exclusion rather than an oversight.
+
+## Domain-rule check, if relevant
+
+If this touches `lib/domain/` — a new field on `Flight`, a new derived quantity, a new
+jurisdiction — skim CLAUDE.md's five non-negotiable domain rules first. A request that implies
+storing a derived quantity, or a field that only covers one authority's discriminators, needs
+reshaping before it can be built as described.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why. Link the issue(s) this closes. -->
+
+## Checklist
+
+- [ ] Tests added or updated for the change, and mutation-tested where the logic is non-trivial
+      (a key branch was confirmed red before green, not just green)
+- [ ] `dart format --set-exit-if-changed .`, `flutter analyze --fatal-infos`, and
+      `flutter test` all pass locally
+- [ ] `dart run tool/check_layering.dart` and `dart run tool/check_domain_types.dart` pass, if
+      `lib/domain/` was touched
+- [ ] A regulatory citation (`FCL.010`, `§61.51(e)(1)(i)`, `AMC1 FCL.050` column N, ...) is
+      included in a code comment where a line of logic depends on it
+- [ ] No derived quantity was added as a stored column or field — `lib/domain/model/Flight`
+      stores raw facts only (CLAUDE.md rule 1); a new number is a projection, not a field
+- [ ] Every jurisdiction-dependent number rendered in the UI is labelled with its jurisdiction
+      (CLAUDE.md rule 5)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2026 Decades-Design. All rights reserved.
+
+This software and its associated source code, documentation, and design materials are
+proprietary and confidential. No part of this repository may be copied, modified, distributed,
+sublicensed, or used, in whole or in part, without the prior written permission of the copyright
+holder.
+
+No license, express or implied, to any intellectual property rights is granted by the
+availability of this source code in this repository, whether public or private.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,103 @@
-# easa_digital_log
+# EASA Digital Logbook
 
-A new Flutter project.
+A Flutter (iOS + Android) pilot logbook and currency tracker, built for a pilot holding licences
+under **more than one authority** — today EASA (primary) and FAA (secondary), with UK CAA
+planned. The app is the pilot's legal record of flight time, so data integrity is treated as a
+hard requirement throughout.
+
+> **Not yet a substitute for a compliant paper or electronic logbook.** The printed EASA export
+> (AMC1 FCL.050 layout) has not been validated end to end and this app has had no regulatory
+> audit. Do not rely on it as your sole record until the PDF export milestone (M6) is complete
+> and you have verified it against your own requirements.
+
+## What it does
+
+- Stores every flight as **raw facts only** — who was flying, in what capacity, under what
+  conditions — never a precomputed "PIC time" or "night time" column. Every derived quantity
+  (PIC, dual, SPIC, PICUS, night, cross-country, instrument, single/multi-pilot time) is computed
+  at read time, per jurisdiction, from those facts.
+- Supports EASA/UK Part-FCL and FAA Part 61 today, added as **declarative profiles** rather than
+  hardcoded logic, so a third authority (Transport Canada, CASA, ...) is a new YAML file and at
+  most one new primitive function, not a rewrite.
+- Surfaces every jurisdiction's currency status side by side, with an explanation of which
+  flights satisfy each rule — never a bare red or green pill.
+- Exports a printable EASA logbook (AMC1 FCL.050, twelve column groups, landscape A4) once M6
+  lands, with running totals that reconcile exactly across pages.
+
+## Why it's built this way
+
+The full reasoning lives in [`CLAUDE.md`](CLAUDE.md) and the [architecture decision
+records](docs/adr/) — this is the short version:
+
+- **Raw facts only, never a derived quantity** ([ADR-0001](docs/adr/0001-raw-facts-only.md)). A
+  flight row cannot express "PIC time" because whether time counts as PIC depends on which
+  authority is asking. Store the discriminators (command authority, sole manipulator, instructor
+  presence and capacity, countersignature state, ...); derive the number per jurisdiction, per
+  read.
+- **All stored times are UTC** ([ADR-0002](docs/adr/0002-utc-only.md)), enforced by a dedicated
+  `UtcInstant` type — a naive local `DateTime` cannot be constructed in the domain layer at all.
+- **Entries are drafts until exported, then immutable**
+  ([ADR-0003](docs/adr/0003-draft-until-exported.md)). A flight is freely editable until it is
+  first included in a generated PDF; after that, every change appends a retained revision rather
+  than overwriting the record.
+- **Currency rules are versioned data, not Dart logic**
+  ([ADR-0004](docs/adr/0004-rules-as-data.md)), evaluated by one generic engine against named,
+  tested primitive functions.
+- **Jurisdictions are profiles, not an enum.** They form a lineage — UK Part-FCL is retained EU
+  law the CAA amends independently, modelled as `extends: eu.easa.part-fcl` with overrides —
+  rather than a flat set of hardcoded cases.
+
+See `docs/jurisdiction-matrix.md` for the rule-by-rule EASA/FAA/UK CAA comparison this is built
+against, and `docs/amc1-fcl050-layout.md` for the printed logbook sheet the export reproduces.
+
+## Deliberately out of scope (for now)
+
+Background flight recording (GPS-based), cloud sync, an account system, analytics, and
+instructor countersignature *workflow* (the data model carries countersignature state; routing a
+signature request to an instructor does not exist yet). None of these are rejected outright —
+they're just not being built until there's a reason to. Triage a feature request against this
+list and against the milestone plan before assuming it's missing by oversight.
+
+## Building and running
+
+This is a solo project built with [puro](https://puro.dev/) rather than a bare Flutter SDK
+install, and the `flutter`/`dart` shims it installs work under **PowerShell only** — not Git
+Bash, not cmd.exe.
+
+```powershell
+flutter pub get
+
+# Code generation (freezed models). Run this after pulling changes that touch
+# lib/domain/model/, and after editing any @freezed class yourself.
+flutter pub run build_runner build
+
+# Format, analyze, and the two custom architecture guards — all four also run in CI.
+dart format --set-exit-if-changed .
+flutter analyze --fatal-infos
+dart run tool/check_layering.dart      # lib/domain/ must be pure Dart, no Flutter imports
+dart run tool/check_domain_types.dart  # lib/domain/ must never construct a naive DateTime
+
+flutter test
+```
+
+An optional pre-commit hook mirrors the fast checks above (not the full test suite) so failures
+surface before you push rather than after — see [`tool/hooks/`](tool/hooks/) to install it. It is
+opt-in; nothing breaks if you skip it, since CI runs the same checks regardless.
+
+A new contributor should be able to clone the repo, run the commands above, and have a clean,
+fully tested build using only this README.
+
+## Project layout
+
+```
+lib/
+  domain/   Pure Dart. No Flutter imports, no I/O. Unit tested. See CLAUDE.md.
+  data/     Drift/SQLite persistence, repositories, revision history.
+  io/       Import/export adapters (ForeFlight, Garmin, CSV).
+  export/   PDF generation (AMC1 FCL.050 layout).
+  ui/       Flutter widgets, Riverpod providers.
+```
+
+`docs/adr/` records decisions that were genuinely hard to reverse; a decision that can live in a
+code comment usually does instead — see `CLAUDE.md` for the full set of project conventions,
+including the non-negotiable domain rules that govern anything under `lib/domain/`.

--- a/tool/hooks/README.md
+++ b/tool/hooks/README.md
@@ -1,0 +1,20 @@
+# Pre-commit hook (opt-in)
+
+Mirrors the fast checks `.github/workflows/ci.yaml` runs on every PR — formatting, analysis, and
+the two domain guards (`check_layering.dart`, `check_domain_types.dart`). Deliberately skips
+`flutter test`; that stays CI's job, so the hook stays fast enough to be tolerable.
+
+Nothing breaks if you don't install this. CI runs the same checks either way — this only moves
+the failure earlier, from push time to commit time.
+
+## Install
+
+```powershell
+git config core.hooksPath tool/hooks
+```
+
+## Uninstall
+
+```powershell
+git config --unset core.hooksPath
+```

--- a/tool/hooks/pre-commit
+++ b/tool/hooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Opt-in pre-commit hook (#10). Git invokes this via its own bundled sh even
+# on Windows, so it shells out to PowerShell immediately -- `flutter`/`dart`
+# are puro shims that only resolve there, not under this sh (CLAUDE.md).
+# The real check logic lives in tool/pre_commit.ps1.
+#
+# Install: git config core.hooksPath tool/hooks
+# Uninstall: git config --unset core.hooksPath
+# See tool/hooks/README.md.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$REPO_ROOT/tool/pre_commit.ps1"

--- a/tool/pre_commit.ps1
+++ b/tool/pre_commit.ps1
@@ -1,0 +1,32 @@
+# Opt-in pre-commit check logic (#10). Mirrors the fast checks
+# .github/workflows/ci.yaml runs on every PR -- format, analyze, and the two
+# domain guards -- deliberately skipping `flutter test`, which stays CI's
+# job: "fast enough to be tolerable" is the whole point of a local hook.
+#
+# Invoked through PowerShell on purpose, not run directly by git's hook
+# shell: `flutter`/`dart` here are puro shims that only resolve under
+# PowerShell (CLAUDE.md), so tool/hooks/pre-commit shells out to this file
+# rather than calling them itself.
+
+$ErrorActionPreference = "Stop"
+$repoRoot = git rev-parse --show-toplevel
+Set-Location $repoRoot
+
+Write-Host "pre-commit: checking formatting..."
+dart format --set-exit-if-changed .
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "pre-commit: analyzing..."
+flutter analyze --fatal-infos
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "pre-commit: checking domain layering..."
+dart run tool/check_layering.dart
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "pre-commit: checking domain types..."
+dart run tool/check_domain_types.dart
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "pre-commit: all checks passed."
+exit 0


### PR DESCRIPTION
## Summary
Remaining M0 issues that didn't need a product decision, plus the LICENSE choice you made (proprietary/all rights reserved). #1 (scaffold identifiers) is left open — it needs a real bundle identifier and app display name from you.

- **#2** — a real README: what the app is, the load-bearing design decisions with pointers to CLAUDE.md/ADRs, build/run instructions, non-goals, and a compliance disclaimer.
- **#9** — LICENSE (proprietary, all rights reserved), a bug report template that asks for jurisdiction and raw flight facts before expected-vs-actual, a feature request template that checks against CLAUDE.md's non-goals list, and a PR checklist mirroring this repo's actual conventions.
- **#10** — an opt-in pre-commit hook mirroring the fast CI checks (format/analyze/layering/domain-types), skipping the full test suite to stay fast. `tool/hooks/pre-commit` is a `#!/bin/sh` script (git invokes hooks via its own bundled sh even on Windows) that immediately shells out to `tool/pre_commit.ps1` through PowerShell, since `flutter`/`dart` are puro shims that only resolve there. `.gitattributes` forces LF line endings on the hook script so `core.autocrlf` can't silently break its shebang on a Windows checkout.

Closes #2
Closes #9
Closes #10

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart`
- [x] `flutter test` (290 passing)
- [x] Ran the pre-commit hook directly end to end: green path passes all four checks; deliberately introduced a formatting violation and confirmed the hook fails with a non-zero exit before the later checks run, then reverted
- [x] Confirmed the hook script's executable bit (100755) and LF line endings actually landed in the git object, not just the working tree