### PR TITLE
Currency rule schema, loader and generic evaluator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Check domain types
         run: dart run tool/check_domain_types.dart
 
+      - name: Check currency rules
+        run: dart run tool/check_currency_rules.dart
+
       - name: Test
         run: flutter test --coverage
 

--- a/assets/rules/schema/currency-rule.schema.json
+++ b/assets/rules/schema/currency-rule.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://easa-digital-log/schema/currency-rule.schema.json",
+  "title": "Currency rule",
+  "description": "One versioned currency rule under assets/rules/. See assets/rules/README.md (#54) for a field-by-field authoring guide, and lib/domain/currency/currency_rule_yaml.dart for the Dart parser this schema documents -- the parser is the actual enforcement (test/domain/currency/currency_rule_schema_test.dart checks the two agree on required fields).",
+  "type": "object",
+  "required": ["id", "jurisdiction", "citation", "effective_from", "requirement"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable across every version of this rule, e.g. easa.fcl060.passenger_recency."
+    },
+    "jurisdiction": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The jurisdiction profile id this rule belongs to, e.g. eu.easa.part-fcl."
+    },
+    "citation": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The regulation this rule implements, e.g. FCL.060(b)(1)."
+    },
+    "effective_from": {
+      "$ref": "#/$defs/date",
+      "description": "The date this version takes effect."
+    },
+    "expires_on": {
+      "$ref": "#/$defs/date",
+      "description": "The date this version was superseded. Omit while still current -- never delete a superseded version, add expires_on to it instead."
+    },
+    "requirement": { "$ref": "#/$defs/requirement" }
+  },
+  "$defs": {
+    "date": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "countableEvent": {
+      "type": "string",
+      "enum": ["landings", "takeoffs", "approaches", "holding_procedures"]
+    },
+    "condition": {
+      "type": "object",
+      "required": ["kind"],
+      "oneOf": [
+        {
+          "properties": {
+            "kind": { "const": "day_night" },
+            "value": { "enum": ["day", "night"] }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "landing_type" },
+            "value": { "enum": ["full_stop", "touch_and_go"] }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "aircraft_match" },
+            "level": { "enum": ["same_type", "same_class", "same_type_or_class"] }
+          },
+          "required": ["level"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "window": {
+      "type": "object",
+      "required": ["kind"],
+      "oneOf": [
+        {
+          "properties": {
+            "kind": { "const": "rolling_days" },
+            "days": { "type": "integer", "exclusiveMinimum": 0 }
+          },
+          "required": ["days"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "calendar_months" },
+            "months": { "type": "integer", "exclusiveMinimum": 0 },
+            "anchor": { "enum": ["evaluation_date", "held_record_expiry"] },
+            "anchor_held_record_kind": { "type": "string", "minLength": 1 }
+          },
+          "required": ["months"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "requirement": {
+      "type": "object",
+      "required": ["kind"],
+      "oneOf": [
+        {
+          "properties": {
+            "kind": { "const": "flight_event_count" },
+            "event": { "$ref": "#/$defs/countableEvent" },
+            "count": { "type": "integer", "exclusiveMinimum": 0 },
+            "window": { "$ref": "#/$defs/window" },
+            "conditions": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/condition" }
+            }
+          },
+          "required": ["event", "count", "window"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "flight_event_hours" },
+            "event": { "$ref": "#/$defs/countableEvent" },
+            "hours": { "type": "number", "exclusiveMinimum": 0 },
+            "window": { "$ref": "#/$defs/window" },
+            "conditions": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/condition" }
+            }
+          },
+          "required": ["event", "hours", "window"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "held_record_currently_valid" },
+            "held_record_kind": { "type": "string", "minLength": 1 }
+          },
+          "required": ["held_record_kind"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "all_of" },
+            "of": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/requirement" }
+            }
+          },
+          "required": ["of"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "any_of" },
+            "of": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/requirement" }
+            }
+          },
+          "required": ["of"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/lib/domain/currency/currency_rule.dart
+++ b/lib/domain/currency/currency_rule.dart
@@ -1,0 +1,136 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/calendar_date.dart';
+import '../model/flight_duration.dart';
+import 'flight_condition.dart';
+import 'rule_window.dart';
+
+part 'currency_rule.freezed.dart';
+
+/// One versioned currency rule, as loaded from `assets/rules/*.yaml` — #40.
+///
+/// [id] identifies the rule across its whole lineage; [effectiveFrom] and
+/// [expiresOn] place one version of it in time, per #41 — "a flight in 2019
+/// must be evaluated against the rule in force in 2019". Superseded versions
+/// are retained (never deleted, per #40's acceptance criteria), so several
+/// [CurrencyRule]s can share the same [id].
+@freezed
+abstract class CurrencyRule with _$CurrencyRule {
+  const factory CurrencyRule({
+    /// Stable across every version of this rule, e.g.
+    /// `easa.fcl060.passenger_recency`.
+    required String id,
+
+    /// The [JurisdictionProfile.id] this rule belongs to, e.g.
+    /// `eu.easa.part-fcl`.
+    required String jurisdictionId,
+
+    /// The regulation this rule implements, e.g. `FCL.060(b)(1)`. Mandatory
+    /// per #40 — every [RuleResult] carries it through for display.
+    required String citation,
+
+    /// The date this version takes effect. #41 selects, for a given
+    /// evaluation date, the latest version with `effectiveFrom <=` that date.
+    required CalendarDate effectiveFrom,
+
+    /// The date this version was superseded, null while still current.
+    /// Retained rather than deleted so a historical flight is always
+    /// evaluated against the rule actually in force on its date.
+    CalendarDate? expiresOn,
+
+    required Requirement requirement,
+  }) = _CurrencyRule;
+}
+
+/// What #40 calls "must express": a count or hours total of qualifying
+/// flight events within a window, a held document's current validity, or a
+/// composite of other requirements — the alternative-means-of-compliance
+/// case (#40: "a proficiency check satisfying a requirement in place of
+/// recency") is [anyOf] over two differently-shaped requirements, not a
+/// distinct kind of its own.
+///
+/// One flat class with a [kind] discriminator — see `FlightCondition`'s
+/// dartdoc for why that shape was chosen over a sealed union in this
+/// codebase.
+@freezed
+abstract class Requirement with _$Requirement {
+  const factory Requirement({
+    required RequirementKind kind,
+
+    // ---- flightEventCount / flightEventHours.
+    CountableFlightEvent? event,
+    int? count,
+    FlightDuration? hours,
+    RuleWindow? window,
+    @Default(<FlightCondition>[]) List<FlightCondition> conditions,
+
+    // ---- heldRecordCurrentlyValid. Also the "prerequisite on the pilot"
+    // case (#40) -- "holds an instrument rating" and "the medical
+    // certificate is valid" are the same check: is there a currently-valid
+    // HeldRecord of this kind.
+    String? heldRecordKind,
+
+    // ---- allOf / anyOf.
+    @Default(<Requirement>[]) List<Requirement> of,
+  }) = _Requirement;
+
+  factory Requirement.flightEventCount({
+    required CountableFlightEvent event,
+    required int count,
+    required RuleWindow window,
+    List<FlightCondition> conditions = const [],
+  }) => Requirement(
+    kind: RequirementKind.flightEventCount,
+    event: event,
+    count: count,
+    window: window,
+    conditions: conditions,
+  );
+
+  factory Requirement.flightEventHours({
+    required CountableFlightEvent event,
+    required FlightDuration hours,
+    required RuleWindow window,
+    List<FlightCondition> conditions = const [],
+  }) => Requirement(
+    kind: RequirementKind.flightEventHours,
+    event: event,
+    hours: hours,
+    window: window,
+    conditions: conditions,
+  );
+
+  factory Requirement.heldRecordCurrentlyValid(String heldRecordKind) =>
+      Requirement(
+        kind: RequirementKind.heldRecordCurrentlyValid,
+        heldRecordKind: heldRecordKind,
+      );
+
+  factory Requirement.allOf(List<Requirement> of) =>
+      Requirement(kind: RequirementKind.allOf, of: of);
+
+  factory Requirement.anyOf(List<Requirement> of) =>
+      Requirement(kind: RequirementKind.anyOf, of: of);
+}
+
+enum RequirementKind {
+  flightEventCount,
+  flightEventHours,
+  heldRecordCurrentlyValid,
+  allOf,
+  anyOf,
+}
+
+/// A per-flight numeric fact [Requirement.flightEventCount] and
+/// [Requirement.flightEventHours] can sum across a flight set.
+///
+/// Deliberately only the events already on `Flight` (M1) — `landings` and
+/// `takeoffs` read [Flight.landings]/[Flight.takeoffs] narrowed by
+/// [FlightCondition.dayNight] and [FlightCondition.landingType];
+/// `approaches` sums [Approach.count]; `holdingProcedures` reads
+/// [Flight.holdingProceduresCount]. Growing this enum when #121 lands
+/// (flight-review/IPC/proficiency-check markers) is the kind of one-name
+/// addition CLAUDE.md's jurisdiction-primitive acceptance test describes,
+/// not "touching the evaluator" in the sense #42 warns against — the
+/// evaluator's dispatch does not change shape, it gains one more case.
+enum CountableFlightEvent { landings, takeoffs, approaches, holdingProcedures }

--- a/lib/domain/currency/currency_rule_evaluator.dart
+++ b/lib/domain/currency/currency_rule_evaluator.dart
@@ -1,0 +1,433 @@
+import '../model/aircraft.dart';
+import '../model/calendar_date.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../repository/flight_read_repository.dart';
+import 'currency_rule.dart';
+import 'evaluation_subject.dart';
+import 'flight_condition.dart';
+import 'held_record.dart';
+import 'rule_result.dart';
+
+/// Evaluates any schema-conformant [CurrencyRule] against an
+/// [EvaluationSubject] with no rule-specific code — #42. If a new
+/// jurisdiction rule needs a change here rather than just a new
+/// [CurrencyRule] value, the schema (#40) is missing an expression; see
+/// that issue's own acceptance criterion.
+///
+/// Stateless and deterministic: the only inputs to [evaluateRequirement]
+/// are its three arguments, so the same call always produces the same
+/// [RuleResult] — #42's "deterministic given the same inputs and evaluation
+/// date".
+class CurrencyRuleEvaluator {
+  const CurrencyRuleEvaluator();
+
+  /// Evaluates [rule] as a whole, labelling the result with its id and
+  /// citation for display.
+  CurrencyRuleEvaluation evaluateRule(
+    CurrencyRule rule,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) => CurrencyRuleEvaluation(
+    ruleId: rule.id,
+    citation: rule.citation,
+    result: evaluateRequirement(rule.requirement, subject, asOf),
+  );
+
+  /// Evaluates one [Requirement] node, recursing into [Requirement.of] for
+  /// [RequirementKind.allOf]/[RequirementKind.anyOf].
+  RuleResult evaluateRequirement(
+    Requirement requirement,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) {
+    switch (requirement.kind) {
+      case RequirementKind.flightEventCount:
+        return _evaluateFlightEventCount(requirement, subject, asOf);
+      case RequirementKind.flightEventHours:
+        return _evaluateFlightEventHours(requirement, subject, asOf);
+      case RequirementKind.heldRecordCurrentlyValid:
+        return _evaluateHeldRecordCurrentlyValid(requirement, subject, asOf);
+      case RequirementKind.allOf:
+        return _evaluateAllOf(requirement, subject, asOf);
+      case RequirementKind.anyOf:
+        return _evaluateAnyOf(requirement, subject, asOf);
+    }
+  }
+
+  RuleResult _evaluateFlightEventCount(
+    Requirement requirement,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) {
+    final window = requirement.window!;
+    final range = window.rangeEndingAt(asOf, heldRecords: subject.heldRecords);
+
+    final occurrences = <_Occurrence<int>>[];
+    for (final record in subject.flights) {
+      if (!_passesAircraftMatch(
+        record,
+        requirement.conditions,
+        subject.referenceAircraft,
+      )) {
+        continue;
+      }
+      final date = CalendarDate.fromUtcInstant(record.flight.offBlocks);
+      if (date < range.start || date > range.end) {
+        continue;
+      }
+      final weight = _eventCount(
+        record.flight,
+        requirement.event!,
+        requirement.conditions,
+      );
+      if (weight > 0) {
+        occurrences.add(_Occurrence(record.id, date, weight));
+      }
+    }
+    occurrences.sort((a, b) => b.date.compareTo(a.date));
+
+    var cumulative = 0;
+    final contributingIds = <String>[];
+    CalendarDate? anchorDate;
+    for (final occurrence in occurrences) {
+      if (cumulative >= requirement.count!) {
+        break;
+      }
+      cumulative += occurrence.weight;
+      contributingIds.add(occurrence.flightId);
+      anchorDate = occurrence.date;
+    }
+
+    final satisfied = cumulative >= requirement.count!;
+    final label = _describeEvent(requirement.event!, requirement.conditions);
+    return RuleResult(
+      satisfied: satisfied,
+      explanation: satisfied
+          ? '$cumulative of ${requirement.count} $label within the window'
+          : '$cumulative of ${requirement.count} $label; needs '
+                '${requirement.count! - cumulative} more',
+      expiresOn: satisfied ? window.expiryFrom(anchorDate!) : null,
+      contributingFlightIds: contributingIds,
+    );
+  }
+
+  RuleResult _evaluateFlightEventHours(
+    Requirement requirement,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) {
+    final window = requirement.window!;
+    final range = window.rangeEndingAt(asOf, heldRecords: subject.heldRecords);
+
+    final occurrences = <_Occurrence<FlightDuration>>[];
+    for (final record in subject.flights) {
+      if (!_passesAircraftMatch(
+        record,
+        requirement.conditions,
+        subject.referenceAircraft,
+      )) {
+        continue;
+      }
+      final date = CalendarDate.fromUtcInstant(record.flight.offBlocks);
+      if (date < range.start || date > range.end) {
+        continue;
+      }
+      final qualifies =
+          _eventCount(
+            record.flight,
+            requirement.event!,
+            requirement.conditions,
+          ) >
+          0;
+      if (!qualifies) {
+        continue;
+      }
+      final blockTime = record.flight.onBlocks.difference(
+        record.flight.offBlocks,
+      );
+      occurrences.add(
+        _Occurrence(record.id, date, FlightDuration(blockTime.inMinutes)),
+      );
+    }
+    occurrences.sort((a, b) => b.date.compareTo(a.date));
+
+    var cumulative = FlightDuration.zero;
+    final contributingIds = <String>[];
+    CalendarDate? anchorDate;
+    for (final occurrence in occurrences) {
+      if (cumulative >= requirement.hours!) {
+        break;
+      }
+      cumulative += occurrence.weight;
+      contributingIds.add(occurrence.flightId);
+      anchorDate = occurrence.date;
+    }
+
+    final satisfied = cumulative >= requirement.hours!;
+    final label = _describeEvent(requirement.event!, requirement.conditions);
+    return RuleResult(
+      satisfied: satisfied,
+      explanation: satisfied
+          ? '${cumulative.toDecimalHours()} of '
+                '${requirement.hours!.toDecimalHours()} hours ($label flights) '
+                'within the window'
+          : '${cumulative.toDecimalHours()} of '
+                '${requirement.hours!.toDecimalHours()} hours ($label flights); '
+                'needs ${(requirement.hours! - cumulative).toDecimalHours()} more',
+      expiresOn: satisfied ? window.expiryFrom(anchorDate!) : null,
+      contributingFlightIds: contributingIds,
+    );
+  }
+
+  RuleResult _evaluateHeldRecordCurrentlyValid(
+    Requirement requirement,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) {
+    final kind = requirement.heldRecordKind!;
+    HeldRecord? covering;
+    for (final record in subject.heldRecords) {
+      if (record.kind == kind && record.coversDate(asOf)) {
+        covering = record;
+        break;
+      }
+    }
+    return RuleResult(
+      satisfied: covering != null,
+      explanation: covering == null
+          ? 'No currently-valid "$kind" held'
+          : 'Currently-valid "$kind" held'
+                '${covering.validUntil != null ? ', expires ${covering.validUntil}' : ''}',
+      expiresOn: covering?.validUntil,
+    );
+  }
+
+  RuleResult _evaluateAllOf(
+    Requirement requirement,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) {
+    final components = [
+      for (final sub in requirement.of) evaluateRequirement(sub, subject, asOf),
+    ];
+    final satisfied = components.every((c) => c.satisfied);
+
+    // Lapses at the earliest of its components' expiries — the first
+    // component to lapse breaks the whole conjunction.
+    CalendarDate? expiresOn;
+    if (satisfied) {
+      for (final component in components) {
+        final componentExpiry = component.expiresOn;
+        if (componentExpiry != null &&
+            (expiresOn == null || componentExpiry < expiresOn)) {
+          expiresOn = componentExpiry;
+        }
+      }
+    }
+
+    return RuleResult(
+      satisfied: satisfied,
+      explanation: satisfied
+          ? 'All ${components.length} requirements met'
+          : '${components.where((c) => c.satisfied).length} of '
+                '${components.length} requirements met',
+      expiresOn: expiresOn,
+      contributingFlightIds: _mergedContributingIds(components),
+      components: components,
+    );
+  }
+
+  RuleResult _evaluateAnyOf(
+    Requirement requirement,
+    EvaluationSubject subject,
+    CalendarDate asOf,
+  ) {
+    final components = [
+      for (final sub in requirement.of) evaluateRequirement(sub, subject, asOf),
+    ];
+    final satisfied = components.any((c) => c.satisfied);
+
+    // The most generous satisfied alternative decides when the whole
+    // disjunction lapses.
+    CalendarDate? expiresOn;
+    for (final component in components) {
+      final componentExpiry = component.expiresOn;
+      if (component.satisfied &&
+          componentExpiry != null &&
+          (expiresOn == null || componentExpiry > expiresOn)) {
+        expiresOn = componentExpiry;
+      }
+    }
+
+    return RuleResult(
+      satisfied: satisfied,
+      explanation: satisfied
+          ? 'Satisfied by at least one of ${components.length} alternatives'
+          : 'None of ${components.length} alternatives satisfied',
+      expiresOn: expiresOn,
+      contributingFlightIds: _mergedContributingIds(components),
+      components: components,
+    );
+  }
+
+  List<String> _mergedContributingIds(List<RuleResult> components) {
+    final ids = <String>{};
+    for (final component in components) {
+      ids.addAll(component.contributingFlightIds);
+    }
+    return ids.toList();
+  }
+}
+
+class _Occurrence<W> {
+  const _Occurrence(this.flightId, this.date, this.weight);
+
+  final String flightId;
+  final CalendarDate date;
+  final W weight;
+}
+
+/// The count [event], narrowed by [conditions], contributes from [flight] —
+/// e.g. `landings` narrowed to [DayNight.night] and [LandingType.fullStop]
+/// reads only [CircuitCounts.nightFullStop].
+int _eventCount(
+  Flight flight,
+  CountableFlightEvent event,
+  List<FlightCondition> conditions,
+) {
+  switch (event) {
+    case CountableFlightEvent.landings:
+      return _circuitCount(flight.landings, conditions);
+    case CountableFlightEvent.takeoffs:
+      return _circuitCount(flight.takeoffs, conditions);
+    case CountableFlightEvent.approaches:
+      var total = 0;
+      for (final approach in flight.approaches) {
+        total += approach.count;
+      }
+      return total;
+    case CountableFlightEvent.holdingProcedures:
+      return flight.holdingProceduresCount;
+  }
+}
+
+int _circuitCount(CircuitCounts counts, List<FlightCondition> conditions) {
+  DayNight? dayNight;
+  LandingType? landingType;
+  for (final condition in conditions) {
+    switch (condition.kind) {
+      case ConditionKind.dayNight:
+        dayNight = condition.dayNight;
+      case ConditionKind.landingType:
+        landingType = condition.landingType;
+      case ConditionKind.aircraftMatch:
+        break; // Applied at the flight-filter level, not here.
+    }
+  }
+
+  final includeDay = dayNight == null || dayNight == DayNight.day;
+  final includeNight = dayNight == null || dayNight == DayNight.night;
+  final includeFullStop =
+      landingType == null || landingType == LandingType.fullStop;
+  final includeTouchAndGo =
+      landingType == null || landingType == LandingType.touchAndGo;
+
+  var total = 0;
+  if (includeDay && includeFullStop) total += counts.dayFullStop;
+  if (includeDay && includeTouchAndGo) total += counts.dayTouchAndGo;
+  if (includeNight && includeFullStop) total += counts.nightFullStop;
+  if (includeNight && includeTouchAndGo) total += counts.nightTouchAndGo;
+  return total;
+}
+
+/// Whether [record] passes every [ConditionKind.aircraftMatch] condition in
+/// [conditions] against [referenceAircraft].
+///
+/// Throws [StateError] if an aircraft-match condition is present but
+/// [referenceAircraft] is null — a rule asking "same type as what?" with
+/// nothing supplied to compare against is a caller error, not a state to
+/// silently treat as passing or failing.
+bool _passesAircraftMatch(
+  FlightRecord record,
+  List<FlightCondition> conditions,
+  Aircraft? referenceAircraft,
+) {
+  for (final condition in conditions) {
+    if (condition.kind != ConditionKind.aircraftMatch) {
+      continue;
+    }
+    if (referenceAircraft == null) {
+      throw StateError(
+        'Requirement has an aircraftMatch condition but '
+        'EvaluationSubject.referenceAircraft is null',
+      );
+    }
+    if (!_aircraftMatches(
+      record.aircraft,
+      referenceAircraft,
+      condition.aircraftMatch!,
+    )) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _aircraftMatches(Aircraft flown, Aircraft reference, AircraftMatch level) {
+  final flownType = flown.typeRatingDesignator ?? flown.icaoTypeDesignator;
+  final referenceType =
+      reference.typeRatingDesignator ?? reference.icaoTypeDesignator;
+  final sameType = flownType != null && flownType == referenceType;
+  final sameClass =
+      flown.engineType == reference.engineType &&
+      flown.engineCount == reference.engineCount &&
+      flown.operatingSurface == reference.operatingSurface;
+
+  return switch (level) {
+    AircraftMatch.sameType => sameType,
+    AircraftMatch.sameClass => sameClass,
+    AircraftMatch.sameTypeOrClass => sameType || sameClass,
+  };
+}
+
+String _eventLabel(CountableFlightEvent event) => switch (event) {
+  CountableFlightEvent.landings => 'landings',
+  CountableFlightEvent.takeoffs => 'takeoffs',
+  CountableFlightEvent.approaches => 'approaches',
+  CountableFlightEvent.holdingProcedures => 'holding procedures',
+};
+
+/// [_eventLabel] qualified by [conditions]' day/night and landing-type
+/// values, e.g. "night full-stop landings" — #43's own example explanation
+/// names the qualifiers, not just the bare event ("needs 1 more full-stop
+/// night landing", not "needs 1 more landing"). Silent about
+/// [ConditionKind.aircraftMatch]: that condition narrows *which flights*
+/// count, not what kind of event is being counted, so it belongs in a
+/// result's flight list, not its event description.
+String _describeEvent(
+  CountableFlightEvent event,
+  List<FlightCondition> conditions,
+) {
+  DayNight? dayNight;
+  LandingType? landingType;
+  for (final condition in conditions) {
+    switch (condition.kind) {
+      case ConditionKind.dayNight:
+        dayNight = condition.dayNight;
+      case ConditionKind.landingType:
+        landingType = condition.landingType;
+      case ConditionKind.aircraftMatch:
+        break;
+    }
+  }
+
+  final qualifiers = [
+    if (dayNight != null) dayNight.name,
+    if (landingType == LandingType.fullStop) 'full-stop',
+    if (landingType == LandingType.touchAndGo) 'touch-and-go',
+  ];
+  return qualifiers.isEmpty
+      ? _eventLabel(event)
+      : '${qualifiers.join(' ')} ${_eventLabel(event)}';
+}

--- a/lib/domain/currency/currency_rule_loader.dart
+++ b/lib/domain/currency/currency_rule_loader.dart
@@ -1,0 +1,92 @@
+import '../model/calendar_date.dart';
+import 'currency_rule.dart';
+import 'currency_rule_yaml.dart';
+
+/// Resolves a [CurrencyRule.id] plus an evaluation date to the exact
+/// version of that rule in force on that date — #41: "a flight in 2019
+/// must be evaluated against the rule in force in 2019", regardless of how
+/// many times the regulation has changed since.
+///
+/// Parsing (`parseCurrencyRuleYaml`) and version resolution are kept
+/// separate, the same split `JurisdictionRegistry` makes from
+/// `parseJurisdictionProfileYaml`: this class works on already-parsed
+/// [CurrencyRule]s, so it stays pure Dart with no file or asset I/O of its
+/// own — reading `assets/rules/*.yaml` is the caller's concern (`lib/data/`
+/// or app start-up), not the domain layer's.
+class CurrencyRuleLoader {
+  /// Groups [rules] by [CurrencyRule.id], sorted oldest-first within each
+  /// group, validating for the errors #41 requires caught at load time
+  /// rather than at evaluation:
+  ///
+  /// Throws [StateError] naming the id and date if two versions of the same
+  /// rule share an [CurrencyRule.effectiveFrom] — an unresolvable ambiguity,
+  /// since nothing then says which one governs that date.
+  CurrencyRuleLoader(Iterable<CurrencyRule> rules) : _byId = {} {
+    for (final rule in rules) {
+      (_byId[rule.id] ??= []).add(rule);
+    }
+    for (final entry in _byId.entries) {
+      entry.value.sort((a, b) => a.effectiveFrom.compareTo(b.effectiveFrom));
+      for (var i = 1; i < entry.value.length; i++) {
+        if (entry.value[i].effectiveFrom == entry.value[i - 1].effectiveFrom) {
+          throw StateError(
+            'Currency rule "${entry.key}" has two versions both effective '
+            'from ${entry.value[i].effectiveFrom}',
+          );
+        }
+      }
+    }
+  }
+
+  /// Parses [yamlContents] — one YAML document per rule file — via
+  /// [parseCurrencyRuleYaml], propagating the first [FormatException]
+  /// immediately rather than loading the rest first: #41's "malformed rule
+  /// files fail loudly at startup, not silently at evaluation" means the
+  /// whole app should refuse to start, not limp along with a partial rule
+  /// set.
+  factory CurrencyRuleLoader.fromYaml(Iterable<String> yamlContents) {
+    return CurrencyRuleLoader([
+      for (final content in yamlContents) parseCurrencyRuleYaml(content),
+    ]);
+  }
+
+  final Map<String, List<CurrencyRule>> _byId;
+
+  /// Every loaded version of rule [id], oldest first. Empty if [id] is
+  /// unknown — superseded versions are never dropped from this list, per
+  /// #41's "superseded rules retained, never deleted".
+  List<CurrencyRule> versionsOf(String id) =>
+      List.unmodifiable(_byId[id] ?? const []);
+
+  /// The version of rule [id] in force on [evaluationDate] — the latest
+  /// version with [CurrencyRule.effectiveFrom] `<=` [evaluationDate].
+  ///
+  /// Throws [ArgumentError] naming [id] if no version of it was ever
+  /// loaded, and [StateError] if every known version's
+  /// [CurrencyRule.effectiveFrom] is after [evaluationDate] — the rule did
+  /// not exist yet on that date, which is a data or caller error, not a
+  /// state to silently fall back from.
+  CurrencyRule resolve(String id, CalendarDate evaluationDate) {
+    final versions = _byId[id];
+    if (versions == null) {
+      throw ArgumentError('No currency rule loaded under id "$id"');
+    }
+
+    CurrencyRule? inForce;
+    for (final version in versions) {
+      if (version.effectiveFrom <= evaluationDate) {
+        inForce = version;
+      } else {
+        break; // sorted oldest-first — nothing later can match either.
+      }
+    }
+    if (inForce == null) {
+      throw StateError(
+        'Currency rule "$id" had no version in force on $evaluationDate — '
+        'the earliest known version takes effect '
+        '${versions.first.effectiveFrom}',
+      );
+    }
+    return inForce;
+  }
+}

--- a/lib/domain/currency/currency_rule_yaml.dart
+++ b/lib/domain/currency/currency_rule_yaml.dart
@@ -1,0 +1,349 @@
+import 'package:yaml/yaml.dart';
+
+import '../model/calendar_date.dart';
+import '../model/flight_duration.dart';
+import 'currency_rule.dart';
+import 'flight_condition.dart';
+import 'rule_window.dart';
+
+/// Parses one `assets/rules/*.yaml` document into a [CurrencyRule] — #40.
+///
+/// Validation happens here, in Dart, the same way
+/// `parseJurisdictionProfileYaml` validates jurisdiction profiles: every
+/// failure is a [FormatException] naming the rule id (once known) and the
+/// offending field, never a silent default. `currency_rule.schema.json`
+/// (published alongside this file) exists for editor autocomplete and as an
+/// independently-checked cross-reference — see the test that asserts the
+/// two agree on which fields are required — not as the enforcement
+/// mechanism itself.
+CurrencyRule parseCurrencyRuleYaml(String yamlContent) {
+  final yaml = loadYaml(yamlContent);
+  if (yaml is! YamlMap) {
+    throw const FormatException('Currency rule YAML must be a map');
+  }
+
+  final id = _requiredString(yaml, 'id', 'currency rule');
+  final jurisdictionId = _requiredString(yaml, 'jurisdiction', id);
+  final citation = _requiredString(yaml, 'citation', id);
+  final effectiveFrom = _requiredDate(yaml, 'effective_from', id);
+  final expiresOn = _optionalDate(yaml, 'expires_on', id);
+
+  final requirementYaml = yaml['requirement'];
+  if (requirementYaml is! YamlMap) {
+    throw FormatException('Currency rule "$id" is missing a "requirement" map');
+  }
+  final requirement = _parseRequirement(requirementYaml, id);
+
+  return CurrencyRule(
+    id: id,
+    jurisdictionId: jurisdictionId,
+    citation: citation,
+    effectiveFrom: effectiveFrom,
+    expiresOn: expiresOn,
+    requirement: requirement,
+  );
+}
+
+const Map<String, RequirementKind> _requirementKinds = {
+  'flight_event_count': RequirementKind.flightEventCount,
+  'flight_event_hours': RequirementKind.flightEventHours,
+  'held_record_currently_valid': RequirementKind.heldRecordCurrentlyValid,
+  'all_of': RequirementKind.allOf,
+  'any_of': RequirementKind.anyOf,
+};
+
+Requirement _parseRequirement(YamlMap yaml, String ruleId) {
+  final kindText = _requiredString(
+    yaml,
+    'kind',
+    ruleId,
+    context: 'requirement',
+  );
+  final kind = _requirementKinds[kindText];
+  if (kind == null) {
+    throw FormatException(
+      'Currency rule "$ruleId": requirement "kind" must be one of '
+      '${_requirementKinds.keys.join(', ')}, got "$kindText"',
+    );
+  }
+
+  switch (kind) {
+    case RequirementKind.flightEventCount:
+      return Requirement.flightEventCount(
+        event: _requiredEvent(yaml, ruleId),
+        count: _requiredInt(yaml, 'count', ruleId, context: 'requirement'),
+        window: _parseWindow(_requiredMap(yaml, 'window', ruleId), ruleId),
+        conditions: _parseConditions(yaml, ruleId),
+      );
+    case RequirementKind.flightEventHours:
+      return Requirement.flightEventHours(
+        event: _requiredEvent(yaml, ruleId),
+        hours: _requiredHours(yaml, ruleId),
+        window: _parseWindow(_requiredMap(yaml, 'window', ruleId), ruleId),
+        conditions: _parseConditions(yaml, ruleId),
+      );
+    case RequirementKind.heldRecordCurrentlyValid:
+      return Requirement.heldRecordCurrentlyValid(
+        _requiredString(
+          yaml,
+          'held_record_kind',
+          ruleId,
+          context: 'requirement',
+        ),
+      );
+    case RequirementKind.allOf:
+      return Requirement.allOf(_parseSubRequirements(yaml, ruleId));
+    case RequirementKind.anyOf:
+      return Requirement.anyOf(_parseSubRequirements(yaml, ruleId));
+  }
+}
+
+List<Requirement> _parseSubRequirements(YamlMap yaml, String ruleId) {
+  final of = yaml['of'];
+  if (of is! YamlList || of.isEmpty) {
+    throw FormatException(
+      'Currency rule "$ruleId": requirement "of" must be a non-empty list',
+    );
+  }
+  return [
+    for (final entry in of)
+      if (entry is YamlMap)
+        _parseRequirement(entry, ruleId)
+      else
+        throw FormatException(
+          'Currency rule "$ruleId": requirement "of" entries must be maps',
+        ),
+  ];
+}
+
+const Map<String, CountableFlightEvent> _events = {
+  'landings': CountableFlightEvent.landings,
+  'takeoffs': CountableFlightEvent.takeoffs,
+  'approaches': CountableFlightEvent.approaches,
+  'holding_procedures': CountableFlightEvent.holdingProcedures,
+};
+
+CountableFlightEvent _requiredEvent(YamlMap yaml, String ruleId) {
+  final text = _requiredString(yaml, 'event', ruleId, context: 'requirement');
+  final event = _events[text];
+  if (event == null) {
+    throw FormatException(
+      'Currency rule "$ruleId": requirement "event" must be one of '
+      '${_events.keys.join(', ')}, got "$text"',
+    );
+  }
+  return event;
+}
+
+FlightDuration _requiredHours(YamlMap yaml, String ruleId) {
+  final value = yaml['hours'];
+  if (value is! num) {
+    throw FormatException(
+      'Currency rule "$ruleId": requirement is missing a numeric "hours"',
+    );
+  }
+  return FlightDuration.parseDecimalHours(value.toString());
+}
+
+const Map<String, WindowAnchor> _anchors = {
+  'evaluation_date': WindowAnchor.evaluationDate,
+  'held_record_expiry': WindowAnchor.heldRecordExpiry,
+};
+
+RuleWindow _parseWindow(YamlMap yaml, String ruleId) {
+  final kindText = _requiredString(yaml, 'kind', ruleId, context: 'window');
+  switch (kindText) {
+    case 'rolling_days':
+      return RuleWindow.rollingDays(
+        _requiredInt(yaml, 'days', ruleId, context: 'window'),
+      );
+    case 'calendar_months':
+      final anchorText = yaml['anchor'] as String? ?? 'evaluation_date';
+      final anchor = _anchors[anchorText];
+      if (anchor == null) {
+        throw FormatException(
+          'Currency rule "$ruleId": window "anchor" must be one of '
+          '${_anchors.keys.join(', ')}, got "$anchorText"',
+        );
+      }
+      final anchorHeldRecordKind = yaml['anchor_held_record_kind'] as String?;
+      if (anchor == WindowAnchor.heldRecordExpiry &&
+          anchorHeldRecordKind == null) {
+        throw FormatException(
+          'Currency rule "$ruleId": window anchor "held_record_expiry" '
+          'requires "anchor_held_record_kind"',
+        );
+      }
+      return RuleWindow.calendarMonths(
+        _requiredInt(yaml, 'months', ruleId, context: 'window'),
+        anchor: anchor,
+        anchorHeldRecordKind: anchorHeldRecordKind,
+      );
+    default:
+      throw FormatException(
+        'Currency rule "$ruleId": window "kind" must be "rolling_days" or '
+        '"calendar_months", got "$kindText"',
+      );
+  }
+}
+
+const Map<String, DayNight> _dayNightValues = {
+  'day': DayNight.day,
+  'night': DayNight.night,
+};
+
+const Map<String, LandingType> _landingTypeValues = {
+  'full_stop': LandingType.fullStop,
+  'touch_and_go': LandingType.touchAndGo,
+};
+
+const Map<String, AircraftMatch> _aircraftMatchValues = {
+  'same_type': AircraftMatch.sameType,
+  'same_class': AircraftMatch.sameClass,
+  'same_type_or_class': AircraftMatch.sameTypeOrClass,
+};
+
+List<FlightCondition> _parseConditions(YamlMap yaml, String ruleId) {
+  final conditions = yaml['conditions'];
+  if (conditions == null) {
+    return const [];
+  }
+  if (conditions is! YamlList) {
+    throw FormatException(
+      'Currency rule "$ruleId": requirement "conditions" must be a list',
+    );
+  }
+  return [for (final entry in conditions) _parseCondition(entry, ruleId)];
+}
+
+FlightCondition _parseCondition(Object? entry, String ruleId) {
+  if (entry is! YamlMap) {
+    throw FormatException(
+      'Currency rule "$ruleId": each entry in "conditions" must be a map',
+    );
+  }
+  final kindText = _requiredString(entry, 'kind', ruleId, context: 'condition');
+  switch (kindText) {
+    case 'day_night':
+      final value = _requiredString(
+        entry,
+        'value',
+        ruleId,
+        context: 'condition',
+      );
+      final dayNight = _dayNightValues[value];
+      if (dayNight == null) {
+        throw FormatException(
+          'Currency rule "$ruleId": condition "value" must be "day" or '
+          '"night", got "$value"',
+        );
+      }
+      return FlightCondition.dayNight(dayNight);
+    case 'landing_type':
+      final value = _requiredString(
+        entry,
+        'value',
+        ruleId,
+        context: 'condition',
+      );
+      final landingType = _landingTypeValues[value];
+      if (landingType == null) {
+        throw FormatException(
+          'Currency rule "$ruleId": condition "value" must be "full_stop" '
+          'or "touch_and_go", got "$value"',
+        );
+      }
+      return FlightCondition.landingType(landingType);
+    case 'aircraft_match':
+      final level = _requiredString(
+        entry,
+        'level',
+        ruleId,
+        context: 'condition',
+      );
+      final match = _aircraftMatchValues[level];
+      if (match == null) {
+        throw FormatException(
+          'Currency rule "$ruleId": condition "level" must be one of '
+          '${_aircraftMatchValues.keys.join(', ')}, got "$level"',
+        );
+      }
+      return FlightCondition.aircraftMatch(match);
+    default:
+      throw FormatException(
+        'Currency rule "$ruleId": condition "kind" must be "day_night", '
+        '"landing_type" or "aircraft_match", got "$kindText"',
+      );
+  }
+}
+
+// ---- Small, shared field-reading helpers. Deliberately not imported from
+// test/fixtures/decoders/fixture_fields.dart: that file is test-only, and
+// production parsing needs its own error wording (rule id, not fixture
+// name).
+
+String _requiredString(
+  YamlMap yaml,
+  String key,
+  String ruleId, {
+  String? context,
+}) {
+  final value = yaml[key];
+  if (value is! String || value.isEmpty) {
+    final where = context == null
+        ? 'Currency rule'
+        : 'Currency rule "$ruleId"\'s $context';
+    throw FormatException('$where is missing a non-empty "$key"');
+  }
+  return value;
+}
+
+int _requiredInt(YamlMap yaml, String key, String ruleId, {String? context}) {
+  final value = yaml[key];
+  if (value is! int) {
+    final where = context == null
+        ? 'Currency rule "$ruleId"'
+        : 'Currency rule "$ruleId"\'s $context';
+    throw FormatException('$where is missing an integer "$key"');
+  }
+  return value;
+}
+
+YamlMap _requiredMap(YamlMap yaml, String key, String ruleId) {
+  final value = yaml[key];
+  if (value is! YamlMap) {
+    throw FormatException('Currency rule "$ruleId" is missing a "$key" map');
+  }
+  return value;
+}
+
+CalendarDate _requiredDate(YamlMap yaml, String key, String ruleId) {
+  final value = yaml[key];
+  if (value is! String) {
+    throw FormatException('Currency rule "$ruleId" is missing a "$key" date');
+  }
+  try {
+    return CalendarDate.parse(value);
+  } on FormatException {
+    throw FormatException(
+      'Currency rule "$ruleId": "$key" must be YYYY-MM-DD, got "$value"',
+    );
+  }
+}
+
+CalendarDate? _optionalDate(YamlMap yaml, String key, String ruleId) {
+  final value = yaml[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is! String) {
+    throw FormatException('Currency rule "$ruleId": "$key" must be a date');
+  }
+  try {
+    return CalendarDate.parse(value);
+  } on FormatException {
+    throw FormatException(
+      'Currency rule "$ruleId": "$key" must be YYYY-MM-DD, got "$value"',
+    );
+  }
+}

--- a/lib/domain/currency/evaluation_subject.dart
+++ b/lib/domain/currency/evaluation_subject.dart
@@ -1,0 +1,36 @@
+import '../model/aircraft.dart';
+import '../repository/flight_read_repository.dart';
+import 'held_record.dart';
+
+/// Everything [CurrencyRuleEvaluator.evaluate] needs about one pilot to
+/// evaluate one [CurrencyRule] against them — a flight set plus held
+/// documents, never just "a flight set" (#42's issue text says that, but a
+/// document-validity or held-rating requirement has no flights in it at
+/// all).
+///
+/// Hand-written, not `@freezed`: constructed fresh for each evaluation call
+/// from data a repository already owns, with no need for `copyWith` or
+/// value equality — the same reasoning as `PrimitiveRegistry`.
+class EvaluationSubject {
+  const EvaluationSubject({
+    required this.flights,
+    this.referenceAircraft,
+    this.heldRecords = const [],
+  });
+
+  /// This pilot's flights, each paired with the aircraft it names — needed
+  /// so [FlightCondition.aircraftMatch] can compare against
+  /// [referenceAircraft].
+  final List<FlightRecord> flights;
+
+  /// The aircraft a recency question is being asked about, e.g. "am I
+  /// current to carry passengers in this aircraft" — null when the rule
+  /// being evaluated has no [FlightCondition.aircraftMatch] condition and so
+  /// never reads it.
+  final Aircraft? referenceAircraft;
+
+  /// Medical certificates, ratings and other held documents — see
+  /// `held_record.dart` for why this is the minimal, decoupled shape rather
+  /// than the real pilot-record model.
+  final List<HeldRecord> heldRecords;
+}

--- a/lib/domain/currency/flight_condition.dart
+++ b/lib/domain/currency/flight_condition.dart
@@ -1,0 +1,49 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'flight_condition.freezed.dart';
+
+/// A filter on which flights contribute toward a [Requirement] — #40's
+/// "conditions on the flights that count: aircraft class, day/night,
+/// full-stop landings, aircraft type match". Exactly these three kinds and
+/// no more: they are the complete list #40's acceptance criteria name: a new
+/// kind is a schema change (#40), not something a rule author should be able
+/// to invent inline.
+///
+/// One flat class with a [kind] discriminator, matching this codebase's
+/// existing union style (see `Countersignature`, `CapacityFilter`) rather
+/// than a sealed class — there is no precedent for sealed unions here and
+/// introducing the first one for a three-variant type is not worth the
+/// inconsistency.
+@freezed
+abstract class FlightCondition with _$FlightCondition {
+  const factory FlightCondition({
+    required ConditionKind kind,
+    DayNight? dayNight,
+    LandingType? landingType,
+    AircraftMatch? aircraftMatch,
+  }) = _FlightCondition;
+
+  factory FlightCondition.dayNight(DayNight value) =>
+      FlightCondition(kind: ConditionKind.dayNight, dayNight: value);
+
+  factory FlightCondition.landingType(LandingType value) =>
+      FlightCondition(kind: ConditionKind.landingType, landingType: value);
+
+  factory FlightCondition.aircraftMatch(AircraftMatch value) =>
+      FlightCondition(kind: ConditionKind.aircraftMatch, aircraftMatch: value);
+}
+
+enum ConditionKind { dayNight, landingType, aircraftMatch }
+
+enum DayNight { day, night }
+
+enum LandingType { fullStop, touchAndGo }
+
+/// How closely the flown aircraft must match the aircraft the recency
+/// question is being asked about (`EvaluationSubject.referenceAircraft`).
+///
+/// `sameType` compares [Aircraft.typeRatingDesignator] when the reference
+/// aircraft has one, else [Aircraft.icaoTypeDesignator]; `sameClass`
+/// compares engine type, engine count and operating surface — the same
+/// tuple that determines an EASA class rating (SEP(land), MEP(sea), ...).
+enum AircraftMatch { sameType, sameClass, sameTypeOrClass }

--- a/lib/domain/currency/held_record.dart
+++ b/lib/domain/currency/held_record.dart
@@ -1,0 +1,49 @@
+import '../model/calendar_date.dart';
+
+/// A pilot-held document the currency engine can check the validity of — a
+/// medical certificate, a class or type rating, an instrument rating.
+///
+/// Deliberately minimal and decoupled from the real pilot-record model
+/// (`Licence`, `MedicalCertificate` — M3's PR3): this is the stable shape
+/// [CurrencyRuleEvaluator] depends on, so the engine (#42) can be built and
+/// tested before the concrete pilot-record model exists. PR3 projects real
+/// held ratings and medical certificates into [HeldRecord]s rather than the
+/// evaluator depending on those models directly — the same reason
+/// `ProjectionResult` is a named-quantity map instead of per-jurisdiction
+/// fields (see `derived_quantity.dart`).
+///
+/// [validUntil] is resolved ahead of time — by whichever primitive computes
+/// an EASA medical's age-dependent duration, for instance — not recomputed
+/// here. The evaluator only ever asks "is this date within the stored
+/// range", never "how long is this class of document valid for": that
+/// question is real logic and belongs in a primitive, per CLAUDE.md's
+/// "declarative stops" rule.
+class HeldRecord {
+  const HeldRecord({
+    required this.kind,
+    required this.validFrom,
+    this.validUntil,
+  });
+
+  /// Identifies which kind of document this is, e.g. `medical_certificate`,
+  /// `eu.easa.sep_class_rating`, `us.faa.instrument_rating`. Matched against
+  /// a rule's `of` field — see `currency_rule.dart`.
+  final String kind;
+
+  final CalendarDate validFrom;
+
+  /// Null means never expires — the FAA endorsement case
+  /// (`docs/ratings-and-endorsements.md` §1): "an FAA endorsement is a
+  /// permanent record with no expiry that feeds an eligibility check only."
+  final CalendarDate? validUntil;
+
+  /// Whether [date] falls within this record's validity, [validFrom]
+  /// inclusive.
+  bool coversDate(CalendarDate date) {
+    if (date < validFrom) {
+      return false;
+    }
+    final until = validUntil;
+    return until == null || date <= until;
+  }
+}

--- a/lib/domain/currency/rule_result.dart
+++ b/lib/domain/currency/rule_result.dart
@@ -1,0 +1,53 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/calendar_date.dart';
+
+part 'rule_result.freezed.dart';
+
+/// The outcome of evaluating one [CurrencyRule] (or, recursively, one
+/// [Requirement] inside it) against an [EvaluationSubject] — #43: "not
+/// current, with no explanation, is a bug."
+///
+/// [components] carries the sub-results of an `allOf`/`anyOf` requirement,
+/// so a composite rule's explanation can point at exactly which branch
+/// succeeded or which one is missing something, rather than collapsing to a
+/// single opaque boolean. Empty for a leaf requirement.
+@freezed
+abstract class RuleResult with _$RuleResult {
+  const factory RuleResult({
+    required bool satisfied,
+
+    /// Human-readable, naming what is missing or confirming what was found
+    /// — e.g. "2 of 3 night landings; needs 1 more full-stop night landing
+    /// by 14 Sep" or "3 of 3 landings within 90 days, in G-ABCD (C152)".
+    /// Never empty.
+    required String explanation,
+
+    /// Set when [satisfied] and the requirement can lapse — the date this
+    /// result stops holding if nothing else qualifying happens. Null when
+    /// [satisfied] is false, or when the requirement can never lapse.
+    CalendarDate? expiresOn,
+
+    /// Ids of the flights that contributed to this result, satisfied or
+    /// not — a partial count still names which flights it has.
+    @Default(<String>[]) List<String> contributingFlightIds,
+
+    /// Sub-results of an `allOf`/`anyOf` requirement, in the order they were
+    /// declared. Empty for a leaf requirement (flight-event or held-record
+    /// check).
+    @Default(<RuleResult>[]) List<RuleResult> components,
+  }) = _RuleResult;
+}
+
+/// A [RuleResult] labelled with the rule it came from — what
+/// [CurrencyRuleEvaluator.evaluate] actually returns. Kept separate from
+/// [RuleResult] itself because [RuleResult.components] nests un-labelled
+/// sub-results: only the outermost result belongs to a citable rule.
+@freezed
+abstract class CurrencyRuleEvaluation with _$CurrencyRuleEvaluation {
+  const factory CurrencyRuleEvaluation({
+    required String ruleId,
+    required String citation,
+    required RuleResult result,
+  }) = _CurrencyRuleEvaluation;
+}

--- a/lib/domain/currency/rule_window.dart
+++ b/lib/domain/currency/rule_window.dart
@@ -1,0 +1,201 @@
+import '../model/calendar_date.dart';
+import 'held_record.dart';
+
+/// The two window shapes #40 requires as distinct concepts: "3 in the
+/// preceding 90 days" is a sliding rolling-day window; "24 calendar months"
+/// is not "730 days" — it runs to the end of a specific month regardless of
+/// which day of the month the anchor fell on.
+enum WindowKind { rollingDays, calendarMonths }
+
+/// What a [RuleWindow] is measured relative to.
+enum WindowAnchor {
+  /// The date the rule is being evaluated as of — the ordinary case, and
+  /// the only anchor a *rolling* recency rule (EASA/FAA passenger currency)
+  /// ever uses.
+  evaluationDate,
+
+  /// A held record's expiry date, e.g. FCL.740.A's SEP revalidation window,
+  /// which runs against the *rating's* expiry, not against today (#47). The
+  /// window does not slide as the evaluation date changes; it is fixed once
+  /// the anchoring record's expiry is known.
+  heldRecordExpiry,
+}
+
+/// The `[start, end]` range a window resolves to for one evaluation —
+/// occurrences dated within this range, inclusive at both ends, count
+/// toward the requirement.
+class DateRange {
+  const DateRange(this.start, this.end);
+
+  final CalendarDate start;
+  final CalendarDate end;
+}
+
+/// A recency window, as #40 requires it expressible: a rolling number of
+/// days, or a number of calendar months, optionally anchored to a held
+/// record's expiry rather than to the evaluation date.
+///
+/// Two independent questions a window answers, kept as two methods rather
+/// than folded into one, because they answer genuinely different things:
+/// [rangeEndingAt] sums *multiple* occurrences backward from a reference
+/// point (how the evaluator filters a flight set); [expiryFrom] projects
+/// forward from a *single* occurrence (how a satisfied [RuleResult]'s
+/// expiry date, and #44's forward projection, are computed).
+class RuleWindow {
+  const RuleWindow._({
+    required this.kind,
+    this.days,
+    this.months,
+    this.anchor = WindowAnchor.evaluationDate,
+    this.anchorHeldRecordKind,
+  });
+
+  factory RuleWindow.rollingDays(int days) =>
+      RuleWindow._(kind: WindowKind.rollingDays, days: days);
+
+  factory RuleWindow.calendarMonths(
+    int months, {
+    WindowAnchor anchor = WindowAnchor.evaluationDate,
+    String? anchorHeldRecordKind,
+  }) {
+    if (anchor == WindowAnchor.heldRecordExpiry &&
+        anchorHeldRecordKind == null) {
+      throw ArgumentError(
+        'anchorHeldRecordKind is required when anchor is heldRecordExpiry',
+      );
+    }
+    return RuleWindow._(
+      kind: WindowKind.calendarMonths,
+      months: months,
+      anchor: anchor,
+      anchorHeldRecordKind: anchorHeldRecordKind,
+    );
+  }
+
+  final WindowKind kind;
+
+  /// Set when [kind] is [WindowKind.rollingDays].
+  final int? days;
+
+  /// Set when [kind] is [WindowKind.calendarMonths].
+  final int? months;
+  final WindowAnchor anchor;
+
+  /// The [HeldRecord.kind] to anchor to, when [anchor] is
+  /// [WindowAnchor.heldRecordExpiry]. Non-null exactly when [anchor] is.
+  final String? anchorHeldRecordKind;
+
+  /// The window's reference point: [evaluationDate] itself, or — for
+  /// [WindowAnchor.heldRecordExpiry] — the matching [HeldRecord]'s expiry.
+  ///
+  /// Throws [StateError] naming the missing kind if no matching held record
+  /// with an expiry is present: an expiry-anchored rule with nothing to
+  /// anchor to is a configuration or data problem, not a state to silently
+  /// treat as "not applicable".
+  CalendarDate _referenceDate(
+    CalendarDate evaluationDate,
+    List<HeldRecord> heldRecords,
+  ) {
+    if (anchor == WindowAnchor.evaluationDate) {
+      return evaluationDate;
+    }
+    final recordKind = anchorHeldRecordKind!;
+    for (final record in heldRecords) {
+      if (record.kind == recordKind && record.validUntil != null) {
+        return record.validUntil!;
+      }
+    }
+    throw StateError(
+      'Window anchors to held record kind "$recordKind" with an expiry, '
+      'but no such record was supplied',
+    );
+  }
+
+  /// The range to sum qualifying occurrences across, ending at this
+  /// window's reference point (see [_referenceDate]).
+  DateRange rangeEndingAt(
+    CalendarDate evaluationDate, {
+    required List<HeldRecord> heldRecords,
+  }) {
+    final end = _referenceDate(evaluationDate, heldRecords);
+    final start = switch (kind) {
+      WindowKind.rollingDays => end.addDays(-days!),
+      WindowKind.calendarMonths => _shiftCalendarMonths(end, -months!),
+    };
+    return DateRange(start, end);
+  }
+
+  /// The last date a single occurrence dated [occurrenceDate] still counts
+  /// toward this window — the day recency lapses is the day after.
+  ///
+  /// For [WindowKind.calendarMonths] this is always the last day of the
+  /// target month, never a day-of-month-preserving shift — "24 calendar
+  /// months" is valid *through the end of* the 24th month regardless of
+  /// which day of the month the occurrence fell on (#49).
+  CalendarDate expiryFrom(CalendarDate occurrenceDate) {
+    return switch (kind) {
+      WindowKind.rollingDays => occurrenceDate.addDays(days!),
+      WindowKind.calendarMonths => _lastDayOfMonth(
+        _shiftMonthOnly(occurrenceDate.year, occurrenceDate.month, months!),
+      ),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is RuleWindow &&
+      other.kind == kind &&
+      other.days == days &&
+      other.months == months &&
+      other.anchor == anchor &&
+      other.anchorHeldRecordKind == anchorHeldRecordKind;
+
+  @override
+  int get hashCode =>
+      Object.hash(kind, days, months, anchor, anchorHeldRecordKind);
+
+  @override
+  String toString() =>
+      'RuleWindow(kind: $kind, days: $days, months: $months, '
+      'anchor: $anchor, anchorHeldRecordKind: $anchorHeldRecordKind)';
+}
+
+bool _isLeapYear(int year) =>
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+
+int _daysInMonth(int year, int month) {
+  const lengths = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month == 2 && _isLeapYear(year)) {
+    return 29;
+  }
+  return lengths[month - 1];
+}
+
+/// (year, month) shifted by [deltaMonths], normalising overflow/underflow
+/// into year carries. Floor division, not truncating `~/`, so this is also
+/// correct for a negative [deltaMonths] that crosses a year boundary — Dart's
+/// `%` already returns a non-negative remainder against a positive divisor,
+/// so `total - (total % 12)` is always the exact multiple of 12 at or below
+/// `total`.
+(int, int) _shiftMonthOnly(int year, int month, int deltaMonths) {
+  final total = year * 12 + (month - 1) + deltaMonths;
+  final remainder = total % 12;
+  final newYear = (total - remainder) ~/ 12;
+  return (newYear, remainder + 1);
+}
+
+/// [date] shifted by [deltaMonths] calendar months, clamping the day to the
+/// target month's last real day (e.g. 31 Jan − 1 month → 31 Dec is fine, but
+/// 31 Jan + 1 month clamps to 28/29 Feb — there is no 31 February).
+CalendarDate _shiftCalendarMonths(CalendarDate date, int deltaMonths) {
+  final (year, month) = _shiftMonthOnly(date.year, date.month, deltaMonths);
+  final day = date.day > _daysInMonth(year, month)
+      ? _daysInMonth(year, month)
+      : date.day;
+  return CalendarDate(year, month, day);
+}
+
+CalendarDate _lastDayOfMonth((int, int) yearMonth) {
+  final (year, month) = yearMonth;
+  return CalendarDate(year, month, _daysInMonth(year, month));
+}

--- a/lib/domain/model/calendar_date.dart
+++ b/lib/domain/model/calendar_date.dart
@@ -40,6 +40,42 @@ class CalendarDate implements Comparable<CalendarDate> {
 
   static final RegExp _pattern = RegExp(r'^(\d{4})-(\d{2})-(\d{2})$');
 
+  /// This date shifted by [days] days; negative moves backward.
+  ///
+  /// Pure integer calendar arithmetic (Fliegel & van Flandern's Julian day
+  /// number algorithm) rather than `DateTime`, which `lib/domain/` may not
+  /// name at all — rule 3, `tool/check_domain_types.dart`.
+  CalendarDate addDays(int days) {
+    final jdn = _toJulianDayNumber(year, month, day) + days;
+    return _fromJulianDayNumber(jdn);
+  }
+
+  static int _toJulianDayNumber(int y, int m, int d) {
+    final a = (14 - m) ~/ 12;
+    final y2 = y + 4800 - a;
+    final m2 = m + 12 * a - 3;
+    return d +
+        (153 * m2 + 2) ~/ 5 +
+        365 * y2 +
+        y2 ~/ 4 -
+        y2 ~/ 100 +
+        y2 ~/ 400 -
+        32045;
+  }
+
+  static CalendarDate _fromJulianDayNumber(int jdn) {
+    final a = jdn + 32044;
+    final b = (4 * a + 3) ~/ 146097;
+    final c = a - (146097 * b) ~/ 4;
+    final d = (4 * c + 3) ~/ 1461;
+    final e = c - (1461 * d) ~/ 4;
+    final m = (5 * e + 2) ~/ 153;
+    final day = e - (153 * m + 2) ~/ 5 + 1;
+    final month = m + 3 - 12 * (m ~/ 10);
+    final year = 100 * b + d - 4800 + (m ~/ 10);
+    return CalendarDate(year, month, day);
+  }
+
   @override
   int compareTo(CalendarDate other) {
     if (year != other.year) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,6 +283,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -315,6 +323,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.12.0"
+  json_schema:
+    dependency: "direct dev"
+    description:
+      name: json_schema
+      sha256: f37d9c3fdfe8c9aae55fdfd5af815d24ce63c3a0f6a2c1f0982c30f43643fa1a
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.2"
   json_serializable:
     dependency: "direct dev"
     description:
@@ -443,6 +459,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   recase:
     dependency: transitive
     description:
@@ -459,6 +483,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: "6a43b1858dca2febaf93e15639aa6b0c49ccdfd7647775f15a499f872b018154"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   shelf:
     dependency: transitive
     description:
@@ -584,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uri:
+    dependency: transitive
+    description:
+      name: uri
+      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,10 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.15.1
+  # Only used by test/domain/currency/currency_rule_schema_test.dart and
+  # tool/check_currency_rules.dart -- the app never validates against the
+  # published JSON Schema at runtime, see currency_rule_yaml.dart's dartdoc.
+  json_schema: ^5.2.2
   json_serializable: ^6.14.1
   # drift_dev is capped below 2.34.1 by the freezed pin above, not by choice
   # — see the comment on the drift dependency for the full chain.
@@ -50,3 +54,4 @@ flutter:
   assets:
     - assets/aerodromes/
     - assets/jurisdictions/
+    - assets/rules/

--- a/test/domain/currency/currency_rule_evaluator_test.dart
+++ b/test/domain/currency/currency_rule_evaluator_test.dart
@@ -1,0 +1,604 @@
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/flight_condition.dart';
+import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/currency/rule_window.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A flight with every field defaulted to something inert, overriding only
+/// what a given currency test cares about. Deliberately not a
+/// `test/fixtures/` YAML fixture: these are synthetic mechanism probes for
+/// the generic evaluator, not realistic scenarios worth a shared,
+/// named fixture -- #53's golden, hand-verified fixture logbook is where
+/// that investment belongs.
+Flight _flight({
+  required CalendarDate date,
+  CircuitCounts? landings,
+  CircuitCounts? takeoffs,
+  List<Approach> approaches = const [],
+  int holdingProceduresCount = 0,
+  String aircraftRegistration = 'G-TEST',
+}) {
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
+  return Flight(
+    aircraftRegistration: aircraftRegistration,
+    route: const ['EGXX'],
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(const Duration(hours: 1)),
+    capacity: const PilotCapacity(
+      commandAuthority: true,
+      soleManipulator: true,
+      soleOccupant: true,
+      multiPilotOperation: false,
+      additionalCrewRequiredByRule: false,
+      actingAsInstructor: false,
+      actingAsExaminer: false,
+      picusClaimed: false,
+      picInterventionNotRequired: false,
+    ),
+    carryingPassengers: false,
+    takeoffs: takeoffs ?? const CircuitCounts(),
+    landings: landings ?? const CircuitCounts(),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: approaches,
+    holdingProceduresCount: holdingProceduresCount,
+    trackingPerformed: false,
+    remarks: '',
+  );
+}
+
+const _testAircraft = Aircraft(
+  registration: 'G-TEST',
+  manufacturer: 'Cessna',
+  model: '152',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+FlightRecord _record(String id, Flight flight, {Aircraft? aircraft}) =>
+    FlightRecord(id: id, flight: flight, aircraft: aircraft ?? _testAircraft);
+
+void main() {
+  const evaluator = CurrencyRuleEvaluator();
+
+  group('flightEventCount', () {
+    final requirement = Requirement.flightEventCount(
+      event: CountableFlightEvent.landings,
+      count: 3,
+      window: RuleWindow.rollingDays(90),
+    );
+
+    test('satisfied by exactly the boundary flights, and reports expiry', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        flights: [
+          _record(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 3, 3), // exactly 90 days back
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+          _record(
+            '2',
+            _flight(
+              date: CalendarDate(2024, 4, 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+          _record(
+            '3',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(requirement, subject, asOf);
+
+      expect(result.satisfied, isTrue);
+      expect(result.contributingFlightIds, unorderedEquals(['1', '2', '3']));
+      // Oldest of the 3 relied-upon landings is 2024-03-03; recency lapses
+      // the day after it falls outside the 90-day window.
+      expect(result.expiresOn, CalendarDate(2024, 6, 1));
+    });
+
+    test(
+      'one day later, the oldest landing has aged out and it is unsatisfied',
+      () {
+        final asOf = CalendarDate(2024, 6, 2);
+        final subject = EvaluationSubject(
+          flights: [
+            _record(
+              '1',
+              _flight(
+                date: CalendarDate(2024, 3, 3),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+            _record(
+              '2',
+              _flight(
+                date: CalendarDate(2024, 4, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+            _record(
+              '3',
+              _flight(
+                date: CalendarDate(2024, 5, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          requirement,
+          subject,
+          asOf,
+        );
+
+        expect(result.satisfied, isFalse);
+        expect(result.expiresOn, isNull);
+        expect(result.explanation, contains('2 of 3'));
+      },
+    );
+
+    test('a flight contributing multiple landings counts each one', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        flights: [
+          _record(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 3),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(requirement, subject, asOf);
+
+      expect(result.satisfied, isTrue);
+      expect(result.contributingFlightIds, ['1']);
+    });
+
+    test('flights outside the window do not contribute', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        flights: [
+          _record(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 3, 2), // 91 days back
+              landings: const CircuitCounts(dayFullStop: 3),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(requirement, subject, asOf);
+
+      expect(result.satisfied, isFalse);
+      expect(result.contributingFlightIds, isEmpty);
+    });
+  });
+
+  group('flightEventCount with day/night and full-stop conditions', () {
+    test('night full-stop only counts the matching sub-count', () {
+      final requirement = Requirement.flightEventCount(
+        event: CountableFlightEvent.landings,
+        count: 1,
+        window: RuleWindow.rollingDays(90),
+        conditions: [
+          FlightCondition.dayNight(DayNight.night),
+          FlightCondition.landingType(LandingType.fullStop),
+        ],
+      );
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        flights: [
+          _record(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 5, nightTouchAndGo: 5),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(requirement, subject, asOf);
+
+      expect(result.satisfied, isFalse);
+
+      final withOneNightFullStop = EvaluationSubject(
+        flights: [
+          _record(
+            '2',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(nightFullStop: 1),
+            ),
+          ),
+        ],
+      );
+      expect(
+        evaluator
+            .evaluateRequirement(requirement, withOneNightFullStop, asOf)
+            .satisfied,
+        isTrue,
+      );
+    });
+  });
+
+  group('explanation wording', () {
+    test(
+      'names the day/night and landing-type qualifiers, not just the bare event',
+      () {
+        // #43's own example: "needs 1 more full-stop night landing", not
+        // "needs 1 more landing".
+        final requirement = Requirement.flightEventCount(
+          event: CountableFlightEvent.landings,
+          count: 3,
+          window: RuleWindow.rollingDays(90),
+          conditions: [
+            FlightCondition.dayNight(DayNight.night),
+            FlightCondition.landingType(LandingType.fullStop),
+          ],
+        );
+        final subject = EvaluationSubject(
+          flights: [
+            _record(
+              '1',
+              _flight(
+                date: CalendarDate(2024, 5, 1),
+                landings: const CircuitCounts(nightFullStop: 2),
+              ),
+            ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          requirement,
+          subject,
+          CalendarDate(2024, 6, 1),
+        );
+
+        expect(result.explanation, contains('night full-stop landings'));
+        expect(result.explanation, contains('2 of 3'));
+      },
+    );
+  });
+
+  group('flightEventCount with aircraft match condition', () {
+    final requirement = Requirement.flightEventCount(
+      event: CountableFlightEvent.landings,
+      count: 1,
+      window: RuleWindow.rollingDays(90),
+      conditions: [FlightCondition.aircraftMatch(AircraftMatch.sameType)],
+    );
+
+    test('only flights in the reference aircraft type count', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: const Aircraft(
+          registration: 'G-REF',
+          manufacturer: 'Piper',
+          model: 'Arrow',
+          icaoTypeDesignator: 'PA28',
+          category: AircraftCategory.aeroplane,
+          engineType: EngineType.piston,
+          engineCount: 1,
+          operatingSurface: OperatingSurface.land,
+          requiresMultiCrew: false,
+        ),
+        flights: [
+          _record(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+            aircraft: const Aircraft(
+              registration: 'G-OTHER',
+              manufacturer: 'Cessna',
+              model: '152',
+              icaoTypeDesignator: 'C152',
+              category: AircraftCategory.aeroplane,
+              engineType: EngineType.piston,
+              engineCount: 1,
+              operatingSurface: OperatingSurface.land,
+              requiresMultiCrew: false,
+            ),
+          ),
+          _record(
+            '2',
+            _flight(
+              date: CalendarDate(2024, 5, 2),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+            aircraft: const Aircraft(
+              registration: 'G-SAME',
+              manufacturer: 'Piper',
+              model: 'Arrow',
+              icaoTypeDesignator: 'PA28',
+              category: AircraftCategory.aeroplane,
+              engineType: EngineType.piston,
+              engineCount: 1,
+              operatingSurface: OperatingSurface.land,
+              requiresMultiCrew: false,
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(requirement, subject, asOf);
+
+      expect(result.satisfied, isTrue);
+      expect(result.contributingFlightIds, ['2']);
+    });
+  });
+
+  group('flightEventHours', () {
+    test('sums flight duration, not count', () {
+      final requirement = Requirement.flightEventHours(
+        event: CountableFlightEvent.landings,
+        hours: const FlightDuration(6 * 60),
+        window: RuleWindow.rollingDays(365),
+        conditions: const [],
+      );
+      final asOf = CalendarDate(2024, 6, 1);
+      // Each flight is 1 hour (see _flight's fixed onBlocks - offBlocks).
+      final subject = EvaluationSubject(
+        flights: [
+          for (var i = 0; i < 6; i++)
+            _record(
+              '$i',
+              _flight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(requirement, subject, asOf);
+
+      expect(result.satisfied, isTrue);
+    });
+  });
+
+  group('heldRecordCurrentlyValid', () {
+    final requirement = Requirement.heldRecordCurrentlyValid(
+      'us.faa.instrument_rating',
+    );
+
+    test('satisfied when a covering held record exists', () {
+      final subject = EvaluationSubject(
+        flights: const [],
+        heldRecords: [
+          HeldRecord(
+            kind: 'us.faa.instrument_rating',
+            validFrom: CalendarDate(2020, 1, 1),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        subject,
+        CalendarDate(2024, 1, 1),
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+
+    test('unsatisfied when no held record of that kind exists', () {
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        const EvaluationSubject(flights: []),
+        CalendarDate(2024, 1, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+
+    test('unsatisfied once the held record has expired', () {
+      final subject = EvaluationSubject(
+        flights: const [],
+        heldRecords: [
+          HeldRecord(
+            kind: 'eu.easa.sep_class_rating',
+            validFrom: CalendarDate(2022, 1, 1),
+            validUntil: CalendarDate(2024, 1, 1),
+          ),
+        ],
+      );
+      final ratingRequirement = Requirement.heldRecordCurrentlyValid(
+        'eu.easa.sep_class_rating',
+      );
+
+      final result = evaluator.evaluateRequirement(
+        ratingRequirement,
+        subject,
+        CalendarDate(2024, 1, 2),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('anyOf', () {
+    test('alternative means of compliance: satisfied if either branch is', () {
+      final recency = Requirement.flightEventCount(
+        event: CountableFlightEvent.landings,
+        count: 3,
+        window: RuleWindow.rollingDays(90),
+      );
+      final proficiencyCheckAlternative = Requirement.heldRecordCurrentlyValid(
+        'proficiency_check',
+      );
+      final requirement = Requirement.anyOf([
+        recency,
+        proficiencyCheckAlternative,
+      ]);
+
+      final subject = EvaluationSubject(
+        flights: const [],
+        heldRecords: [
+          HeldRecord(
+            kind: 'proficiency_check',
+            validFrom: CalendarDate(2024, 1, 1),
+            validUntil: CalendarDate(2024, 12, 1),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        subject,
+        CalendarDate(2024, 6, 1),
+      );
+
+      expect(result.satisfied, isTrue);
+      expect(result.components, hasLength(2));
+      expect(result.components[0].satisfied, isFalse);
+      expect(result.components[1].satisfied, isTrue);
+    });
+
+    test('unsatisfied when every branch is', () {
+      final requirement = Requirement.anyOf([
+        Requirement.heldRecordCurrentlyValid('a'),
+        Requirement.heldRecordCurrentlyValid('b'),
+      ]);
+
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        const EvaluationSubject(flights: []),
+        CalendarDate(2024, 6, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('allOf', () {
+    test('satisfied only when every branch is', () {
+      final requirement = Requirement.allOf([
+        Requirement.heldRecordCurrentlyValid('a'),
+        Requirement.heldRecordCurrentlyValid('b'),
+      ]);
+      final subject = EvaluationSubject(
+        flights: const [],
+        heldRecords: [
+          HeldRecord(kind: 'a', validFrom: CalendarDate(2020, 1, 1)),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        subject,
+        CalendarDate(2024, 6, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+      expect(result.components[0].satisfied, isTrue);
+      expect(result.components[1].satisfied, isFalse);
+    });
+  });
+
+  group('CurrencyRuleEvaluator.evaluateRule', () {
+    test('labels the result with the rule id and citation', () {
+      final rule = CurrencyRule(
+        id: 'test.rule',
+        jurisdictionId: 'eu.easa.part-fcl',
+        citation: 'FCL.060(b)(1)',
+        effectiveFrom: CalendarDate(2020, 1, 1),
+        requirement: Requirement.heldRecordCurrentlyValid('x'),
+      );
+
+      final evaluation = evaluator.evaluateRule(
+        rule,
+        const EvaluationSubject(flights: []),
+        CalendarDate(2024, 1, 1),
+      );
+
+      expect(evaluation.ruleId, 'test.rule');
+      expect(evaluation.citation, 'FCL.060(b)(1)');
+      expect(evaluation.result.satisfied, isFalse);
+    });
+  });
+
+  group('window anchored to a held record expiry', () {
+    test(
+      'sums hours in the fixed window preceding the rating expiry, not today',
+      () {
+        final requirement = Requirement.flightEventHours(
+          event: CountableFlightEvent.landings,
+          hours: const FlightDuration(2 * 60),
+          window: RuleWindow.calendarMonths(
+            12,
+            anchor: WindowAnchor.heldRecordExpiry,
+            anchorHeldRecordKind: 'eu.easa.sep_class_rating',
+          ),
+          conditions: const [],
+        );
+        final heldRecords = [
+          HeldRecord(
+            kind: 'eu.easa.sep_class_rating',
+            validFrom: CalendarDate(2023, 1, 1),
+            validUntil: CalendarDate(2025, 1, 1),
+          ),
+        ];
+        // Two 1-hour flights inside [2024-01-01, 2025-01-01]; evaluated
+        // "today" in 2024, long before the rating's own expiry.
+        final subject = EvaluationSubject(
+          flights: [
+            _record(
+              '1',
+              _flight(
+                date: CalendarDate(2024, 3, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+            _record(
+              '2',
+              _flight(
+                date: CalendarDate(2024, 4, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+          ],
+          heldRecords: heldRecords,
+        );
+
+        final result = evaluator.evaluateRequirement(
+          requirement,
+          subject,
+          CalendarDate(2024, 6, 1),
+        );
+
+        expect(result.satisfied, isTrue);
+      },
+    );
+  });
+}

--- a/test/domain/currency/currency_rule_loader_test.dart
+++ b/test/domain/currency/currency_rule_loader_test.dart
@@ -1,0 +1,134 @@
+import 'package:easa_digital_log/domain/currency/currency_rule_loader.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _v1 = '''
+id: faa.61_56.flight_review
+jurisdiction: us.faa.part61
+citation: "§61.56 (pre-2020 wording)"
+effective_from: 2010-01-01
+expires_on: 2020-06-01
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: flight_review
+''';
+
+const _v2 = '''
+id: faa.61_56.flight_review
+jurisdiction: us.faa.part61
+citation: "§61.56"
+effective_from: 2020-06-01
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: flight_review
+''';
+
+const _otherRule = '''
+id: easa.fcl060.passenger_recency
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.060(b)(1)"
+effective_from: 2011-11-08
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: x
+''';
+
+void main() {
+  group('CurrencyRuleLoader.fromYaml', () {
+    test(
+      'loads every file and resolves the version in force on a given date',
+      () {
+        final loader = CurrencyRuleLoader.fromYaml([_v1, _v2, _otherRule]);
+
+        final beforeTransition = loader.resolve(
+          'faa.61_56.flight_review',
+          CalendarDate(2020, 5, 31),
+        );
+        final onTransition = loader.resolve(
+          'faa.61_56.flight_review',
+          CalendarDate(2020, 6, 1),
+        );
+
+        expect(beforeTransition.citation, '§61.56 (pre-2020 wording)');
+        expect(onTransition.citation, '§61.56');
+      },
+    );
+
+    test(
+      'a historical flight is evaluated against the rule in force on its own date',
+      () {
+        // #41's own framing: "a flight in 2019 must be evaluated against the
+        // rule in force in 2019", regardless of which version is current now.
+        final loader = CurrencyRuleLoader.fromYaml([_v1, _v2]);
+
+        final rule2019 = loader.resolve(
+          'faa.61_56.flight_review',
+          CalendarDate(2019, 1, 1),
+        );
+
+        expect(rule2019.citation, '§61.56 (pre-2020 wording)');
+      },
+    );
+
+    test('superseded versions are retained, not deleted', () {
+      final loader = CurrencyRuleLoader.fromYaml([_v1, _v2]);
+
+      expect(
+        loader.versionsOf('faa.61_56.flight_review').map((r) => r.citation),
+        containsAll(['§61.56 (pre-2020 wording)', '§61.56']),
+      );
+    });
+
+    test('throws ArgumentError naming the id when it is unknown', () {
+      final loader = CurrencyRuleLoader.fromYaml([_otherRule]);
+
+      expect(
+        () => loader.resolve('no.such.rule', CalendarDate(2024, 1, 1)),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('no.such.rule'),
+          ),
+        ),
+      );
+    });
+
+    test('throws StateError when evaluated before any version existed', () {
+      final loader = CurrencyRuleLoader.fromYaml([_v1, _v2]);
+
+      expect(
+        () =>
+            loader.resolve('faa.61_56.flight_review', CalendarDate(2005, 1, 1)),
+        throwsStateError,
+      );
+    });
+
+    test(
+      'fails loudly at load time when one file is malformed, not deferred to evaluation',
+      () {
+        expect(
+          () => CurrencyRuleLoader.fromYaml([_otherRule, 'not: [valid, rule']),
+          throwsFormatException,
+        );
+      },
+    );
+
+    test('rejects two versions of the same rule sharing an effective_from', () {
+      const duplicate = '''
+id: faa.61_56.flight_review
+jurisdiction: us.faa.part61
+citation: "a different citation, same effective date"
+effective_from: 2010-01-01
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: flight_review
+''';
+
+      expect(
+        () => CurrencyRuleLoader.fromYaml([_v1, duplicate]),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/test/domain/currency/currency_rule_schema_test.dart
+++ b/test/domain/currency/currency_rule_schema_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_schema/json_schema.dart';
+import 'package:yaml/yaml.dart';
+
+/// The exact fields `parseCurrencyRuleYaml` treats as mandatory --
+/// duplicated here deliberately, not imported, so this test fails the
+/// moment the parser and the published schema drift apart, whichever one
+/// changed.
+const _parserRequiredFields = [
+  'id',
+  'jurisdiction',
+  'citation',
+  'effective_from',
+  'requirement',
+];
+
+const _validRuleYaml = '''
+id: easa.fcl060.passenger_recency
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.060(b)(1)"
+effective_from: 2011-11-08
+requirement:
+  kind: any_of
+  of:
+    - kind: flight_event_count
+      event: landings
+      count: 3
+      window: { kind: rolling_days, days: 90 }
+      conditions:
+        - { kind: aircraft_match, level: same_type_or_class }
+    - kind: held_record_currently_valid
+      held_record_kind: proficiency_check
+''';
+
+/// Converts a `package:yaml` document (whose maps/lists are `YamlMap`/
+/// `YamlList`, not plain `Map`/`List`) into plain JSON-compatible values --
+/// `json_schema` validates structurally, but its error paths and `oneOf`
+/// disambiguation are only exercised against ordinary Dart collections in
+/// its own test suite, so round-tripping through `jsonDecode(jsonEncode(_))`
+/// (which already knows how to serialise `YamlMap`/`YamlList` as maps and
+/// lists) is the safe, known-supported input shape rather than a shortcut.
+Object? _toPlain(String yamlContent) =>
+    jsonDecode(jsonEncode(loadYaml(yamlContent)));
+
+void main() {
+  late JsonSchema schema;
+
+  setUpAll(() {
+    final schemaFile = File('assets/rules/schema/currency-rule.schema.json');
+    schema = JsonSchema.create(schemaFile.readAsStringSync());
+  });
+
+  test('the published schema requires exactly what the parser requires', () {
+    expect(schema.requiredProperties, unorderedEquals(_parserRequiredFields));
+  });
+
+  test('validates a rule the Dart parser also accepts', () {
+    final result = schema.validate(_toPlain(_validRuleYaml));
+
+    expect(result.errors, isEmpty);
+    // The schema and the parser are two independent checks of the same
+    // input; both must accept it.
+    expect(() => parseCurrencyRuleYaml(_validRuleYaml), returnsNormally);
+  });
+
+  test('rejects a rule missing a mandatory field', () {
+    const missingCitation = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+effective_from: 2011-11-08
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: x
+''';
+
+    final result = schema.validate(_toPlain(missingCitation));
+
+    expect(result.isValid, isFalse);
+  });
+
+  test('rejects an unknown top-level field', () {
+    const withTypo = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: x
+effective_from: 2011-11-08
+effectiv_form: 2011-11-08
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: x
+''';
+
+    final result = schema.validate(_toPlain(withTypo));
+
+    expect(result.isValid, isFalse);
+  });
+
+  test('rejects a requirement mixing fields from two different kinds', () {
+    const mixedKind = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: x
+effective_from: 2011-11-08
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: x
+  count: 3
+''';
+
+    final result = schema.validate(_toPlain(mixedKind));
+
+    expect(result.isValid, isFalse);
+  });
+}

--- a/test/domain/currency/currency_rule_yaml_test.dart
+++ b/test/domain/currency/currency_rule_yaml_test.dart
@@ -1,0 +1,246 @@
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:easa_digital_log/domain/currency/flight_condition.dart';
+import 'package:easa_digital_log/domain/currency/rule_window.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseCurrencyRuleYaml', () {
+    test('parses a minimal flight-event-count rule', () {
+      const yaml = '''
+id: easa.fcl060.passenger_recency
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.060(b)(1)"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_count
+  event: landings
+  count: 3
+  window:
+    kind: rolling_days
+    days: 90
+''';
+
+      final rule = parseCurrencyRuleYaml(yaml);
+
+      expect(rule.id, 'easa.fcl060.passenger_recency');
+      expect(rule.jurisdictionId, 'eu.easa.part-fcl');
+      expect(rule.citation, 'FCL.060(b)(1)');
+      expect(rule.effectiveFrom, CalendarDate(2011, 11, 8));
+      expect(rule.expiresOn, isNull);
+      expect(
+        rule.requirement,
+        Requirement.flightEventCount(
+          event: CountableFlightEvent.landings,
+          count: 3,
+          window: RuleWindow.rollingDays(90),
+        ),
+      );
+    });
+
+    test('parses expires_on when present', () {
+      const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+expires_on: 2020-01-01
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: x
+''';
+
+      final rule = parseCurrencyRuleYaml(yaml);
+
+      expect(rule.expiresOn, CalendarDate(2020, 1, 1));
+    });
+
+    test('parses conditions: day/night, landing type, aircraft match', () {
+      const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_count
+  event: landings
+  count: 1
+  window:
+    kind: rolling_days
+    days: 90
+  conditions:
+    - kind: day_night
+      value: night
+    - kind: landing_type
+      value: full_stop
+    - kind: aircraft_match
+      level: same_type_or_class
+''';
+
+      final rule = parseCurrencyRuleYaml(yaml);
+
+      expect(rule.requirement.conditions, [
+        FlightCondition.dayNight(DayNight.night),
+        FlightCondition.landingType(LandingType.fullStop),
+        FlightCondition.aircraftMatch(AircraftMatch.sameTypeOrClass),
+      ]);
+    });
+
+    test(
+      'parses a calendar-months window anchored to a held record expiry',
+      () {
+        const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_hours
+  event: landings
+  hours: 12
+  window:
+    kind: calendar_months
+    months: 12
+    anchor: held_record_expiry
+    anchor_held_record_kind: eu.easa.sep_class_rating
+''';
+
+        final rule = parseCurrencyRuleYaml(yaml);
+
+        expect(rule.requirement.hours, const FlightDuration(12 * 60));
+        expect(
+          rule.requirement.window,
+          RuleWindow.calendarMonths(
+            12,
+            anchor: WindowAnchor.heldRecordExpiry,
+            anchorHeldRecordKind: 'eu.easa.sep_class_rating',
+          ),
+        );
+      },
+    );
+
+    test('parses fractional hours', () {
+      const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_hours
+  event: landings
+  hours: 6.5
+  window: { kind: rolling_days, days: 90 }
+''';
+
+      final rule = parseCurrencyRuleYaml(yaml);
+
+      expect(rule.requirement.hours, const FlightDuration(6 * 60 + 30));
+    });
+
+    test(
+      'parses a nested any_of composite (alternative means of compliance)',
+      () {
+        const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: any_of
+  of:
+    - kind: flight_event_count
+      event: landings
+      count: 3
+      window: { kind: rolling_days, days: 90 }
+    - kind: held_record_currently_valid
+      held_record_kind: proficiency_check
+''';
+
+        final rule = parseCurrencyRuleYaml(yaml);
+
+        expect(rule.requirement.kind, RequirementKind.anyOf);
+        expect(rule.requirement.of, hasLength(2));
+        expect(rule.requirement.of[0].kind, RequirementKind.flightEventCount);
+        expect(
+          rule.requirement.of[1].kind,
+          RequirementKind.heldRecordCurrentlyValid,
+        );
+      },
+    );
+
+    for (final missing in [
+      'id',
+      'jurisdiction',
+      'citation',
+      'effective_from',
+      'requirement',
+    ]) {
+      test(
+        'throws FormatException naming the field when "$missing" is missing',
+        () {
+          final fields = {
+            'id': 'x',
+            'jurisdiction': 'eu.easa.part-fcl',
+            'citation': 'x',
+            'effective_from': '2011-11-08',
+          };
+          fields.remove(missing);
+          final buffer = StringBuffer();
+          fields.forEach((key, value) => buffer.writeln('$key: $value'));
+          if (missing != 'requirement') {
+            buffer.writeln('requirement:');
+            buffer.writeln('  kind: held_record_currently_valid');
+            buffer.writeln('  held_record_kind: x');
+          }
+
+          expect(
+            () => parseCurrencyRuleYaml(buffer.toString()),
+            throwsA(
+              isA<FormatException>().having(
+                (e) => e.message,
+                'message',
+                contains(missing),
+              ),
+            ),
+          );
+        },
+      );
+    }
+
+    test('rejects a malformed effective_from date', () {
+      const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: "not-a-date"
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: x
+''';
+
+      expect(() => parseCurrencyRuleYaml(yaml), throwsFormatException);
+    });
+
+    test('rejects an unknown requirement kind', () {
+      const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: not_a_real_kind
+''';
+
+      expect(() => parseCurrencyRuleYaml(yaml), throwsFormatException);
+    });
+
+    test('rejects a top-level document that is not a map', () {
+      expect(
+        () => parseCurrencyRuleYaml('- just\n- a list'),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/domain/currency/rule_window_test.dart
+++ b/test/domain/currency/rule_window_test.dart
@@ -1,0 +1,109 @@
+import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/currency/rule_window.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RuleWindow.rollingDays', () {
+    test('start is exactly the boundary day, inclusive', () {
+      // '3 in the preceding 90 days', evaluated on 2024-06-01: an event on
+      // 2024-03-03 is exactly 90 days back and must still count -- #45's
+      // acceptance criterion is a boundary test at exactly 90 days.
+      final window = RuleWindow.rollingDays(90);
+      final asOf = CalendarDate(2024, 6, 1);
+
+      final range = window.rangeEndingAt(asOf, heldRecords: const []);
+
+      expect(range.start, CalendarDate(2024, 3, 3));
+      expect(range.end, asOf);
+    });
+
+    test('day 91 back falls outside the window', () {
+      final window = RuleWindow.rollingDays(90);
+      final asOf = CalendarDate(2024, 6, 1);
+      final range = window.rangeEndingAt(asOf, heldRecords: const []);
+
+      expect(CalendarDate(2024, 3, 2) < range.start, isTrue);
+    });
+  });
+
+  group('RuleWindow.expiryFrom', () {
+    test('rollingDays: the last day still within N days of the occurrence', () {
+      final window = RuleWindow.rollingDays(90);
+
+      final expiry = window.expiryFrom(CalendarDate(2024, 3, 3));
+
+      expect(expiry, CalendarDate(2024, 6, 1));
+    });
+
+    test(
+      'calendarMonths: valid through the end of the Nth month, not N*30 days',
+      () {
+        // A flight review on 2024-01-15 is valid for 24 calendar months --
+        // #49: "valid through the end of the 24th month, not 730 days".
+        final window = RuleWindow.calendarMonths(24);
+
+        final expiry = window.expiryFrom(CalendarDate(2024, 1, 15));
+
+        expect(expiry, CalendarDate(2026, 1, 31));
+      },
+    );
+
+    test(
+      'calendarMonths: from the 31st lands on the last real day of the target month',
+      () {
+        // #49: "Tests at the month boundary, including from the 31st of a
+        // month" -- January 31 + 1 calendar month has no "31 February".
+        final window = RuleWindow.calendarMonths(1);
+
+        final expiry = window.expiryFrom(CalendarDate(2024, 1, 31));
+
+        expect(expiry, CalendarDate(2024, 2, 29)); // 2024 is a leap year
+      },
+    );
+
+    test(
+      'anchored to a held record expiry uses that date, not evaluationDate',
+      () {
+        final window = RuleWindow.calendarMonths(
+          12,
+          anchor: WindowAnchor.heldRecordExpiry,
+          anchorHeldRecordKind: 'eu.easa.sep_class_rating',
+        );
+        final heldRecords = [
+          HeldRecord(
+            kind: 'eu.easa.sep_class_rating',
+            validFrom: CalendarDate(2023, 1, 1),
+            validUntil: CalendarDate(2025, 1, 1),
+          ),
+        ];
+
+        // Evaluated today, 2024-01-01, but the window is relative to the
+        // rating's 2025-01-01 expiry, not to today -- #47.
+        final range = window.rangeEndingAt(
+          CalendarDate(2024, 1, 1),
+          heldRecords: heldRecords,
+        );
+
+        expect(range.end, CalendarDate(2025, 1, 1));
+        expect(range.start, CalendarDate(2024, 1, 1));
+      },
+    );
+
+    test('anchored to a missing held record throws', () {
+      final window = RuleWindow.calendarMonths(
+        12,
+        anchor: WindowAnchor.heldRecordExpiry,
+        anchorHeldRecordKind: 'eu.easa.sep_class_rating',
+      );
+
+      expect(
+        () => window.rangeEndingAt(
+          CalendarDate(2024, 1, 1),
+          heldRecords: const [],
+        ),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/test/domain/model/calendar_date_test.dart
+++ b/test/domain/model/calendar_date_test.dart
@@ -15,6 +15,29 @@ void main() {
     });
   });
 
+  group('CalendarDate.addDays', () {
+    test('crosses a month boundary', () {
+      expect(
+        const CalendarDate(2024, 1, 28).addDays(5),
+        const CalendarDate(2024, 2, 2),
+      );
+    });
+
+    test('crosses a leap-year February 29', () {
+      expect(
+        const CalendarDate(2024, 2, 28).addDays(1),
+        const CalendarDate(2024, 2, 29),
+      );
+    });
+
+    test('negative days moves backward across a year boundary', () {
+      expect(
+        const CalendarDate(2024, 1, 3).addDays(-5),
+        const CalendarDate(2023, 12, 29),
+      );
+    });
+  });
+
   group('CalendarDate', () {
     test('orders, compares and de-duplicates by value', () {
       const a = CalendarDate(2026, 6, 15);

--- a/tool/check_currency_rules.dart
+++ b/tool/check_currency_rules.dart
@@ -1,0 +1,75 @@
+/// Validates every `assets/rules/*.yaml` file two independent ways — #40's
+/// "JSON Schema published and validated in CI against every rule file":
+/// against `assets/rules/schema/currency-rule.schema.json`, and against the
+/// Dart parser (`lib/domain/currency/currency_rule_yaml.dart`), which is the
+/// real enforcement at load time (#41). A file that fails either is a build
+/// failure, not a runtime surprise.
+///
+/// Run: `dart run tool/check_currency_rules.dart`
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:json_schema/json_schema.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+const String rulesDirectory = 'assets/rules';
+const String schemaPath = 'assets/rules/schema/currency-rule.schema.json';
+
+void main() {
+  final directory = Directory(rulesDirectory);
+  if (!directory.existsSync()) {
+    stdout.writeln(
+      'check_currency_rules: $rulesDirectory does not exist yet — '
+      'nothing to check.',
+    );
+    exit(0);
+  }
+
+  final schema = JsonSchema.create(File(schemaPath).readAsStringSync());
+
+  final ruleFiles =
+      directory
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.yaml'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  final failures = <String>[];
+  for (final file in ruleFiles) {
+    final relativePath = p.relative(file.path);
+    final content = file.readAsStringSync();
+
+    try {
+      parseCurrencyRuleYaml(content);
+    } on FormatException catch (e) {
+      failures.add('$relativePath: Dart parser rejected it — $e');
+      continue;
+    }
+
+    final plain = jsonDecode(jsonEncode(loadYaml(content)));
+    final result = schema.validate(plain);
+    if (!result.isValid) {
+      for (final error in result.errors) {
+        failures.add('$relativePath: schema violation — $error');
+      }
+    }
+  }
+
+  if (failures.isEmpty) {
+    stdout.writeln(
+      'check_currency_rules: ${ruleFiles.length} rule file(s) clean.',
+    );
+    exit(0);
+  }
+
+  stderr.writeln('check_currency_rules: ${failures.length} violation(s):');
+  for (final failure in failures) {
+    stderr.writeln('  $failure');
+  }
+  exit(1);
+}


### PR DESCRIPTION
## Summary
- Declarative YAML currency rule schema (#40): event counts, hours, held-document validity, and `allOf`/`anyOf` composites — alternative means of compliance falls out of `anyOf` rather than needing its own concept.
- JSON Schema published at `assets/rules/schema/currency-rule.schema.json`, kept honest by a test asserting it and the Dart parser require exactly the same fields; a new `tool/check_currency_rules.dart` CI step validates every future rule file both ways.
- Effective-date-aware rule loader (#41): resolves a rule id + evaluation date to the exact version in force, retains superseded versions, fails loudly at load time on a malformed file.
- Generic evaluator (#42) with explainable results (#43): rolling-day and calendar-month windows (including the expiry-anchored case #47 needs), day/night and full-stop/aircraft-match conditions, and results that name which flights contributed and what's still missing ("2 of 3 night full-stop landings; needs 1 more").
- `EvaluationSubject`/`HeldRecord` are deliberately minimal placeholders decoupled from the real pilot-record model, so #51/#52's held-rating and medical-certificate rules can be evaluated once that model lands in a later PR without touching the evaluator again.
- Incidental: `CalendarDate.addDays`, pure Julian-day arithmetic (no `DateTime`, banned in `lib/domain/`).

Closes #40, #41, #42, #43.

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_currency_rules.dart`
- [x] `flutter test --coverage` — 422 passing, 49 new
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 93.2%, above the 90% gate
- [x] `dart run tool/check_schema_snapshot.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)