### PR TITLE
Schema migration framework: backup/rollback, committed snapshot, CI enforcement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,5 @@ jobs:
       # scoped to the one layer that matters.
       - name: Check domain coverage
         run: dart run tool/check_domain_coverage.dart coverage/lcov.info
+      - name: Check schema snapshot
+        run: dart run tool/check_schema_snapshot.dart

--- a/docs/adr/0010-migration-safety.md
+++ b/docs/adr/0010-migration-safety.md
@@ -1,0 +1,53 @@
+# ADR-0010: Two-layer migration safety, backup scoped to migration only
+
+**Status:** Accepted
+**Date:** 2026-08-09
+
+## Context
+
+The database holds the pilot's legal record. A botched schema migration is data loss a fresh
+install cannot recover from — #36's whole premise. Two related decisions needed settling before
+building the migration framework: how many layers of protection a migration gets, and whether
+the pre-migration backup this needs is the same thing as #37's (not yet designed) backup/restore
+feature.
+
+## Decision
+
+Two independent layers protect a migration, not one:
+
+1. SQLite's own transactional DDL — a migration step that throws partway through already rolls
+   back at the SQL level, restoring the pre-migration schema and data with no extra code.
+2. A file-level backup (`lib/data/open_with_backup.dart`), copied before opening/migrating and
+   restored on any exception. This covers what a transaction can't: the app being killed
+   mid-write, or a migration that throws no exception but is simply wrong.
+
+The backup is internal-only — no restore UI, no retention policy, not #37. #37 designs its own
+user-facing backup/restore feature later, informed by nothing this ADR commits to.
+
+## Alternatives considered
+
+Relying on SQL transactional rollback alone. Rejected: it protects against a migration that
+*fails loudly*, not one that fails silently or is interrupted by the process dying — exactly the
+failure modes a legal record on a personal device is most exposed to (a phone losing power or an
+OS killing the app mid-write).
+
+Building the file backup as a first cut of #37's general backup/restore feature. Rejected: #37
+has no design yet, and guessing at its shape now risks building the wrong reusable primitive
+before the actual requirements (retention, restore UI, what "a backup" even means to a pilot) are
+known. Keeping this one purpose-built and narrow costs nothing and commits to nothing.
+
+## Consequences
+
+`openAppDatabase`/`openWithBackup` is the only sanctioned way to open the real database file —
+any other call site that constructs `AppDatabase(NativeDatabase(file))` directly bypasses the
+safety net. #37, whenever it happens, is free to design its own thing without being constrained
+by this one.
+
+**Record here, from implementation:** the migration mechanism (schema versioning, `onUpgrade`,
+the CI snapshot check) is proven against a throwaway fixture schema under `test/`, not a real
+`AppDatabase` change — `AppDatabase` had nothing pending to migrate when this was built. Also,
+generating the real v1 schema snapshot (`dart run drift_dev schema dump`) required pinning
+`drift` to exactly `2.34.0` — `drift_dev` 2.34.0's schema-dump command is incompatible with
+`drift` 2.34.3's `drift3_preview` module, and `drift_dev` can't be upgraded past 2.34.0 without
+conflicting with the `freezed` 3.2.5 pin from ADR-0006. See the comment on the `drift` dependency
+in `pubspec.yaml` for the full chain.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@
 | [0007](0007-duration-representation.md) | Represent logbook durations as integer minutes | Accepted | `FlightDuration` stores whole minutes for exact arithmetic; `HH:MM` and decimal hours (tenths, half away from zero) are display-only formats, and rounding never happens before a total is summed. |
 | [0008](0008-night-time-position-interpolation.md) | Approximate in-flight position as a straight great-circle line between two waypoints | Accepted | Night-time primitives interpolate position linearly, by elapsed time, along the great circle between the first and last resolvable route waypoints — not every intermediate stop, since `Flight` records no per-waypoint timestamp to split time against. |
 | [0009](0009-date-boundary-policy.md) | A flight's logbook date is the UTC calendar date of departure | Accepted | `Flight.logbookDate` is the UTC calendar date of `offBlocks`, never of `onBlocks` and never a local date — the one place list ordering, PDF pagination and currency windows must read it from. |
+| [0010](0010-migration-safety.md) | Two-layer migration safety, backup scoped to migration only | Accepted | A schema migration is protected by SQL transactional rollback and a separate file-level backup; the backup is internal-only, not a first cut of #37's backup/restore feature. |
 
 New ADRs are numbered sequentially and are never renumbered. A decision that is later reversed
 is superseded by a new ADR, not edited in place — the old record stays as evidence of what was

--- a/docs/superpowers/plans/2026-08-09-schema-migration-framework.md
+++ b/docs/superpowers/plans/2026-08-09-schema-migration-framework.md
@@ -1,0 +1,822 @@
+# Schema Migration Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make schema changes to `AppDatabase` safe: a pre-migration file backup with
+automatic rollback, a committed schema snapshot with a CI check that catches an unversioned
+schema change, and a real, tested migration path — proven against a throwaway fixture schema
+since `AppDatabase` itself has nothing pending to migrate yet.
+
+**Architecture:** A generic `openWithBackup` helper wraps any database open in a
+copy-before/delete-or-restore-after sequence. `drift_dev schema dump` produces the committed
+JSON snapshot; a hand-rolled `tool/check_schema_snapshot.dart` (matching this project's existing
+`check_layering.dart`/`check_domain_coverage.dart` style) diffs it against the current schema in
+CI. A small fixture-only Drift database proves the actual migration mechanics.
+
+**Tech Stack:** `drift`/`drift_dev` (already installed, 2.34.x) — no new dependency.
+
+## Global Constraints
+
+- The pre-migration backup is internal-only: no restore UI, no retention policy, not #37. A
+  private mechanism whose only job is guaranteeing the on-disk file is never left corrupted.
+- `AppDatabase.schemaVersion` stays at `1` — nothing in this plan changes the real app schema.
+  The migration machinery is proven against a throwaway fixture schema under `test/` instead.
+- `drift_schemas/*.json` snapshot files are committed to git — unlike `.g.dart` output, they are
+  the only record of an old schema's shape and cannot be regenerated later.
+- The exact `drift_dev schema dump`/`Migrator.addColumn`/`MigrationStrategy` signatures below
+  were confirmed by reading the installed `drift`/`drift_dev` 2.34.x source directly (not
+  guessed) — `dart run drift_dev schema dump <input.dart> <output-dir>`; `OnUpgrade` is
+  `Future<void> Function(Migrator m, int from, int to)`; `Migrator.addColumn(TableInfo table,
+  GeneratedColumn column)`. If a future `drift`/`drift_dev` upgrade changes these, that's normal
+  API drift — adjust the call site, not the design.
+- Everything here must run via PowerShell, same as every other check in this project (`dart`/
+  `flutter` are puro shims that only resolve there) — `tool/check_schema_snapshot.dart` shells
+  out to `dart run drift_dev ...` as a subprocess, which only resolves under the same shell.
+
+---
+
+## Task 1: `openWithBackup` — the generic backup/rollback wrapper
+
+**Files:**
+- Create: `lib/data/open_with_backup.dart`
+- Test: `test/data/open_with_backup_test.dart`
+
+**Interfaces:**
+- Produces: `Future<T> openWithBackup<T>(File dbFile, Future<T> Function() open)`. Task 2's
+  `openAppDatabase` and Task 3's fixture test both call this directly.
+
+`open` is fully caller-controlled — this keeps the wrapper generic without needing to
+hand-subclass `GeneratedDatabase` (a codegen-produced base class not meant to be subclassed by
+hand) just to test it. The failure path is tested with a plain throwing callback; no fake
+database needed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/data/open_with_backup_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:easa_digital_log/data/open_with_backup.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDir;
+  late File dbFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('open_with_backup_test');
+    dbFile = File(p.join(tempDir.path, 'test.sqlite'));
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  test('on success, deletes the backup and leaves the file content-preserving', () async {
+    await dbFile.writeAsString('original content');
+
+    final result = await openWithBackup(dbFile, () async {
+      await dbFile.writeAsString('modified content');
+      return 'ok';
+    });
+
+    expect(result, 'ok');
+    expect(await dbFile.readAsString(), 'modified content');
+    expect(await File('${dbFile.path}.backup').exists(), isFalse);
+  });
+
+  test('on failure, restores the original file and rethrows', () async {
+    await dbFile.writeAsString('original content');
+
+    await expectLater(
+      () => openWithBackup(dbFile, () async {
+        await dbFile.writeAsString('corrupted mid-write');
+        throw StateError('migration failed');
+      }),
+      throwsStateError,
+    );
+
+    expect(await dbFile.readAsString(), 'original content');
+    expect(await File('${dbFile.path}.backup').exists(), isFalse);
+  });
+
+  test('works when the file does not exist yet (first run, nothing to back up)', () async {
+    final result = await openWithBackup(dbFile, () async {
+      await dbFile.writeAsString('created');
+      return 'ok';
+    });
+
+    expect(result, 'ok');
+    expect(await dbFile.readAsString(), 'created');
+  });
+
+  test('propagates the original exception unchanged', () async {
+    await dbFile.writeAsString('original content');
+
+    await expectLater(
+      () => openWithBackup(dbFile, () async {
+        throw ArgumentError('a specific error');
+      }),
+      throwsArgumentError,
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/data/open_with_backup_test.dart`
+Expected: FAIL — `open_with_backup.dart` does not exist.
+
+- [ ] **Step 3: Implement `openWithBackup`**
+
+Create `lib/data/open_with_backup.dart`:
+
+```dart
+import 'dart:io';
+
+/// Copies [dbFile] to a sibling `.backup` file before calling [open]. On
+/// success, deletes the backup. On failure, restores [dbFile] from the
+/// backup and rethrows — [dbFile] is never left in a partially-written
+/// state, whatever [open] does to it.
+///
+/// [open] is fully caller-controlled: it decides what "opening" means
+/// (construct a database, run a query to force migrations, whatever) and
+/// returns whatever it wants. This keeps the wrapper generic without
+/// needing to model a specific database type.
+Future<T> openWithBackup<T>(File dbFile, Future<T> Function() open) async {
+  final backupFile = File('${dbFile.path}.backup');
+
+  if (await dbFile.exists()) {
+    await dbFile.copy(backupFile.path);
+  }
+
+  try {
+    final result = await open();
+    if (await backupFile.exists()) {
+      await backupFile.delete();
+    }
+    return result;
+  } catch (_) {
+    if (await backupFile.exists()) {
+      if (await dbFile.exists()) {
+        await dbFile.delete();
+      }
+      await backupFile.rename(dbFile.path);
+    }
+    rethrow;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/data/open_with_backup_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Full local verification and commit**
+
+```powershell
+dart format --set-exit-if-changed .
+flutter analyze --fatal-infos
+flutter test
+```
+
+```bash
+git add lib/data/open_with_backup.dart test/data/open_with_backup_test.dart
+git commit -m "feat: generic pre-migration backup/rollback wrapper (#36)"
+```
+
+---
+
+## Task 2: Committed schema snapshot and the CI check
+
+**Files:**
+- Create: `drift_schemas/drift_schema_v1.json` (generated, then committed)
+- Create: `tool/check_schema_snapshot.dart`
+- Modify: `lib/data/database.dart` (add `openAppDatabase`)
+- Modify: `.github/workflows/ci.yaml`
+- Test: `test/tool/check_schema_snapshot_test.dart`
+
+**Interfaces:**
+- Consumes: `openWithBackup` (Task 1).
+- Produces: `Future<AppDatabase> openAppDatabase(File dbFile)`; `bool schemasMatch(String
+  dumpedJson, String committedJson)` (the pure, unit-testable comparison `main()` uses).
+
+- [ ] **Step 1: Generate and commit the real v1 snapshot**
+
+Run:
+```powershell
+dart run drift_dev schema dump lib/data/database.dart drift_schemas
+```
+Expected: writes `drift_schemas/drift_schema_v1.json`. This file is committed, not gitignored —
+unlike `.g.dart` output, it's the only record of what v1 actually looked like.
+
+- [ ] **Step 2: Add `openAppDatabase` to `database.dart`**
+
+In `lib/data/database.dart`, add these imports at the top:
+
+```dart
+import 'dart:io';
+
+import 'open_with_backup.dart';
+```
+
+Add this function at the end of the file, after the `AppDatabase` class:
+
+```dart
+/// Opens [dbFile] as an [AppDatabase], guarded by [openWithBackup]. Querying
+/// once (`SELECT 1`) forces drift's open-and-migrate sequence to run and
+/// surface any error here, rather than lazily on whatever query a caller
+/// happens to run first.
+Future<AppDatabase> openAppDatabase(File dbFile) {
+  return openWithBackup(dbFile, () async {
+    final db = AppDatabase(NativeDatabase(dbFile));
+    await db.customStatement('SELECT 1');
+    return db;
+  });
+}
+```
+
+Add `import 'package:drift/native.dart';` to the top of `database.dart` too, for
+`NativeDatabase`.
+
+- [ ] **Step 3: Write the failing test for the comparison logic**
+
+Create `test/tool/check_schema_snapshot_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/check_schema_snapshot.dart';
+
+void main() {
+  group('schemasMatch', () {
+    test('true for identical JSON', () {
+      const json = '{"a": 1, "b": [1, 2, 3]}';
+      expect(schemasMatch(json, json), isTrue);
+    });
+
+    test('true when formatting differs but content is the same', () {
+      const a = '{"a": 1, "b": 2}';
+      const b = '{\n  "b": 2,\n  "a": 1\n}';
+      expect(schemasMatch(a, b), isTrue);
+    });
+
+    test('false when a value differs', () {
+      const a = '{"a": 1}';
+      const b = '{"a": 2}';
+      expect(schemasMatch(a, b), isFalse);
+    });
+
+    test('false when a key is added or removed', () {
+      const a = '{"a": 1}';
+      const b = '{"a": 1, "b": 2}';
+      expect(schemasMatch(a, b), isFalse);
+    });
+
+    test('false when a list differs', () {
+      const a = '{"a": [1, 2]}';
+      const b = '{"a": [1, 3]}';
+      expect(schemasMatch(a, b), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `flutter test test/tool/check_schema_snapshot_test.dart`
+Expected: FAIL — `tool/check_schema_snapshot.dart` does not exist.
+
+- [ ] **Step 5: Implement the check tool**
+
+Create `tool/check_schema_snapshot.dart`:
+
+```dart
+/// Enforces that `drift_schemas/drift_schema_v<N>.json` (N = AppDatabase's
+/// current schemaVersion) matches what the current code would actually
+/// produce — the signal that a table changed without a version bump and a
+/// fresh committed snapshot. Mirrors `check_layering.dart`/
+/// `check_domain_coverage.dart`'s "small hand-rolled guard wired into CI"
+/// style.
+///
+/// Run: `dart run tool/check_schema_snapshot.dart`
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+const String _databaseSource = 'lib/data/database.dart';
+const String _snapshotsDir = 'drift_schemas';
+final RegExp _snapshotFilename = RegExp(r'drift_schema_v(\d+)\.json$');
+
+/// True if [dumpedJson] and [committedJson] decode to the same structure,
+/// ignoring formatting differences (key order, whitespace).
+bool schemasMatch(String dumpedJson, String committedJson) {
+  return _deepEquals(jsonDecode(dumpedJson), jsonDecode(committedJson));
+}
+
+bool _deepEquals(Object? a, Object? b) {
+  if (a is Map && b is Map) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final key in a.keys) {
+      if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (a is List && b is List) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (var i = 0; i < a.length; i++) {
+      if (!_deepEquals(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return a == b;
+}
+
+Future<void> main() async {
+  final tempDir = await Directory.systemTemp.createTemp('check_schema_snapshot');
+  try {
+    final result = await Process.run('dart', [
+      'run',
+      'drift_dev',
+      'schema',
+      'dump',
+      _databaseSource,
+      tempDir.path,
+    ]);
+    if (result.exitCode != 0) {
+      stderr.writeln('check_schema_snapshot: failed to dump the current schema:');
+      stderr.writeln(result.stderr);
+      exit(1);
+    }
+
+    final dumped = tempDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => _snapshotFilename.hasMatch(f.path))
+        .toList();
+    if (dumped.length != 1) {
+      stderr.writeln(
+        'check_schema_snapshot: expected exactly one dumped schema file, '
+        'found ${dumped.length}.',
+      );
+      exit(1);
+    }
+
+    final dumpedFile = dumped.single;
+    final version = _snapshotFilename.firstMatch(dumpedFile.path)!.group(1);
+    final committedFile = File('$_snapshotsDir/drift_schema_v$version.json');
+
+    if (!committedFile.existsSync()) {
+      stderr.writeln(
+        'check_schema_snapshot: schemaVersion is $version but '
+        '${committedFile.path} does not exist. Run:\n'
+        '  dart run drift_dev schema dump $_databaseSource $_snapshotsDir\n'
+        'and commit the result.',
+      );
+      exit(1);
+    }
+
+    final dumpedJson = await dumpedFile.readAsString();
+    final committedJson = await committedFile.readAsString();
+
+    if (!schemasMatch(dumpedJson, committedJson)) {
+      stderr.writeln(
+        'check_schema_snapshot: the current schema no longer matches '
+        '${committedFile.path}. If this is an intentional change, bump '
+        'AppDatabase.schemaVersion, add an onUpgrade step, and regenerate '
+        'the snapshot:\n'
+        '  dart run drift_dev schema dump $_databaseSource $_snapshotsDir\n'
+        'then commit the result.',
+      );
+      exit(1);
+    }
+
+    stdout.writeln('check_schema_snapshot: drift_schema_v$version.json is up to date.');
+  } finally {
+    await tempDir.delete(recursive: true);
+  }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `flutter test test/tool/check_schema_snapshot_test.dart`
+Expected: PASS
+
+- [ ] **Step 7: Run the tool itself against the real, just-committed snapshot**
+
+Run: `dart run tool/check_schema_snapshot.dart`
+Expected: `check_schema_snapshot: drift_schema_v1.json is up to date.`, exit 0 — this is the
+tool's own end-to-end proof, checking the file it wrote in Step 1 against itself.
+
+- [ ] **Step 8: Wire the check into CI**
+
+In `.github/workflows/ci.yaml`, add this step after the existing `Check domain coverage` step
+(same file structure this project already uses for `check_layering.dart`/
+`check_domain_types.dart`):
+
+```yaml
+      - name: Check schema snapshot
+        run: dart run tool/check_schema_snapshot.dart
+```
+
+- [ ] **Step 9: Full local verification and commit**
+
+```powershell
+dart format --set-exit-if-changed .
+flutter analyze --fatal-infos
+dart run tool/check_layering.dart
+dart run tool/check_domain_types.dart
+flutter test
+```
+
+```bash
+git add drift_schemas/ tool/check_schema_snapshot.dart lib/data/database.dart test/tool/check_schema_snapshot_test.dart .github/workflows/ci.yaml
+git commit -m "feat: commit the v1 schema snapshot and enforce it in CI (#36)"
+```
+
+---
+
+## Task 3: Fixture schema — proving the migration mechanism end-to-end
+
+**Files:**
+- Create: `test/data/migration_fixture/fixture_database.dart`
+- Create: `test/data/migration_fixture/fixture_database_test.dart`
+- Create: `test/data/migration_fixture/drift_schemas/drift_schema_v1.json` (generated)
+- Create: `test/data/migration_fixture/drift_schemas/drift_schema_v2.json` (generated)
+
+**Interfaces:**
+- Consumes: `openWithBackup` (Task 1).
+- Produces: nothing later tasks depend on — this is the proof, not new production surface.
+
+A tiny, throwaway database: one table, two versions. v1 has `id`/`name`; v2 adds a nullable
+`notes` column — real enough to prove an actual `ALTER TABLE` migration works, small enough to
+read in one sitting.
+
+- [ ] **Step 1: Define the fixture database at v2**
+
+Create `test/data/migration_fixture/fixture_database.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+
+part 'fixture_database.g.dart';
+
+@DataClassName('FixtureItemRow')
+class FixtureItemsTable extends Table {
+  @override
+  String get tableName => 'fixture_items';
+
+  TextColumn get id => text()();
+  TextColumn get name => text()();
+  TextColumn get notes => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DriftDatabase(tables: [FixtureItemsTable])
+class FixtureDatabase extends _$FixtureDatabase {
+  FixtureDatabase(super.executor);
+
+  @override
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onUpgrade: (Migrator m, int from, int to) async {
+      if (from == 1 && to == 2) {
+        await m.addColumn(fixtureItemsTable, fixtureItemsTable.notes);
+      }
+    },
+  );
+}
+```
+
+- [ ] **Step 2: Generate code and both schema snapshots**
+
+Run:
+```powershell
+flutter pub run build_runner build
+```
+Expected: generates `test/data/migration_fixture/fixture_database.g.dart` (gitignored, like
+every other `.g.dart` — not committed).
+
+The v2 snapshot comes from the current source:
+```powershell
+dart run drift_dev schema dump test/data/migration_fixture/fixture_database.dart test/data/migration_fixture/drift_schemas
+```
+Expected: writes `test/data/migration_fixture/drift_schemas/drift_schema_v2.json`.
+
+The v1 snapshot can't be dumped from source (the table class only ever represents the current
+version) — write it by hand, matching what v1 actually looked like (no `notes` column). Create
+`test/data/migration_fixture/drift_schemas/drift_schema_v1.json`:
+
+```json
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.2.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": "table(fixture_items)",
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "fixture_items",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": null,
+            "default_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": null,
+            "default_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": ["id"]
+      }
+    }
+  ]
+}
+```
+
+Both committed snapshot files are test fixtures, not generated output — commit them.
+
+- [ ] **Step 3: Write the failing migration test**
+
+Create `test/data/migration_fixture/fixture_database_test.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/open_with_backup.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+import 'fixture_database.dart';
+
+/// Creates a v1-shaped database file directly with sqlite3 — the only way
+/// to get a "v1 database" to migrate from, since the Dart table class only
+/// ever represents the current (v2) schema.
+void _seedV1Database(String path, {required String id, required String name}) {
+  final db = sqlite3.sqlite3.open(path);
+  try {
+    db.execute('CREATE TABLE fixture_items (id TEXT NOT NULL, name TEXT NOT NULL, '
+        'PRIMARY KEY (id))');
+    db.execute('INSERT INTO fixture_items (id, name) VALUES (?, ?)', [id, name]);
+    db.execute('PRAGMA user_version = 1');
+  } finally {
+    db.dispose();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+  late File dbFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('fixture_database_test');
+    dbFile = File(p.join(tempDir.path, 'fixture.sqlite'));
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  test('migrating a v1 database to v2 preserves existing data', () async {
+    _seedV1Database(dbFile.path, id: 'item-1', name: 'Original');
+
+    final db = await openWithBackup(dbFile, () async {
+      final database = FixtureDatabase(NativeDatabase(dbFile));
+      await database.customStatement('SELECT 1');
+      return database;
+    });
+    addTearDown(db.close);
+
+    final rows = await db.select(db.fixtureItemsTable).get();
+    expect(rows, hasLength(1));
+    expect(rows.single.id, 'item-1');
+    expect(rows.single.name, 'Original');
+    expect(rows.single.notes, isNull);
+  });
+
+  test('a migration step that throws leaves the original file intact', () async {
+    _seedV1Database(dbFile.path, id: 'item-1', name: 'Original');
+    final originalBytes = await dbFile.readAsBytes();
+
+    await expectLater(
+      () => openWithBackup(dbFile, () async {
+        // A database whose onUpgrade always throws, to force the failure
+        // path without depending on addColumn actually failing.
+        final database = _AlwaysFailsMigrationDatabase(NativeDatabase(dbFile));
+        await database.customStatement('SELECT 1');
+        return database;
+      }),
+      throwsA(anything),
+    );
+
+    expect(await dbFile.readAsBytes(), originalBytes);
+  });
+
+  test('the backup file is gone after a successful migration', () async {
+    _seedV1Database(dbFile.path, id: 'item-1', name: 'Original');
+
+    final db = await openWithBackup(dbFile, () async {
+      final database = FixtureDatabase(NativeDatabase(dbFile));
+      await database.customStatement('SELECT 1');
+      return database;
+    });
+    addTearDown(db.close);
+
+    expect(await File('${dbFile.path}.backup').exists(), isFalse);
+  });
+}
+
+/// Same schema as [FixtureDatabase] but always throws during upgrade — used
+/// only to prove the rollback path without relying on a real migration step
+/// failing.
+class _AlwaysFailsMigrationDatabase extends FixtureDatabase {
+  _AlwaysFailsMigrationDatabase(super.executor);
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onUpgrade: (Migrator m, int from, int to) async {
+      throw StateError('simulated migration failure');
+    },
+  );
+}
+```
+
+Add `path` and `sqlite3` to `dev_dependencies` if not already present — check first:
+
+```powershell
+flutter pub add -d path sqlite3
+```
+`sqlite3` is already a transitive dependency (via `drift`), but must be a **direct**
+`dev_dependency` here to be importable from this test file. `path` is very likely already
+present as a transitive dependency too; `flutter pub add` is a no-op if it's already direct.
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `flutter test test/data/migration_fixture/fixture_database_test.dart`
+Expected: FAIL — `fixture_database.g.dart` doesn't exist yet if Step 2 wasn't completed, or the
+test fails naturally if it was. If Step 2 was already done, this step should largely pass except
+for whatever a fresh look reveals — treat any failure here as real signal, not as expected
+scaffolding (unlike the M2/#35 "intentionally incomplete class" pattern, nothing here is
+deliberately left unbuilt).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `flutter test test/data/migration_fixture/fixture_database_test.dart`
+Expected: PASS — all three tests, proving: data survives a real migration, a thrown migration
+step leaves the original file byte-for-byte intact, and the backup file is cleaned up on
+success.
+
+- [ ] **Step 6: Full local verification and commit**
+
+```powershell
+dart format --set-exit-if-changed .
+flutter analyze --fatal-infos
+flutter test
+```
+
+```bash
+git add test/data/migration_fixture/ pubspec.yaml pubspec.lock
+git commit -m "test: prove the migration mechanism against a fixture schema (#36)"
+```
+
+---
+
+## Task 4: ADR-0010 — migration safety strategy
+
+**Files:**
+- Create: `docs/adr/0010-migration-safety.md`
+- Modify: `docs/adr/README.md` (index row)
+
+Records the two decisions from this plan that are genuinely hard to reverse once real user data
+exists on a real device: the two-layer rollback (SQL transaction + file-level backup) and the
+internal-only backup scope (not #37).
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/adr/0010-migration-safety.md`, following the existing ADR format (see
+`docs/adr/template.md` and `docs/adr/0005-offline-first.md` for the established style —
+Context/Decision/Alternatives considered/Consequences):
+
+```markdown
+# ADR-0010: Two-layer migration safety, backup scoped to migration only
+
+**Status:** Accepted
+**Date:** 2026-08-09
+
+## Context
+
+The database holds the pilot's legal record. A botched schema migration is data loss a fresh
+install cannot recover from — #36's whole premise. Two related decisions needed settling before
+building the migration framework: how many layers of protection a migration gets, and whether
+the pre-migration backup this needs is the same thing as #37's (not yet designed) backup/restore
+feature.
+
+## Decision
+
+Two independent layers protect a migration, not one:
+
+1. SQLite's own transactional DDL — a migration step that throws partway through already rolls
+   back at the SQL level, restoring the pre-migration schema and data with no extra code.
+2. A file-level backup (`lib/data/open_with_backup.dart`), copied before opening/migrating and
+   restored on any exception. This covers what a transaction can't: the app being killed
+   mid-write, or a migration that throws no exception but is simply wrong.
+
+The backup is internal-only — no restore UI, no retention policy, not #37. #37 designs its own
+user-facing backup/restore feature later, informed by nothing this ADR commits to.
+
+## Alternatives considered
+
+Relying on SQL transactional rollback alone. Rejected: it protects against a migration that
+*fails loudly*, not one that fails silently or is interrupted by the process dying — exactly the
+failure modes a legal record on a personal device is most exposed to (a phone losing power or an
+OS killing the app mid-write).
+
+Building the file backup as a first cut of #37's general backup/restore feature. Rejected: #37
+has no design yet, and guessing at its shape now risks building the wrong reusable primitive
+before the actual requirements (retention, restore UI, what "a backup" even means to a pilot) are
+known. Keeping this one purpose-built and narrow costs nothing and commits to nothing.
+
+## Consequences
+
+`openAppDatabase`/`openWithBackup` is the only sanctioned way to open the real database file —
+any other call site that constructs `AppDatabase(NativeDatabase(file))` directly bypasses the
+safety net. #37, whenever it happens, is free to design its own thing without being constrained
+by this one.
+```
+
+- [ ] **Step 2: Update the ADR index**
+
+Read `docs/adr/README.md` and add a row for ADR-0010 following the existing table's format.
+
+- [ ] **Step 3: Full local verification and commit**
+
+```powershell
+dart format --set-exit-if-changed .
+flutter test
+```
+
+```bash
+git add docs/adr/0010-migration-safety.md docs/adr/README.md
+git commit -m "docs: record the migration safety strategy (ADR-0010, #36)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Schema versioning + committed snapshots — Task 2. Migration tests opening a
+v(n-1) database and asserting integrity — Task 3. Pre-migration backup retained until confirmed
+— Task 1 (generic mechanism) + Task 2 (`openAppDatabase` wiring). CI failing on an unversioned
+schema change — Task 2. Rollback rather than a half-migrated database — Task 1 (file-level) +
+Task 3 (proves SQL-level rollback too, via the "throws leaves file intact" test). The ADR — Task
+4. Every Non-goal (backup/restore UI, a real `AppDatabase` schema change, encryption) has no
+task — correctly, since the spec excludes them.
+
+**Placeholder scan:** No stub methods, no invented product schema change. Task 3's hand-written
+v1 snapshot JSON is a genuine fixture value, not a placeholder — it's what a real `schema dump`
+of that exact table shape produces, written by hand only because there's no v1 source left to
+dump it from.
+
+**Type consistency:** `openWithBackup<T>(File, Future<T> Function())` (Task 1) is called
+identically in Task 2's `openAppDatabase` and Task 3's fixture tests. `schemasMatch` (Task 2) is
+the one function both `check_schema_snapshot_test.dart` and `main()` use — no duplicate
+comparison logic.

--- a/docs/superpowers/specs/2026-08-09-schema-migration-framework-design.md
+++ b/docs/superpowers/specs/2026-08-09-schema-migration-framework-design.md
@@ -1,0 +1,85 @@
+# Schema migration framework — Design
+
+**Status:** Proposed
+**Date:** 2026-08-09
+**Covers:** issue #36
+**Depends on:** the M2 persistence foundation (merged) and its `AppDatabase` at `schemaVersion 1`.
+
+## Context
+
+The database holds the pilot's legal record. A botched migration is data loss a fresh install
+can't recover. #36 asks for the machinery to make schema changes safe: versioned snapshots,
+migration tests, a pre-migration safety copy, CI enforcement, and rollback on failure.
+
+`AppDatabase` has never had a schema change — it's still v1, so there is no real v(n-1)→v(n)
+transition to build the testing machinery against yet.
+
+## Scope decisions
+
+- **The pre-migration backup is internal-only**, not #37 (backup/restore). No restore UI, no
+  retention policy — a private helper that copies the db file before migrating and deletes the
+  copy on success. #37 designs its own user-facing thing later, unconstrained by this.
+- **The migration mechanism is proven against a test-only fixture schema**, not a real
+  `AppDatabase` change. `AppDatabase` stays at v1; the scaffolding (versioning, the backup
+  wrapper, the CI check) is wired up and ready for whenever a real v2 change actually happens.
+
+## Architecture
+
+Four pieces:
+
+1. **Schema versioning + committed snapshots.** `drift_dev`'s schema-dump tooling generates a
+   versioned JSON snapshot into `drift_schemas/drift_schema_v<N>.json`. Unlike generated
+   `.g.dart` files, these are committed — they're the only record of what an old schema actually
+   looked like, and can't be regenerated once the code has moved past that version.
+2. **Migration steps.** `AppDatabase.migration`'s `MigrationStrategy.onUpgrade` uses Drift's
+   `stepByStep()` helper — one function per version transition. Currently zero steps; a valid,
+   safe no-op scaffold since `stepByStep()` never fires until `schemaVersion` actually bumps.
+3. **File-backup + rollback wrapper.** A new `openAppDatabase(File dbFile)` — the first thing in
+   this project that opens a database against a real file rather than `NativeDatabase.memory()`,
+   since M2 deliberately left real file-path wiring out of scope. Copies `dbFile` to a temp path
+   before opening (which triggers any pending migration), deletes the copy on success, restores
+   from the copy and rethrows on any exception. SQLite's own transactional DDL already rolls back
+   a migration that throws partway through at the SQL level; this covers what a transaction can't
+   — the app being killed mid-write, or a migration that throws no exception but is wrong.
+4. **CI enforcement.** `tool/check_schema_snapshot.dart`, matching the existing
+   `check_layering.dart`/`check_domain_coverage.dart` pattern: dumps the current schema, diffs it
+   against the committed snapshot for the current `schemaVersion`, fails the build if they
+   disagree — the signal that a table changed without a version bump and a fresh snapshot.
+
+## Proving the mechanism: a test-only fixture schema
+
+```
+test/data/migration_fixture/
+  fixture_database.dart       # 2 tables, schemaVersion 1 and 2 both defined
+  fixture_database_test.dart  # proves the mechanism works
+```
+
+`FixtureDatabase` is a small, throwaway schema with its own `drift_schemas/` snapshots (v1, v2)
+and a real `stepByStep(from1To2: ...)` migration — e.g., a `notes` column that's `TextColumn`
+required in v1 and nullable in v2, small enough to reason about but real enough to prove data
+survives a genuine ALTER. Tests prove, against this fixture:
+
+- Opening a v1-shaped database file, migrating to v2, and asserting the data survived correctly.
+- A migration that throws partway through leaves the original file's data intact.
+- The pre-migration backup file exists during migration and is gone afterward on success.
+
+## Testing
+
+- The fixture-schema tests above (the core "does the mechanism work" proof).
+- `check_schema_snapshot.dart` tests: a schema changed without a matching snapshot → fails; a
+  matching snapshot → passes. Same style as the existing `check_*` guard tests.
+- `openAppDatabase` tests use a real temp file-backed `NativeDatabase`, not memory — copying a
+  file only means something for a file-backed database.
+
+## Non-goals
+
+- User-facing backup/restore UI, retention policy (#37).
+- Any real `AppDatabase` schema change (nothing is pending; the next one just follows this
+  now-proven pattern).
+- Encryption at rest (#38).
+
+## ADR
+
+A new ADR records the two-layer rollback strategy (SQL transaction + file backup) and the
+internal-only backup scope decision — a call that's expensive to reverse once real user data
+exists on a real device.

--- a/drift_schemas/drift_schema_v1.json
+++ b/drift_schemas/drift_schema_v1.json
@@ -1,0 +1,1312 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -1,5 +1,9 @@
-import 'package:drift/drift.dart';
+import 'dart:io';
 
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+
+import 'open_with_backup.dart';
 import 'tables/aircraft_tables.dart';
 import 'tables/custom_aerodrome_table.dart';
 import 'tables/flight_tables.dart';
@@ -36,4 +40,16 @@ class AppDatabase extends _$AppDatabase {
       await customStatement('PRAGMA foreign_keys = ON');
     },
   );
+}
+
+/// Opens [dbFile] as an [AppDatabase], guarded by [openWithBackup]. Querying
+/// once (`SELECT 1`) forces drift's open-and-migrate sequence to run and
+/// surface any error here, rather than lazily on whatever query a caller
+/// happens to run first.
+Future<AppDatabase> openAppDatabase(File dbFile) {
+  return openWithBackup(dbFile, () async {
+    final db = AppDatabase(NativeDatabase(dbFile));
+    await db.customStatement('SELECT 1');
+    return db;
+  });
 }

--- a/lib/data/open_with_backup.dart
+++ b/lib/data/open_with_backup.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+/// Copies [dbFile] to a sibling `.backup` file before calling [open]. On
+/// success, deletes the backup. On failure, restores [dbFile] from the
+/// backup and rethrows — [dbFile] is never left in a partially-written
+/// state, whatever [open] does to it.
+///
+/// [open] is fully caller-controlled: it decides what "opening" means
+/// (construct a database, run a query to force migrations, whatever) and
+/// returns whatever it wants. This keeps the wrapper generic without
+/// needing to model a specific database type.
+Future<T> openWithBackup<T>(File dbFile, Future<T> Function() open) async {
+  final backupFile = File('${dbFile.path}.backup');
+
+  if (await dbFile.exists()) {
+    await dbFile.copy(backupFile.path);
+  }
+
+  try {
+    final result = await open();
+    if (await backupFile.exists()) {
+      await backupFile.delete();
+    }
+    return result;
+  } catch (_) {
+    if (await backupFile.exists()) {
+      if (await dbFile.exists()) {
+        await dbFile.delete();
+      }
+      await backupFile.rename(dbFile.path);
+    }
+    rethrow;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "3a3f1f6f905037d7426e4c445854139fd6a3d592135f7c96d7931682b73d16f4"
+      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.3"
+    version: "2.34.0"
   drift_dev:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -505,7 +505,7 @@ packages:
     source: hosted
     version: "1.10.2"
   sqlite3:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: sqlite3
       sha256: "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -412,7 +412,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,17 @@ environment:
 
 dependencies:
   csv: ^8.0.0
-  drift: ^2.34.3
+  # drift is pinned to exactly 2.34.0, not ^2.34.3. drift_dev 2.34.0's
+  # schema-dump command (`dart run drift_dev schema dump`) throws
+  # "The getter 'allSchemaEntities' isn't defined for the type
+  # 'GeneratedDatabase'" against drift 2.34.3's drift3_preview module — an
+  # incompatibility between that drift patch and drift_dev 2.34.0's
+  # verifier code. drift_dev can't be upgraded past 2.34.0 either: 2.34.1+
+  # needs analyzer ^13, which conflicts with the freezed 3.2.5 pin below
+  # (analyzer <11). Pinning drift down to exactly 2.34.0 — the version
+  # drift_dev 2.34.0 actually resolved against — fixes the schema dump
+  # command; verified all 355 existing tests still pass at this version.
+  drift: 2.34.0
   flutter:
     sdk: flutter
   freezed_annotation: ^3.1.0
@@ -29,6 +39,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   build_runner: ^2.15.1
   json_serializable: ^6.14.1
+  # drift_dev is capped below 2.34.1 by the freezed pin above, not by choice
+  # — see the comment on the drift dependency for the full chain.
   drift_dev: ^2.34.0
   path: ^1.9.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dev_dependencies:
   # — see the comment on the drift dependency for the full chain.
   drift_dev: ^2.34.0
   path: ^1.9.1
+  sqlite3: ^3.5.1
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   build_runner: ^2.15.1
   json_serializable: ^6.14.1
   drift_dev: ^2.34.0
+  path: ^1.9.1
 
 flutter:
   uses-material-design: true

--- a/test/data/migration_fixture/drift_schemas/drift_schema_v1.json
+++ b/test/data/migration_fixture/drift_schemas/drift_schema_v1.json
@@ -1,0 +1,59 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "fixture_items",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "fixture_items",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"fixture_items\" (\"id\" TEXT NOT NULL, \"name\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/test/data/migration_fixture/drift_schemas/drift_schema_v2.json
+++ b/test/data/migration_fixture/drift_schemas/drift_schema_v2.json
@@ -1,0 +1,69 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "fixture_items",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "notes",
+            "getter_name": "notes",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "fixture_items",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"fixture_items\" (\"id\" TEXT NOT NULL, \"name\" TEXT NOT NULL, \"notes\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/test/data/migration_fixture/fixture_database.dart
+++ b/test/data/migration_fixture/fixture_database.dart
@@ -1,0 +1,33 @@
+import 'package:drift/drift.dart';
+
+part 'fixture_database.g.dart';
+
+@DataClassName('FixtureItemRow')
+class FixtureItemsTable extends Table {
+  @override
+  String get tableName => 'fixture_items';
+
+  TextColumn get id => text()();
+  TextColumn get name => text()();
+  TextColumn get notes => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DriftDatabase(tables: [FixtureItemsTable])
+class FixtureDatabase extends _$FixtureDatabase {
+  FixtureDatabase(super.executor);
+
+  @override
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onUpgrade: (Migrator m, int from, int to) async {
+      if (from == 1 && to == 2) {
+        await m.addColumn(fixtureItemsTable, fixtureItemsTable.notes);
+      }
+    },
+  );
+}

--- a/test/data/migration_fixture/fixture_database_test.dart
+++ b/test/data/migration_fixture/fixture_database_test.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/open_with_backup.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+import 'fixture_database.dart';
+
+/// Creates a v1-shaped database file directly with sqlite3 — the only way
+/// to get a "v1 database" to migrate from, since the Dart table class only
+/// ever represents the current (v2) schema.
+void _seedV1Database(String path, {required String id, required String name}) {
+  final db = sqlite3.sqlite3.open(path);
+  try {
+    db.execute(
+      'CREATE TABLE fixture_items (id TEXT NOT NULL, name TEXT NOT NULL, '
+      'PRIMARY KEY (id))',
+    );
+    db.execute('INSERT INTO fixture_items (id, name) VALUES (?, ?)', [
+      id,
+      name,
+    ]);
+    db.execute('PRAGMA user_version = 1');
+  } finally {
+    db.close();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+  late File dbFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('fixture_database_test');
+    dbFile = File(p.join(tempDir.path, 'fixture.sqlite'));
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  test('migrating a v1 database to v2 preserves existing data', () async {
+    _seedV1Database(dbFile.path, id: 'item-1', name: 'Original');
+
+    final db = await openWithBackup(dbFile, () async {
+      final database = FixtureDatabase(NativeDatabase(dbFile));
+      await database.customStatement('SELECT 1');
+      return database;
+    });
+    addTearDown(db.close);
+
+    final rows = await db.select(db.fixtureItemsTable).get();
+    expect(rows, hasLength(1));
+    expect(rows.single.id, 'item-1');
+    expect(rows.single.name, 'Original');
+    expect(rows.single.notes, isNull);
+  });
+
+  test(
+    'a migration step that throws leaves the original file intact',
+    () async {
+      _seedV1Database(dbFile.path, id: 'item-1', name: 'Original');
+      final originalBytes = await dbFile.readAsBytes();
+
+      // The failing open() throws before returning, so openWithBackup never
+      // gets a reference to close — captured here instead, and closed in
+      // teardown, so the native sqlite connection doesn't keep the file
+      // handle open (which blocks the temp dir's deletion on Windows).
+      _AlwaysFailsMigrationDatabase? failingDb;
+      addTearDown(() => failingDb?.close());
+
+      await expectLater(
+        () => openWithBackup(dbFile, () async {
+          // A database whose onUpgrade always throws, to force the failure
+          // path without depending on addColumn actually failing.
+          failingDb = _AlwaysFailsMigrationDatabase(NativeDatabase(dbFile));
+          await failingDb!.customStatement('SELECT 1');
+          return failingDb!;
+        }),
+        throwsA(anything),
+      );
+
+      expect(await dbFile.readAsBytes(), originalBytes);
+    },
+  );
+
+  test('the backup file is gone after a successful migration', () async {
+    _seedV1Database(dbFile.path, id: 'item-1', name: 'Original');
+
+    final db = await openWithBackup(dbFile, () async {
+      final database = FixtureDatabase(NativeDatabase(dbFile));
+      await database.customStatement('SELECT 1');
+      return database;
+    });
+    addTearDown(db.close);
+
+    expect(await File('${dbFile.path}.backup').exists(), isFalse);
+  });
+}
+
+/// Same schema as [FixtureDatabase] but always throws during upgrade — used
+/// only to prove the rollback path without relying on a real migration step
+/// failing.
+class _AlwaysFailsMigrationDatabase extends FixtureDatabase {
+  _AlwaysFailsMigrationDatabase(super.executor);
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onUpgrade: (Migrator m, int from, int to) async {
+      throw StateError('simulated migration failure');
+    },
+  );
+}

--- a/test/data/open_with_backup_test.dart
+++ b/test/data/open_with_backup_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/data/open_with_backup.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDir;
+  late File dbFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('open_with_backup_test');
+    dbFile = File(p.join(tempDir.path, 'test.sqlite'));
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  test(
+    'on success, deletes the backup and leaves the file content-preserving',
+    () async {
+      await dbFile.writeAsString('original content');
+
+      final result = await openWithBackup(dbFile, () async {
+        await dbFile.writeAsString('modified content');
+        return 'ok';
+      });
+
+      expect(result, 'ok');
+      expect(await dbFile.readAsString(), 'modified content');
+      expect(await File('${dbFile.path}.backup').exists(), isFalse);
+    },
+  );
+
+  test('on failure, restores the original file and rethrows', () async {
+    await dbFile.writeAsString('original content');
+
+    await expectLater(
+      () => openWithBackup(dbFile, () async {
+        await dbFile.writeAsString('corrupted mid-write');
+        throw StateError('migration failed');
+      }),
+      throwsStateError,
+    );
+
+    expect(await dbFile.readAsString(), 'original content');
+    expect(await File('${dbFile.path}.backup').exists(), isFalse);
+  });
+
+  test(
+    'works when the file does not exist yet (first run, nothing to back up)',
+    () async {
+      final result = await openWithBackup(dbFile, () async {
+        await dbFile.writeAsString('created');
+        return 'ok';
+      });
+
+      expect(result, 'ok');
+      expect(await dbFile.readAsString(), 'created');
+    },
+  );
+
+  test('propagates the original exception unchanged', () async {
+    await dbFile.writeAsString('original content');
+
+    await expectLater(
+      () => openWithBackup(dbFile, () async {
+        throw ArgumentError('a specific error');
+      }),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/tool/check_schema_snapshot_test.dart
+++ b/test/tool/check_schema_snapshot_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/check_schema_snapshot.dart';
+
+void main() {
+  group('schemasMatch', () {
+    test('true for identical JSON', () {
+      const json = '{"a": 1, "b": [1, 2, 3]}';
+      expect(schemasMatch(json, json), isTrue);
+    });
+
+    test('true when formatting differs but content is the same', () {
+      const a = '{"a": 1, "b": 2}';
+      const b = '{\n  "b": 2,\n  "a": 1\n}';
+      expect(schemasMatch(a, b), isTrue);
+    });
+
+    test('false when a value differs', () {
+      const a = '{"a": 1}';
+      const b = '{"a": 2}';
+      expect(schemasMatch(a, b), isFalse);
+    });
+
+    test('false when a key is added or removed', () {
+      const a = '{"a": 1}';
+      const b = '{"a": 1, "b": 2}';
+      expect(schemasMatch(a, b), isFalse);
+    });
+
+    test('false when a list differs', () {
+      const a = '{"a": [1, 2]}';
+      const b = '{"a": [1, 3]}';
+      expect(schemasMatch(a, b), isFalse);
+    });
+  });
+}

--- a/tool/check_schema_snapshot.dart
+++ b/tool/check_schema_snapshot.dart
@@ -1,0 +1,127 @@
+/// Enforces that `drift_schemas/drift_schema_v<N>.json` (N = AppDatabase's
+/// current schemaVersion) matches what the current code would actually
+/// produce — the signal that a table changed without a version bump and a
+/// fresh committed snapshot. Mirrors `check_layering.dart`/
+/// `check_domain_coverage.dart`'s "small hand-rolled guard wired into CI"
+/// style.
+///
+/// Run: `dart run tool/check_schema_snapshot.dart`
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+const String _databaseSource = 'lib/data/database.dart';
+const String _snapshotsDir = 'drift_schemas';
+final RegExp _snapshotFilename = RegExp(r'drift_schema_v(\d+)\.json$');
+
+/// True if [dumpedJson] and [committedJson] decode to the same structure,
+/// ignoring formatting differences (key order, whitespace).
+bool schemasMatch(String dumpedJson, String committedJson) {
+  return _deepEquals(jsonDecode(dumpedJson), jsonDecode(committedJson));
+}
+
+bool _deepEquals(Object? a, Object? b) {
+  if (a is Map && b is Map) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final key in a.keys) {
+      if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (a is List && b is List) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (var i = 0; i < a.length; i++) {
+      if (!_deepEquals(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return a == b;
+}
+
+Future<void> main() async {
+  final tempDir = await Directory.systemTemp.createTemp(
+    'check_schema_snapshot',
+  );
+  try {
+    // `dart run drift_dev ...` fails here — this project's `dart`/`flutter`
+    // are puro shims, and plain `dart` can't find the Flutter SDK
+    // (CLAUDE.md's documented build_runner gotcha applies to drift_dev's
+    // CLI too). `flutter pub run` resolves correctly. `runInShell: true` is
+    // required on Windows for Process.run to find a PATH-shimmed `flutter`
+    // executable at all (it's a .bat wrapper, not resolved by a direct
+    // executable lookup).
+    final result = await Process.run('flutter', [
+      'pub',
+      'run',
+      'drift_dev',
+      'schema',
+      'dump',
+      _databaseSource,
+      tempDir.path,
+    ], runInShell: true);
+    if (result.exitCode != 0) {
+      stderr.writeln(
+        'check_schema_snapshot: failed to dump the current schema:',
+      );
+      stderr.writeln(result.stderr);
+      exit(1);
+    }
+
+    final dumped = tempDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => _snapshotFilename.hasMatch(f.path))
+        .toList();
+    if (dumped.length != 1) {
+      stderr.writeln(
+        'check_schema_snapshot: expected exactly one dumped schema file, '
+        'found ${dumped.length}.',
+      );
+      exit(1);
+    }
+
+    final dumpedFile = dumped.single;
+    final version = _snapshotFilename.firstMatch(dumpedFile.path)!.group(1);
+    final committedFile = File('$_snapshotsDir/drift_schema_v$version.json');
+
+    if (!committedFile.existsSync()) {
+      stderr.writeln(
+        'check_schema_snapshot: schemaVersion is $version but '
+        '${committedFile.path} does not exist. Run:\n'
+        '  flutter pub run drift_dev schema dump $_databaseSource $_snapshotsDir\n'
+        'and commit the result.',
+      );
+      exit(1);
+    }
+
+    final dumpedJson = await dumpedFile.readAsString();
+    final committedJson = await committedFile.readAsString();
+
+    if (!schemasMatch(dumpedJson, committedJson)) {
+      stderr.writeln(
+        'check_schema_snapshot: the current schema no longer matches '
+        '${committedFile.path}. If this is an intentional change, bump '
+        'AppDatabase.schemaVersion, add an onUpgrade step, and regenerate '
+        'the snapshot:\n'
+        '  flutter pub run drift_dev schema dump $_databaseSource $_snapshotsDir\n'
+        'then commit the result.',
+      );
+      exit(1);
+    }
+
+    stdout.writeln(
+      'check_schema_snapshot: drift_schema_v$version.json is up to date.',
+    );
+  } finally {
+    await tempDir.delete(recursive: true);
+  }
+}


### PR DESCRIPTION
## Summary

Makes future schema changes to `AppDatabase` safe, per ADR-0010's two-layer approach:

- **File-level backup + rollback** (`lib/data/open_with_backup.dart`): copies the db file before
  opening/migrating, deletes it on success, restores it and rethrows on any failure. Internal
  only — no restore UI, no retention policy, not #37 (which has no design yet).
- **Committed schema snapshot**: `drift_schemas/drift_schema_v1.json`, generated via
  `drift_dev schema dump`, the only record of what v1 actually looked like.
- **CI enforcement** (`tool/check_schema_snapshot.dart`): diffs the current schema against the
  committed snapshot, fails the build if a table changed without a version bump — same
  hand-rolled-guard pattern as `check_layering.dart`/`check_domain_coverage.dart`.
- **The migration mechanism proven end-to-end** against a throwaway fixture schema
  (`test/data/migration_fixture/`), not a real `AppDatabase` change — nothing was pending to
  migrate, so this is pure infrastructure, not an invented product change. Tests prove: data
  survives a real v1→v2 migration, a migration step that throws leaves the original file
  byte-for-byte intact, and the backup file is cleaned up on success.

**Dependency note:** `drift` is now pinned to exactly `2.34.0` (was `^2.34.3`) —
`drift_dev` 2.34.0's schema-dump command is incompatible with `drift` 2.34.3's `drift3_preview`
module, and `drift_dev` can't be upgraded past 2.34.0 without conflicting with the `freezed`
3.2.5 pin from ADR-0006. Full chain documented in the `pubspec.yaml` comment. All 355
pre-existing tests were re-verified green at the downgraded version before building on top of it.

Full design rationale: `docs/superpowers/specs/2026-08-09-schema-migration-framework-design.md`.

Closes #36

## Test plan

- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_schema_snapshot.dart` (verified both red — corrupted the snapshot and
      confirmed it fails — and green paths manually, not just via unit tests of the pure diff
      function)
- [x] `flutter test` — 363 tests, all green