### PR TITLE
Close out M2: dev seed data, backup/restore, encryption spike

### DIFF
--- a/docs/adr/0011-backup-format.md
+++ b/docs/adr/0011-backup-format.md
@@ -1,0 +1,57 @@
+# ADR-0011: Backup format is the live SQLite file, via `VACUUM INTO`
+
+**Status:** Accepted
+**Date:** 2026-08-09
+
+## Context
+
+#37 needs a backup file format that includes every flight, its full revision history, and its
+draft/committed/tombstoned state, and that stays restorable as the schema evolves. ADR-0010
+deliberately left this undesigned, on the grounds that guessing at it while building the
+migration framework risked baking in the wrong shape.
+
+## Decision
+
+A backup is an ordinary SQLite file — the database file itself, produced by SQLite's
+`VACUUM INTO`. Not a custom JSON/zip export, not a subset of tables.
+
+This works because the live database already *is* the complete legal record: `flights`,
+`flight_revisions`, `committed_at`/`tombstoned_at`, `aircraft`, `custom_aerodromes` — nothing is
+summarized or derived on the way in. `VACUUM INTO` produces a transactionally consistent copy
+without needing exclusive access to the live connection, unlike a raw file copy taken while a
+connection might be mid-write.
+
+Versioning is free, not bolted on: SQLite's `user_version` pragma is drift's `schemaVersion`, so
+an old backup restored years from now is opened exactly the way an old on-device database is
+opened today — through `openAppDatabase`, running whatever migrations #36's framework has
+accumulated by then. There is no second version number to keep in sync with the schema.
+
+Implementation: `lib/data/database_backup.dart`. `exportDatabaseBackup` wraps `VACUUM INTO`.
+`restoreDatabaseBackup` replaces the live file (clearing any stale rollback-journal sidecar) and
+leaves reopening it — and therefore migrating it — to the caller via `openAppDatabase`.
+
+## Alternatives considered
+
+A custom export format (JSON rows, or a zip of JSON plus a manifest). Rejected: it would
+duplicate the schema in a second, hand-maintained shape, and every future migration would need a
+second migration path written for the export format alongside the real one. The SQLite file
+already has an evolution story; reusing it means #36's migration framework *is* the backup format's
+migration framework, with no separate code path to keep correct.
+
+A raw file copy of the live `.sqlite` file instead of `VACUUM INTO`. Rejected: safe only if the
+database is guaranteed closed or quiescent at the moment of copy, which a "back up now" action
+triggered from a live app cannot guarantee. `VACUUM INTO` is SQLite's own answer to taking a
+consistent snapshot without that guarantee, and as a side effect produces a defragmented,
+minimum-size file.
+
+## Consequences
+
+A backup's integrity is exactly SQLite's file-format integrity — no redundant encoding, no
+second format to validate independently. Restoring an old backup depends on the migration
+framework being able to carry it forward, so a migration that only handles the *previous* schema
+version rather than *any* older one would silently break restoring a very old backup; #36's
+migrations must stay cumulative.
+
+Share-sheet delivery of the backup file and an in-app "back up now"/reminder UI are not part of
+this decision — there is no app UI yet (M4). `isBackupOverdue` in `database_backup.dart` is the
+pure decision logic for the reminder, written now and left for M4 to call from an actual screen.

--- a/docs/adr/0012-encryption-at-rest.md
+++ b/docs/adr/0012-encryption-at-rest.md
@@ -1,0 +1,61 @@
+# ADR-0012: No app-level encryption at rest, for now
+
+**Status:** Accepted
+**Date:** 2026-08-09
+
+## Context
+
+#38: the database holds GDPR personal data — names, credential numbers, dates, and a detailed
+movement history (every aerodrome the pilot has flown to or from). This spike asks whether to
+encrypt the SQLite file itself, timeboxed to one day.
+
+**Package landscape has moved since ADR-0006 was written.** `sqlcipher_flutter_libs`, the
+obvious candidate, does nothing as of 0.7.0 — drift dropped SQLCipher support at 2.32.0 (this
+project is pinned to drift 2.34.0, past that point) in favour of SQLite3MultipleCiphers, a
+different SQLite fork bundled through the newer Dart build-hooks system
+(`hooks.user_defines.sqlite3.source: sqlite3mc` in `pubspec.yaml`), not a plain dependency
+add. Key material is supplied via `PRAGMA key` in `NativeDatabase`'s `setup` callback, with a
+runtime check for the `cipher` pragma recommended to confirm the encrypted build actually loaded.
+
+**Threat model.** Android has mandated file-based encryption since Android 10; iOS encrypts the
+app sandbox by default. Both already protect the case that matters most for a personal device
+with no cloud backend and no account system (ADR-0006, CLAUDE.md "deliberately out of scope"):
+the device is lost, stolen, or seized while powered off or locked. App-level encryption adds
+protection mainly against a narrower set of cases OS encryption doesn't fully close — an
+unencrypted local device backup, or a compromised OS reading files while the device is unlocked
+— neither of which is this app's primary exposure today.
+
+## Decision
+
+Do not add app-level encryption at rest now. Rely on platform full-disk / file-based encryption.
+
+The determining factor is not "is it needed in principle" — GDPR data always benefits from
+defence in depth — but cost against this project's actual state: SQLite3MultipleCiphers needs the
+Dart build-hooks system, which is materially newer and less proven than anything else in the
+stack, stacked on an already fragile, exact-pinned `drift`/`drift_dev`/`freezed`/`analyzer` chain
+(see the extensive version-conflict comments in `pubspec.yaml` and ADR-0006). Taking on that risk
+now, before the schema has settled and before there is even a UI to exercise it end to end, is a
+bad trade against a threat OS encryption already substantially covers.
+
+**#37's backup file is unaffected as a store of the same information** — it is a `VACUUM INTO`
+copy of the same unencrypted database (ADR-0011), so it carries the same exposure as the live
+file and the same OS-level protection while at rest on the destination the user chooses.
+
+## Alternatives considered
+
+Implement SQLite3MultipleCiphers now. Rejected for the reasons above — see "Decision."
+
+Encrypt only specific sensitive columns (names, credential numbers) rather than the whole
+database. Rejected without deep investigation: it would leave route/movement history — arguably
+the more sensitive GDPR data — unprotected, and adds bespoke crypto code to maintain for a
+narrower guarantee than whole-file encryption already gives for free at the OS level.
+
+## Consequences
+
+No new dependency, no build-hooks adoption, no key-management or backup-rekey design needed now.
+
+This decision is revisited, not permanent. The condition that would flip it: this app takes on a
+threat model OS encryption doesn't cover — cloud sync (explicitly out of scope today, ADR-0006),
+shared/managed devices, or a requirement to defend against a compromised-but-unlocked device. If
+that happens, this ADR's package research (SQLite3MultipleCiphers via build hooks) is the starting
+point, not a decision to redo from scratch.

--- a/lib/data/database_backup.dart
+++ b/lib/data/database_backup.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'database.dart';
+
+/// #37: user-facing backup/restore of the whole logbook. Distinct from
+/// `open_with_backup.dart`, which is an internal, migration-scoped safety
+/// net with no restore UI and no retention story (see ADR-0010) — that one
+/// protects a single `openAppDatabase` call; this one is what a pilot
+/// invokes deliberately, from the UI M4 eventually builds.
+///
+/// **Format decision (see `docs/adr/0011-backup-format.md`): the backup
+/// *is* an ordinary SQLite file, produced by `VACUUM INTO`.** The live
+/// database already is the complete legal record — every flight, every
+/// `flight_revisions` row, every draft/committed/tombstoned state, all
+/// reference data — so no separate export format is needed to satisfy "full
+/// export including revision history and entry states." Versioning is free
+/// too: SQLite's own `user_version` pragma is drift's `schemaVersion`, so an
+/// old backup restored years from now runs through the exact migration
+/// framework (#36) that already exists to open an old on-device database.
+
+/// Writes a complete, consistent snapshot of [db] to [destination] using
+/// SQLite's `VACUUM INTO`. Safe to call while [db] is open and in normal
+/// use — `VACUUM INTO` reads a transactionally consistent view without
+/// requiring exclusive access or a prior checkpoint, unlike a raw file copy
+/// while a connection is live.
+///
+/// Overwrites [destination] if it already exists.
+Future<void> exportDatabaseBackup(AppDatabase db, File destination) async {
+  if (await destination.exists()) {
+    await destination.delete();
+  }
+  await destination.parent.create(recursive: true);
+  await db.customStatement('VACUUM INTO ?', [destination.path]);
+}
+
+/// Replaces [liveDbFile] with [backupFile]'s content.
+///
+/// The caller must have closed any open connection to [liveDbFile] first —
+/// this operates purely on files, matching `openWithBackup`'s contract —
+/// and must have already warned the user that this discards whatever is
+/// currently there; this function does not ask. Reopen [liveDbFile]
+/// afterwards via `openAppDatabase`, which migrates it forward if
+/// [backupFile] predates the app's current schema version.
+///
+/// Throws [ArgumentError] if [backupFile] does not exist.
+Future<void> restoreDatabaseBackup(File backupFile, File liveDbFile) async {
+  if (!await backupFile.exists()) {
+    throw ArgumentError.value(backupFile.path, 'backupFile', 'does not exist');
+  }
+
+  if (await liveDbFile.exists()) {
+    await liveDbFile.delete();
+  }
+  // A rollback-journal sidecar can survive an app crash mid-write. VACUUM
+  // INTO's output never has one, but leaving a stale one next to the file
+  // it replaces would make SQLite think a crashed transaction needs
+  // recovering against data that was never actually mid-write.
+  final journal = File('${liveDbFile.path}-journal');
+  if (await journal.exists()) {
+    await journal.delete();
+  }
+
+  await liveDbFile.parent.create(recursive: true);
+  await backupFile.copy(liveDbFile.path);
+}
+
+/// Whether a backup reminder should be shown, given the last successful
+/// backup time ([lastBackupAt], `null` if none has ever been taken) and the
+/// current time.
+///
+/// Pure decision logic only. Where [lastBackupAt] is persisted and how the
+/// reminder is actually surfaced (a banner, a notification) is M4's
+/// concern, once there is a UI to put it in — kept separate here so the
+/// decision itself is written and tested now rather than guessed at later.
+bool isBackupOverdue(
+  DateTime? lastBackupAt,
+  DateTime now, {
+  Duration interval = const Duration(days: 30),
+}) {
+  if (lastBackupAt == null) {
+    return true;
+  }
+  return now.difference(lastBackupAt) >= interval;
+}

--- a/test/data/database_backup_test.dart
+++ b/test/data/database_backup_test.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/database_backup.dart';
+import 'package:easa_digital_log/data/repositories/aircraft_repository.dart';
+import 'package:easa_digital_log/data/repositories/flight_repository_drift.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({String remarks = ''}) {
+  return Flight(
+    aircraftRegistration: 'G-ABCD',
+    route: const ['EGKA', 'EGKB'],
+    prePlannedNavigation: false,
+    offBlocks: UtcInstant.utc(2026, 6, 1, 10),
+    onBlocks: UtcInstant.utc(2026, 6, 1, 11),
+    capacity: _capacity,
+    carryingPassengers: false,
+    takeoffs: const CircuitCounts(dayFullStop: 1),
+    landings: const CircuitCounts(dayFullStop: 1),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: const [],
+    holdingProceduresCount: 0,
+    trackingPerformed: false,
+    remarks: remarks,
+  );
+}
+
+Future<List<Object?>> _snapshot(AppDatabase db) async {
+  final flights = await db.select(db.flightsTable).get();
+  final revisions = await db.select(db.flightRevisionsTable).get();
+  final aircraft = await db.select(db.aircraftsTable).get();
+  return [
+    flights.map((r) => r.toJson()).toList(),
+    revisions.map((r) => r.toJson()).toList(),
+    aircraft.map((r) => r.toJson()).toList(),
+  ];
+}
+
+void main() {
+  late Directory tempDir;
+  late File dbFile;
+  late File backupFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('database_backup_test');
+    dbFile = File(p.join(tempDir.path, 'live.sqlite'));
+    backupFile = File(p.join(tempDir.path, 'backup.sqlite'));
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  test('export, wipe, restore round-trips flights, revisions and aircraft '
+      'exactly', () async {
+    var db = AppDatabase(NativeDatabase(dbFile));
+    final aircraftId = await AircraftRepository(db).upsert(
+      const Aircraft(
+        registration: 'G-ABCD',
+        manufacturer: 'Cessna',
+        model: '152',
+        category: AircraftCategory.aeroplane,
+        engineType: EngineType.piston,
+        engineCount: 1,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: false,
+      ),
+    );
+    final flights = DriftFlightRepository(db);
+
+    // Exercise the full lifecycle: a draft, a committed flight with a
+    // revision, and a tombstoned flight — so the round trip actually
+    // proves revision history and entry states survive, not just a bare
+    // row.
+    await flights.createDraft(
+      _flight(remarks: 'still a draft'),
+      aircraftId: aircraftId,
+    );
+
+    final committedId = await flights.createDraft(
+      _flight(remarks: 'original'),
+      aircraftId: aircraftId,
+    );
+    await flights.commit(committedId);
+    await flights.updateCommitted(
+      committedId,
+      _flight(remarks: 'corrected'),
+      reason: 'test correction',
+    );
+
+    final tombstonedId = await flights.createDraft(
+      _flight(remarks: 'to be voided'),
+      aircraftId: aircraftId,
+    );
+    await flights.commit(tombstonedId);
+    await flights.tombstone(tombstonedId, reason: 'test void');
+
+    final before = await _snapshot(db);
+
+    await exportDatabaseBackup(db, backupFile);
+    expect(await backupFile.exists(), isTrue);
+
+    await db.close();
+    await dbFile.delete();
+
+    await restoreDatabaseBackup(backupFile, dbFile);
+    expect(await dbFile.readAsBytes(), await backupFile.readAsBytes());
+
+    db = AppDatabase(NativeDatabase(dbFile));
+    final after = await _snapshot(db);
+    await db.close();
+
+    expect(after, equals(before));
+  });
+
+  test('restoreDatabaseBackup throws when the backup file is missing', () {
+    expect(
+      () => restoreDatabaseBackup(backupFile, dbFile),
+      throwsArgumentError,
+    );
+  });
+
+  test('restoreDatabaseBackup replaces an existing live file and its stale '
+      'journal', () async {
+    await backupFile.writeAsString('backup content');
+    await dbFile.writeAsString('stale live content');
+    final journal = File('${dbFile.path}-journal');
+    await journal.writeAsString('stale journal');
+
+    await restoreDatabaseBackup(backupFile, dbFile);
+
+    expect(await dbFile.readAsString(), 'backup content');
+    expect(await journal.exists(), isFalse);
+  });
+
+  group('isBackupOverdue', () {
+    test('true when no backup has ever been taken', () {
+      expect(isBackupOverdue(null, DateTime.utc(2026, 1, 1)), isTrue);
+    });
+
+    test('false just under the interval', () {
+      final lastBackup = DateTime.utc(2026, 1, 1);
+      final now = lastBackup.add(const Duration(days: 29));
+      expect(isBackupOverdue(lastBackup, now), isFalse);
+    });
+
+    test('true at and beyond the interval', () {
+      final lastBackup = DateTime.utc(2026, 1, 1);
+      expect(
+        isBackupOverdue(lastBackup, lastBackup.add(const Duration(days: 30))),
+        isTrue,
+      );
+      expect(
+        isBackupOverdue(lastBackup, lastBackup.add(const Duration(days: 45))),
+        isTrue,
+      );
+    });
+
+    test('honours a custom interval', () {
+      final lastBackup = DateTime.utc(2026, 1, 1);
+      expect(
+        isBackupOverdue(
+          lastBackup,
+          lastBackup.add(const Duration(days: 8)),
+          interval: const Duration(days: 7),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/tool/seed_dev_data.dart
+++ b/tool/seed_dev_data.dart
@@ -1,0 +1,330 @@
+// #39: development-only seed data. This is a `tool/` script, never compiled
+// into the app — that alone satisfies "never available in release builds".
+// Reads no assets and touches no `lib/ui/`, so it can run standalone:
+//
+//   dart run tool/seed_dev_data.dart <path-to-db-file> [--flights=300] [--years=3] [--seed=1234]
+//
+// Deletes and recreates the target file. FSTD sessions are not seeded —
+// there is no persistence model for them yet (M2 design spec, "Non-goals").
+
+import 'dart:io';
+import 'dart:math';
+
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/aircraft_repository.dart';
+import 'package:easa_digital_log/data/repositories/flight_repository_drift.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty || args.first.startsWith('-')) {
+    stderr.writeln(
+      'Usage: dart run tool/seed_dev_data.dart <path-to-db-file> '
+      '[--flights=300] [--years=3] [--seed=1234]',
+    );
+    exit(64);
+  }
+
+  final dbPath = args.first;
+  final options = <String, String>{
+    for (final arg in args.skip(1))
+      if (arg.startsWith('--') && arg.contains('='))
+        arg.substring(2).split('=').first: arg.substring(2).split('=').last,
+  };
+  final flightCount = int.parse(options['flights'] ?? '300');
+  final years = int.parse(options['years'] ?? '3');
+  final seed = int.parse(
+    options['seed'] ?? DateTime.now().millisecondsSinceEpoch.toString(),
+  );
+  final random = Random(seed);
+
+  final dbFile = File(dbPath);
+  if (await dbFile.exists()) {
+    await dbFile.delete();
+  }
+  await dbFile.parent.create(recursive: true);
+
+  final db = AppDatabase(NativeDatabase(dbFile));
+  await db.customStatement('SELECT 1');
+  final aircraftRepo = AircraftRepository(db);
+  final flightRepo = DriftFlightRepository(db);
+
+  final aircraftIds = <String>[];
+  final registrationsById = <String, String>{};
+  for (final aircraft in _seedAircraft) {
+    final id = await aircraftRepo.upsert(aircraft);
+    aircraftIds.add(id);
+    registrationsById[id] = aircraft.registration;
+  }
+
+  final now = DateTime.now().toUtc();
+  final earliest = DateTime.utc(now.year - years, now.month, now.day);
+  final spanDays = now.difference(earliest).inDays;
+
+  var committed = 0;
+  var tombstoned = 0;
+  var revised = 0;
+
+  for (var i = 0; i < flightCount; i++) {
+    final aircraftId = aircraftIds[random.nextInt(aircraftIds.length)];
+    final offBlocks = earliest.add(
+      Duration(
+        days: random.nextInt(spanDays + 1),
+        hours: random.nextInt(24),
+        minutes: random.nextInt(60),
+      ),
+    );
+    final flight = _randomFlight(
+      random,
+      offBlocks,
+      registrationsById[aircraftId]!,
+    );
+    final id = await flightRepo.createDraft(flight, aircraftId: aircraftId);
+
+    // Roughly two thirds of seeded flights are committed (exported at least
+    // once), matching a logbook that is mostly historical with a handful of
+    // recent drafts still being filled in.
+    if (random.nextDouble() < 0.65) {
+      await flightRepo.commit(id);
+      committed++;
+
+      // A slice of committed flights pick up a correction, to exercise
+      // revision history.
+      if (random.nextDouble() < 0.1) {
+        await flightRepo.updateCommitted(
+          id,
+          flight.copyWith(remarks: '${flight.remarks} (corrected)'.trim()),
+          reason: 'Seed data: simulated post-export correction',
+        );
+        revised++;
+      }
+
+      // A small slice are deleted-but-retained, to exercise tombstoning.
+      if (random.nextDouble() < 0.03) {
+        await flightRepo.tombstone(id, reason: 'Seed data: simulated void');
+        tombstoned++;
+      }
+    }
+  }
+
+  await db.close();
+
+  stdout.writeln(
+    'Seeded $flightCount flights across ${aircraftIds.length} aircraft '
+    'into $dbPath (seed=$seed): $committed committed, $revised revised, '
+    '$tombstoned tombstoned.',
+  );
+}
+
+const _capacityBase = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+/// One of a handful of realistic flight shapes, picked at random per flight.
+/// Not exhaustive of every `PilotCapacity` combination — just enough
+/// variety to exercise night, IFR, multi-leg, instruction and PICUS
+/// projections and currency rules downstream.
+Flight _randomFlight(
+  Random random,
+  DateTime offBlocksUtc,
+  String aircraftRegistration,
+) {
+  final archetype = random.nextInt(7);
+  final durationMinutes = 30 + random.nextInt(150);
+  final offBlocks = UtcInstant.fromDateTime(offBlocksUtc);
+  final onBlocks = offBlocks.add(Duration(minutes: durationMinutes));
+  final isNight = offBlocksUtc.hour >= 20 || offBlocksUtc.hour < 6;
+
+  final route = archetype == 2
+      ? _multiLegRoute(random)
+      : [_randomIcao(random), _randomIcao(random)];
+
+  final takeoffs = isNight
+      ? const CircuitCounts(nightFullStop: 1)
+      : const CircuitCounts(dayFullStop: 1);
+  final landings = isNight
+      ? const CircuitCounts(nightFullStop: 1)
+      : const CircuitCounts(dayFullStop: 1);
+
+  var capacity = _capacityBase;
+  var ifrFlightPlanFiled = false;
+  var actualInstrumentTime = FlightDuration.zero;
+  var simulatedInstrumentTime = FlightDuration.zero;
+  var approaches = const <Approach>[];
+  var holdingProceduresCount = 0;
+  var otherPilotName = '';
+  var otherPilotCredentialNumber = '';
+
+  switch (archetype) {
+    case 0: // Ordinary solo PIC, VFR local.
+      break;
+    case 1: // Dual instruction received.
+      capacity = capacity.copyWith(
+        commandAuthority: false,
+        soleOccupant: false,
+        instructor: const InstructorPresence(
+          capacity: InstructorCapacity.flightInstructor,
+          influencedFlight: true,
+          name: 'J. Reilly',
+          credentialNumber: 'CFI-4471',
+        ),
+      );
+      break;
+    case 2: // Multi-leg cross-country, PIC.
+      break;
+    case 3: // Instruction given, as instructor.
+      capacity = capacity.copyWith(
+        soleOccupant: false,
+        actingAsInstructor: true,
+      );
+      break;
+    case 4: // PICUS under supervision.
+      capacity = capacity.copyWith(
+        commandAuthority: false,
+        soleOccupant: false,
+        soleManipulator: false,
+        picusClaimed: true,
+        picInterventionNotRequired: true,
+        instructor: const InstructorPresence(
+          capacity: InstructorCapacity.flightInstructor,
+          influencedFlight: false,
+          name: 'M. Okafor',
+          credentialNumber: 'CFI-2290',
+        ),
+      );
+      break;
+    case 5: // IFR, actual instrument, with an approach and a hold.
+      ifrFlightPlanFiled = true;
+      actualInstrumentTime = FlightDuration(20 + random.nextInt(40));
+      approaches = [
+        Approach(
+          type: ApproachType.ils,
+          aerodromeIcao: route.last,
+          runway: '${(random.nextInt(18) + 1) * 2}',
+          count: 1 + random.nextInt(2),
+        ),
+      ];
+      holdingProceduresCount = random.nextInt(2);
+      break;
+    case 6: // Simulated instrument under the hood, with a safety pilot.
+      simulatedInstrumentTime = FlightDuration(15 + random.nextInt(30));
+      capacity = capacity.copyWith(otherPilotRole: OtherPilotRole.safetyPilot);
+      otherPilotName = 'S. Delacroix';
+      otherPilotCredentialNumber = 'PPL-88214';
+      break;
+  }
+
+  return Flight(
+    aircraftRegistration: aircraftRegistration,
+    route: route,
+    prePlannedNavigation: route.length > 2,
+    offBlocks: offBlocks,
+    onBlocks: onBlocks,
+    takeoff: offBlocks.add(const Duration(minutes: 5)),
+    landing: onBlocks.subtract(const Duration(minutes: 5)),
+    capacity: capacity,
+    otherPilotName: otherPilotName.isEmpty ? null : otherPilotName,
+    otherPilotCredentialNumber: otherPilotCredentialNumber.isEmpty
+        ? null
+        : otherPilotCredentialNumber,
+    carryingPassengers: random.nextDouble() < 0.2,
+    takeoffs: takeoffs,
+    landings: landings,
+    ifrFlightPlanFiled: ifrFlightPlanFiled,
+    actualInstrumentTime: actualInstrumentTime,
+    simulatedInstrumentTime: simulatedInstrumentTime,
+    approaches: approaches,
+    holdingProceduresCount: holdingProceduresCount,
+    trackingPerformed: archetype == 5 || archetype == 6,
+    remarks: archetype == 4 ? 'PICUS sector, supervised' : '',
+  );
+}
+
+const _icaoCandidates = [
+  'EGKA',
+  'EGKB',
+  'EGHH',
+  'EGLF',
+  'EGTB',
+  'EGSS',
+  'EGNX',
+  'EGBJ',
+];
+
+String _randomIcao(Random random) =>
+    _icaoCandidates[random.nextInt(_icaoCandidates.length)];
+
+List<String> _multiLegRoute(Random random) {
+  final legCount = 3 + random.nextInt(2);
+  return List.generate(legCount, (_) => _randomIcao(random));
+}
+
+final _seedAircraft = [
+  const Aircraft(
+    registration: 'G-ABCD',
+    manufacturer: 'Cessna',
+    model: '152',
+    icaoTypeDesignator: 'C152',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 1,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+  ),
+  const Aircraft(
+    registration: 'G-ARRW',
+    manufacturer: 'Piper',
+    model: 'Arrow',
+    icaoTypeDesignator: 'PA28',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 1,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+    requiredQualifications: {
+      'us.faa.part61': {AircraftQualification.faaComplex},
+      'eu.easa.part-fcl': {
+        AircraftQualification.easaVariablePitchPropeller,
+        AircraftQualification.easaRetractableUndercarriage,
+      },
+    },
+  ),
+  const Aircraft(
+    registration: 'N456BD',
+    manufacturer: 'Cessna',
+    model: '206',
+    icaoTypeDesignator: 'C206',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 1,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+    requiredQualifications: {
+      'us.faa.part61': {AircraftQualification.faaHighPerformance},
+    },
+  ),
+  const Aircraft(
+    registration: 'G-MULTI',
+    manufacturer: 'Beechcraft',
+    model: 'Baron 58',
+    icaoTypeDesignator: 'BE58',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 2,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+  ),
+];


### PR DESCRIPTION
## Summary
- **#39** — `tool/seed_dev_data.dart`: a debug-only script (never compiled into the app) that populates a realistic multi-year logbook exercising night, IFR, multi-leg, dual instruction, PICUS, and safety-pilot flights across drafts, committed, revised, and tombstoned entries.
- **#37** — `lib/data/database_backup.dart` + ADR-0011: full backup/restore via SQLite `VACUUM INTO`, producing a single consistent file that already contains every flight, revision, and entry state, versioned for free via drift's schema pragma and restorable through the #36 migration framework. Round-trip tested (export → wipe → restore → byte-identical, row-identical, revisions intact). Share-sheet delivery and an in-app reminder banner are left for M4 (no app UI exists yet); the reminder's decision logic (`isBackupOverdue`) is implemented and tested now.
- **#38** — ADR-0012: encryption at rest deferred. SQLCipher's Flutter path is deprecated; the current successor needs the newer Dart build-hooks system on top of an already tightly-pinned drift/freezed dependency chain, for protection that mandatory OS-level full-disk/file-based encryption already substantially covers.

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `flutter test --coverage` (370 passing)
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info`
- [x] `dart run tool/check_schema_snapshot.dart`
- [x] Smoke-ran `tool/seed_dev_data.dart` against a throwaway database

🤖 Generated with [Claude Code](https://claude.com/claude-code)