### PR TITLE
First jurisdiction currency rules and expiry projection

### DIFF
--- a/assets/rules/easa/fcl060_b1_passenger_recency.yaml
+++ b/assets/rules/easa/fcl060_b1_passenger_recency.yaml
@@ -1,0 +1,30 @@
+# FCL.060(b)(1): three take-offs, approaches and landings in the preceding
+# 90 days, in an aircraft of the same type or class (or an FFS representing
+# it -- the FFS case is not modelled here; see #11's FSTD session model,
+# which is a separate flight kind entirely).
+#
+# Represented as a landing count alone, not three separate counts of
+# take-offs/approaches/landings: docs/entry-form.md 5 is explicit that this
+# is a recency *condition*, not a logging requirement, and an approach is
+# implicit in every landing -- unlike FAA 61.57(a), which genuinely needs
+# take-offs and landings counted independently (docs/entry-form.md 5,
+# "a pilot who took over in flight has zero take-offs and one landing").
+#
+# Scope: FCL.060(b)(2), the multi-pilot variant with its own sole-manipulator
+# and countersignature conditions, is deliberately not covered by this rule
+# -- #45's own acceptance criteria allow scoping it out explicitly rather
+# than guessing at its shape.
+id: easa.fcl060.b1_passenger_recency
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.060(b)(1)"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_count
+  event: landings
+  count: 3
+  window:
+    kind: rolling_days
+    days: 90
+  conditions:
+    - kind: aircraft_match
+      level: same_type_or_class

--- a/assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml
+++ b/assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml
@@ -1,0 +1,39 @@
+# Sec.61.57(a)(2): in a tailwheel airplane, the three takeoffs and three
+# landings required by Sec.61.57(a) must each have been to a full stop.
+#
+# A caller evaluating currency for a tailwheel aircraft should resolve this
+# rule id instead of 61_57_a's -- check
+# Aircraft.requiredQualifications['us.faa.part61'] for
+# AircraftQualification.faaTailwheel, the same fact the entry form and
+# endorsement tracking already key on (docs/ratings-and-endorsements.md 3).
+# The currency engine itself has no notion of "tailwheel"; that selection is
+# the caller's, not a conditional inside this rule.
+id: us.faa.61_57_a2.tailwheel_takeoff_landing_currency
+jurisdiction: us.faa.part61
+citation: "§61.57(a)(2)"
+effective_from: 1997-08-04
+requirement:
+  kind: all_of
+  of:
+    - kind: flight_event_count
+      event: takeoffs
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: landing_type
+          value: full_stop
+        - kind: aircraft_match
+          level: class_or_type_if_required
+    - kind: flight_event_count
+      event: landings
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: landing_type
+          value: full_stop
+        - kind: aircraft_match
+          level: class_or_type_if_required

--- a/assets/rules/faa/61_57_a_takeoff_landing_currency.yaml
+++ b/assets/rules/faa/61_57_a_takeoff_landing_currency.yaml
@@ -1,0 +1,40 @@
+# Sec.61.57(a): three takeoffs and three landings within the preceding 90
+# days, in an aircraft of the same category and class, and the same type if
+# a type rating is required for that aircraft.
+#
+# Takeoffs and landings are counted independently -- docs/entry-form.md 5:
+# "a pilot who took over in flight has zero take-offs and one landing" --
+# unlike EASA's FCL.060(b)(1), where a landing count alone stands in for the
+# regulation's "take-offs, approaches and landings" wording.
+#
+# The tailwheel full-stop variant is a separate rule --
+# 61_57_a2_tailwheel_takeoff_landing_currency.yaml -- rather than a
+# conditional inside this one: which rule applies depends on the aircraft
+# being asked about, and Aircraft.requiredQualifications already answers
+# that without teaching the currency engine anything about aircraft
+# qualifications.
+id: us.faa.61_57_a.takeoff_landing_currency
+jurisdiction: us.faa.part61
+citation: "§61.57(a)"
+effective_from: 1997-08-04
+requirement:
+  kind: all_of
+  of:
+    - kind: flight_event_count
+      event: takeoffs
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: aircraft_match
+          level: class_or_type_if_required
+    - kind: flight_event_count
+      event: landings
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: aircraft_match
+          level: class_or_type_if_required

--- a/assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml
+++ b/assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml
@@ -1,0 +1,52 @@
+# Sec.61.57(b): for night passenger carriage, three takeoffs and three
+# landings to a full stop within the preceding 90 days, during the period
+# from one hour after sunset to one hour before sunrise, in an aircraft of
+# the same category and class, and the same type if a type rating is
+# required.
+#
+# The full-stop condition is the divergence from EASA's FCL.060(b)(3) (#46,
+# not yet implemented): EASA's night passenger recency needs one night
+# take-off and landing of any kind, full-stop or touch-and-go
+# (docs/jurisdiction-matrix.md 5, "Landings must be full-stop? No" for EASA,
+# "yes" for FAA). A night touch-and-go can satisfy the EASA rule and not
+# this one.
+#
+# The day/night split read here is Flight.landings/.takeoffs'
+# CircuitCounts.night* fields -- the pilot-entered raw fact, not a
+# recomputed civil-twilight or sunset-based window. See
+# faa_night_time.dart's own dartdoc: that field already carries the
+# currency-relevant day/night split and must not be reconciled against a
+# projection's own night-time figure.
+id: us.faa.61_57_b.night_takeoff_landing_currency
+jurisdiction: us.faa.part61
+citation: "§61.57(b)"
+effective_from: 1997-08-04
+requirement:
+  kind: all_of
+  of:
+    - kind: flight_event_count
+      event: takeoffs
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: day_night
+          value: night
+        - kind: landing_type
+          value: full_stop
+        - kind: aircraft_match
+          level: class_or_type_if_required
+    - kind: flight_event_count
+      event: landings
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: day_night
+          value: night
+        - kind: landing_type
+          value: full_stop
+        - kind: aircraft_match
+          level: class_or_type_if_required

--- a/assets/rules/schema/currency-rule.schema.json
+++ b/assets/rules/schema/currency-rule.schema.json
@@ -64,7 +64,14 @@
         {
           "properties": {
             "kind": { "const": "aircraft_match" },
-            "level": { "enum": ["same_type", "same_class", "same_type_or_class"] }
+            "level": {
+              "enum": [
+                "same_type",
+                "same_class",
+                "same_type_or_class",
+                "class_or_type_if_required"
+              ]
+            }
           },
           "required": ["level"],
           "additionalProperties": false

--- a/lib/domain/currency/currency_expiry_projection.dart
+++ b/lib/domain/currency/currency_expiry_projection.dart
@@ -1,0 +1,59 @@
+import '../model/calendar_date.dart';
+import 'rule_result.dart';
+
+/// One [CurrencyRuleEvaluation]'s worth of "when does this next lapse",
+/// pulled out of its full result — what [nextToExpire] returns.
+class NextExpiry {
+  const NextExpiry({
+    required this.ruleId,
+    required this.citation,
+    required this.expiresOn,
+  });
+
+  final String ruleId;
+  final String citation;
+  final CalendarDate expiresOn;
+}
+
+/// Across every rule evaluation in [evaluations], the one that lapses
+/// soonest — #44's "combined next thing to expire view across all
+/// applicable requirements".
+///
+/// "You are current" is less useful than "you stop being current on 14
+/// September unless you fly" (#44's own framing) — this is the single
+/// figure a dashboard needs to show that.
+///
+/// An evaluation only competes for "next to expire" if it is currently
+/// [RuleResult.satisfied] *and* carries a real [RuleResult.expiresOn]:
+///
+/// - Unsatisfied requirements (no qualifying events at all, or not enough
+///   of them) are excluded, not treated as "already expired" — they are a
+///   "not current" state, a different concern from "about to lapse".
+/// - Requirements that can never lapse (satisfied with a null
+///   [RuleResult.expiresOn] — an FAA endorsement, for instance) are
+///   likewise excluded: something that never lapses can never be the next
+///   thing *to* lapse.
+///
+/// Returns `null` if nothing in [evaluations] qualifies — an empty list, or
+/// a list where every entry is unsatisfied, never-lapsing, or both.
+NextExpiry? nextToExpire(List<CurrencyRuleEvaluation> evaluations) {
+  CurrencyRuleEvaluation? earliest;
+  for (final evaluation in evaluations) {
+    final expiresOn = evaluation.result.expiresOn;
+    if (!evaluation.result.satisfied || expiresOn == null) {
+      continue;
+    }
+    final earliestExpiresOn = earliest?.result.expiresOn;
+    if (earliestExpiresOn == null || expiresOn < earliestExpiresOn) {
+      earliest = evaluation;
+    }
+  }
+  if (earliest == null) {
+    return null;
+  }
+  return NextExpiry(
+    ruleId: earliest.ruleId,
+    citation: earliest.citation,
+    expiresOn: earliest.result.expiresOn!,
+  );
+}

--- a/lib/domain/currency/currency_rule_evaluator.dart
+++ b/lib/domain/currency/currency_rule_evaluator.dart
@@ -388,6 +388,14 @@ bool _aircraftMatches(Aircraft flown, Aircraft reference, AircraftMatch level) {
     AircraftMatch.sameType => sameType,
     AircraftMatch.sameClass => sameClass,
     AircraftMatch.sameTypeOrClass => sameType || sameClass,
+    // §61.57(a): a type match only if the reference aircraft is itself
+    // type-rated — tested against the actual type-rating designators, not
+    // the icaoTypeDesignator fallback [sameType] uses, since this is
+    // specifically about type-rating currency.
+    AircraftMatch.classOrTypeIfRequired =>
+      reference.typeRatingDesignator == null
+          ? sameClass
+          : flown.typeRatingDesignator == reference.typeRatingDesignator,
   };
 }
 

--- a/lib/domain/currency/currency_rule_yaml.dart
+++ b/lib/domain/currency/currency_rule_yaml.dart
@@ -201,6 +201,7 @@ const Map<String, AircraftMatch> _aircraftMatchValues = {
   'same_type': AircraftMatch.sameType,
   'same_class': AircraftMatch.sameClass,
   'same_type_or_class': AircraftMatch.sameTypeOrClass,
+  'class_or_type_if_required': AircraftMatch.classOrTypeIfRequired,
 };
 
 List<FlightCondition> _parseConditions(YamlMap yaml, String ruleId) {

--- a/lib/domain/currency/flight_condition.dart
+++ b/lib/domain/currency/flight_condition.dart
@@ -46,4 +46,18 @@ enum LandingType { fullStop, touchAndGo }
 /// aircraft has one, else [Aircraft.icaoTypeDesignator]; `sameClass`
 /// compares engine type, engine count and operating surface — the same
 /// tuple that determines an EASA class rating (SEP(land), MEP(sea), ...).
-enum AircraftMatch { sameType, sameClass, sameTypeOrClass }
+///
+/// [classOrTypeIfRequired] is `§61.57(a)`'s own wording: "the same category
+/// and class of aircraft (if a class rating is required) and, if the
+/// aircraft is type-rated, ... the same type of aircraft" — same class
+/// ordinarily, but same *type* when [Aircraft.typeRatingDesignator] is set,
+/// since a type is always a subset of its class. A distinct value rather
+/// than reusing [sameType]/[sameClass]: which one applies depends on the
+/// *reference* aircraft, not on a rule author's static choice, and only
+/// `§61.57(a)` needs that.
+enum AircraftMatch {
+  sameType,
+  sameClass,
+  sameTypeOrClass,
+  classOrTypeIfRequired,
+}

--- a/test/domain/currency/currency_expiry_projection_test.dart
+++ b/test/domain/currency/currency_expiry_projection_test.dart
@@ -1,0 +1,186 @@
+import 'package:easa_digital_log/domain/currency/currency_expiry_projection.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/rule_result.dart';
+import 'package:easa_digital_log/domain/currency/rule_window.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'currency_test_helpers.dart';
+
+CurrencyRuleEvaluation _evaluation({
+  required String ruleId,
+  required bool satisfied,
+  CalendarDate? expiresOn,
+}) => CurrencyRuleEvaluation(
+  ruleId: ruleId,
+  citation: 'citation for $ruleId',
+  result: RuleResult(
+    satisfied: satisfied,
+    explanation: 'irrelevant to this test',
+    expiresOn: expiresOn,
+  ),
+);
+
+void main() {
+  group('nextToExpire', () {
+    test('picks the earliest expiry among several satisfied rules', () {
+      final evaluations = [
+        _evaluation(
+          ruleId: 'a',
+          satisfied: true,
+          expiresOn: CalendarDate(2024, 9, 1),
+        ),
+        _evaluation(
+          ruleId: 'b',
+          satisfied: true,
+          expiresOn: CalendarDate(2024, 7, 1),
+        ),
+        _evaluation(
+          ruleId: 'c',
+          satisfied: true,
+          expiresOn: CalendarDate(2024, 12, 1),
+        ),
+      ];
+
+      final next = nextToExpire(evaluations);
+
+      expect(next?.ruleId, 'b');
+      expect(next?.expiresOn, CalendarDate(2024, 7, 1));
+    });
+
+    test('a satisfied rule that never lapses is not "next to expire"', () {
+      final evaluations = [
+        _evaluation(ruleId: 'never-lapses', satisfied: true, expiresOn: null),
+        _evaluation(
+          ruleId: 'does-lapse',
+          satisfied: true,
+          expiresOn: CalendarDate(2024, 7, 1),
+        ),
+      ];
+
+      final next = nextToExpire(evaluations);
+
+      expect(next?.ruleId, 'does-lapse');
+    });
+
+    test('an unsatisfied rule is excluded, not treated as already expired', () {
+      final evaluations = [
+        _evaluation(ruleId: 'not-current', satisfied: false, expiresOn: null),
+      ];
+
+      expect(nextToExpire(evaluations), isNull);
+    });
+
+    test('null when nothing is both satisfied and lapsing', () {
+      expect(nextToExpire(const []), isNull);
+      expect(
+        nextToExpire([
+          _evaluation(ruleId: 'a', satisfied: true, expiresOn: null),
+        ]),
+        isNull,
+      );
+    });
+  });
+
+  group('nextToExpire against the real evaluator', () {
+    const evaluator = CurrencyRuleEvaluator();
+    final rule = CurrencyRule(
+      id: 'test.recency',
+      jurisdictionId: 'eu.easa.part-fcl',
+      citation: 'test citation',
+      effectiveFrom: CalendarDate(2020, 1, 1),
+      requirement: Requirement.flightEventCount(
+        event: CountableFlightEvent.landings,
+        count: 3,
+        window: RuleWindow.rollingDays(90),
+      ),
+    );
+
+    test('flying one more qualifying flight extends currency', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final threeLandings = EvaluationSubject(
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 3, 3 + i), // oldest is the anchor
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+        ],
+      );
+      final before = evaluator.evaluateRule(rule, threeLandings, asOf);
+
+      final withOneMoreRecentLanding = EvaluationSubject(
+        flights: [
+          ...threeLandings.flights,
+          currencyTestRecord(
+            'newest',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 30),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+        ],
+      );
+      final after = evaluator.evaluateRule(
+        rule,
+        withOneMoreRecentLanding,
+        asOf,
+      );
+
+      final beforeNext = nextToExpire([before]);
+      final afterNext = nextToExpire([after]);
+
+      expect(beforeNext, isNotNull);
+      expect(afterNext, isNotNull);
+      expect(afterNext!.expiresOn > beforeNext!.expiresOn, isTrue);
+    });
+
+    test(
+      'flying one more flight that does not qualify does not change the expiry',
+      () {
+        final asOf = CalendarDate(2024, 6, 1);
+        final threeLandings = EvaluationSubject(
+          flights: [
+            for (var i = 0; i < 3; i++)
+              currencyTestRecord(
+                '$i',
+                currencyTestFlight(
+                  date: CalendarDate(2024, 3, 3 + i),
+                  landings: const CircuitCounts(dayFullStop: 1),
+                ),
+              ),
+          ],
+        );
+        final before = evaluator.evaluateRule(rule, threeLandings, asOf);
+
+        // Adds a flight with zero landings -- a flight happened, but it
+        // contributes nothing to this requirement.
+        final withAnIrrelevantFlight = EvaluationSubject(
+          flights: [
+            ...threeLandings.flights,
+            currencyTestRecord(
+              'irrelevant',
+              currencyTestFlight(date: CalendarDate(2024, 5, 30)),
+            ),
+          ],
+        );
+        final after = evaluator.evaluateRule(
+          rule,
+          withAnIrrelevantFlight,
+          asOf,
+        );
+
+        expect(
+          nextToExpire([after])?.expiresOn,
+          nextToExpire([before])?.expiresOn,
+        );
+      },
+    );
+  });
+}

--- a/test/domain/currency/currency_rule_evaluator_test.dart
+++ b/test/domain/currency/currency_rule_evaluator_test.dart
@@ -8,17 +8,11 @@ import 'package:easa_digital_log/domain/model/aircraft.dart';
 import 'package:easa_digital_log/domain/model/calendar_date.dart';
 import 'package:easa_digital_log/domain/model/flight.dart';
 import 'package:easa_digital_log/domain/model/flight_duration.dart';
-import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
-import 'package:easa_digital_log/domain/model/utc_instant.dart';
 import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// A flight with every field defaulted to something inert, overriding only
-/// what a given currency test cares about. Deliberately not a
-/// `test/fixtures/` YAML fixture: these are synthetic mechanism probes for
-/// the generic evaluator, not realistic scenarios worth a shared,
-/// named fixture -- #53's golden, hand-verified fixture logbook is where
-/// that investment belongs.
+import 'currency_test_helpers.dart';
+
 Flight _flight({
   required CalendarDate date,
   CircuitCounts? landings,
@@ -26,51 +20,17 @@ Flight _flight({
   List<Approach> approaches = const [],
   int holdingProceduresCount = 0,
   String aircraftRegistration = 'G-TEST',
-}) {
-  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
-  return Flight(
-    aircraftRegistration: aircraftRegistration,
-    route: const ['EGXX'],
-    prePlannedNavigation: false,
-    offBlocks: offBlocks,
-    onBlocks: offBlocks.add(const Duration(hours: 1)),
-    capacity: const PilotCapacity(
-      commandAuthority: true,
-      soleManipulator: true,
-      soleOccupant: true,
-      multiPilotOperation: false,
-      additionalCrewRequiredByRule: false,
-      actingAsInstructor: false,
-      actingAsExaminer: false,
-      picusClaimed: false,
-      picInterventionNotRequired: false,
-    ),
-    carryingPassengers: false,
-    takeoffs: takeoffs ?? const CircuitCounts(),
-    landings: landings ?? const CircuitCounts(),
-    ifrFlightPlanFiled: false,
-    actualInstrumentTime: FlightDuration.zero,
-    simulatedInstrumentTime: FlightDuration.zero,
-    approaches: approaches,
-    holdingProceduresCount: holdingProceduresCount,
-    trackingPerformed: false,
-    remarks: '',
-  );
-}
-
-const _testAircraft = Aircraft(
-  registration: 'G-TEST',
-  manufacturer: 'Cessna',
-  model: '152',
-  category: AircraftCategory.aeroplane,
-  engineType: EngineType.piston,
-  engineCount: 1,
-  operatingSurface: OperatingSurface.land,
-  requiresMultiCrew: false,
+}) => currencyTestFlight(
+  date: date,
+  landings: landings,
+  takeoffs: takeoffs,
+  approaches: approaches,
+  holdingProceduresCount: holdingProceduresCount,
+  aircraftRegistration: aircraftRegistration,
 );
 
 FlightRecord _record(String id, Flight flight, {Aircraft? aircraft}) =>
-    FlightRecord(id: id, flight: flight, aircraft: aircraft ?? _testAircraft);
+    currencyTestRecord(id, flight, aircraft: aircraft);
 
 void main() {
   const evaluator = CurrencyRuleEvaluator();
@@ -356,6 +316,119 @@ void main() {
       expect(result.satisfied, isTrue);
       expect(result.contributingFlightIds, ['2']);
     });
+  });
+
+  group('flightEventCount with classOrTypeIfRequired aircraft match', () {
+    final requirement = Requirement.flightEventCount(
+      event: CountableFlightEvent.landings,
+      count: 1,
+      window: RuleWindow.rollingDays(90),
+      conditions: [
+        FlightCondition.aircraftMatch(AircraftMatch.classOrTypeIfRequired),
+      ],
+    );
+
+    test(
+      'requires the same type when the reference aircraft is type-rated',
+      () {
+        final subject = EvaluationSubject(
+          referenceAircraft: const Aircraft(
+            registration: 'G-REF',
+            manufacturer: 'Airbus',
+            model: 'A320',
+            icaoTypeDesignator: 'A320',
+            typeRatingDesignator: 'A320',
+            category: AircraftCategory.aeroplane,
+            engineType: EngineType.turbofan,
+            engineCount: 2,
+            operatingSurface: OperatingSurface.land,
+            requiresMultiCrew: true,
+          ),
+          flights: [
+            _record(
+              'same-class-diff-type',
+              _flight(
+                date: CalendarDate(2024, 5, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+              aircraft: const Aircraft(
+                registration: 'G-OTHER',
+                manufacturer: 'Boeing',
+                model: '737',
+                icaoTypeDesignator: 'B737',
+                typeRatingDesignator: 'B737',
+                category: AircraftCategory.aeroplane,
+                engineType: EngineType.turbofan,
+                engineCount: 2,
+                operatingSurface: OperatingSurface.land,
+                requiresMultiCrew: true,
+              ),
+            ),
+          ],
+        );
+
+        expect(
+          evaluator
+              .evaluateRequirement(
+                requirement,
+                subject,
+                CalendarDate(2024, 6, 1),
+              )
+              .satisfied,
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'requires only the same class when the reference aircraft is class-rated',
+      () {
+        final subject = EvaluationSubject(
+          referenceAircraft: const Aircraft(
+            registration: 'G-REF',
+            manufacturer: 'Cessna',
+            model: '152',
+            icaoTypeDesignator: 'C152',
+            category: AircraftCategory.aeroplane,
+            engineType: EngineType.piston,
+            engineCount: 1,
+            operatingSurface: OperatingSurface.land,
+            requiresMultiCrew: false,
+          ),
+          flights: [
+            _record(
+              'same-class-diff-type-designator',
+              _flight(
+                date: CalendarDate(2024, 5, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+              aircraft: const Aircraft(
+                registration: 'G-OTHER',
+                manufacturer: 'Piper',
+                model: 'Cherokee',
+                icaoTypeDesignator: 'PA28',
+                category: AircraftCategory.aeroplane,
+                engineType: EngineType.piston,
+                engineCount: 1,
+                operatingSurface: OperatingSurface.land,
+                requiresMultiCrew: false,
+              ),
+            ),
+          ],
+        );
+
+        expect(
+          evaluator
+              .evaluateRequirement(
+                requirement,
+                subject,
+                CalendarDate(2024, 6, 1),
+              )
+              .satisfied,
+          isTrue,
+        );
+      },
+    );
   });
 
   group('flightEventHours', () {

--- a/test/domain/currency/currency_rule_yaml_test.dart
+++ b/test/domain/currency/currency_rule_yaml_test.dart
@@ -88,6 +88,29 @@ requirement:
       ]);
     });
 
+    test('parses the class_or_type_if_required aircraft match level', () {
+      const yaml = '''
+id: x
+jurisdiction: us.faa.part61
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_count
+  event: landings
+  count: 3
+  window: { kind: rolling_days, days: 90 }
+  conditions:
+    - kind: aircraft_match
+      level: class_or_type_if_required
+''';
+
+      final rule = parseCurrencyRuleYaml(yaml);
+
+      expect(rule.requirement.conditions, [
+        FlightCondition.aircraftMatch(AircraftMatch.classOrTypeIfRequired),
+      ]);
+    });
+
     test(
       'parses a calendar-months window anchored to a held record expiry',
       () {

--- a/test/domain/currency/currency_test_helpers.dart
+++ b/test/domain/currency/currency_test_helpers.dart
@@ -1,0 +1,69 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+
+/// A flight with every field defaulted to something inert, overriding only
+/// what a given currency test cares about. Deliberately not a
+/// `test/fixtures/` YAML fixture: these are synthetic mechanism probes for
+/// the generic evaluator and its rules, not realistic scenarios worth a
+/// shared, named fixture -- #53's golden, hand-verified fixture logbook is
+/// where that investment belongs.
+Flight currencyTestFlight({
+  required CalendarDate date,
+  CircuitCounts? landings,
+  CircuitCounts? takeoffs,
+  List<Approach> approaches = const [],
+  int holdingProceduresCount = 0,
+  String aircraftRegistration = 'G-TEST',
+}) {
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
+  return Flight(
+    aircraftRegistration: aircraftRegistration,
+    route: const ['EGXX'],
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(const Duration(hours: 1)),
+    capacity: const PilotCapacity(
+      commandAuthority: true,
+      soleManipulator: true,
+      soleOccupant: true,
+      multiPilotOperation: false,
+      additionalCrewRequiredByRule: false,
+      actingAsInstructor: false,
+      actingAsExaminer: false,
+      picusClaimed: false,
+      picInterventionNotRequired: false,
+    ),
+    carryingPassengers: false,
+    takeoffs: takeoffs ?? const CircuitCounts(),
+    landings: landings ?? const CircuitCounts(),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: approaches,
+    holdingProceduresCount: holdingProceduresCount,
+    trackingPerformed: false,
+    remarks: '',
+  );
+}
+
+const testAircraft = Aircraft(
+  registration: 'G-TEST',
+  manufacturer: 'Cessna',
+  model: '152',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+FlightRecord currencyTestRecord(
+  String id,
+  Flight flight, {
+  Aircraft? aircraft,
+}) => FlightRecord(id: id, flight: flight, aircraft: aircraft ?? testAircraft);

--- a/test/domain/currency/rules/first_currency_rules_test.dart
+++ b/test/domain/currency/rules/first_currency_rules_test.dart
@@ -1,0 +1,398 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/flight_condition.dart';
+import 'package:easa_digital_log/domain/currency/rule_window.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../currency_test_helpers.dart';
+
+CurrencyRule _loadRule(String path) =>
+    parseCurrencyRuleYaml(File(path).readAsStringSync());
+
+const _typeRatedAircraft = Aircraft(
+  registration: 'G-JET',
+  manufacturer: 'Cessna',
+  model: 'Citation Mustang',
+  icaoTypeDesignator: 'C510',
+  typeRatingDesignator: 'C510S',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.turbofan,
+  engineCount: 2,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+void main() {
+  const evaluator = CurrencyRuleEvaluator();
+
+  group('easa.fcl060.b1_passenger_recency (#45)', () {
+    final rule = _loadRule(
+      'assets/rules/easa/fcl060_b1_passenger_recency.yaml',
+    );
+
+    test('metadata matches the regulation', () {
+      expect(rule.citation, 'FCL.060(b)(1)');
+      expect(rule.jurisdictionId, 'eu.easa.part-fcl');
+    });
+
+    test('satisfied by 3 landings, the oldest exactly 90 days back', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 3, 3), // exactly 90 days before asOf
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+          currencyTestRecord(
+            '2',
+            currencyTestFlight(
+              date: CalendarDate(2024, 4, 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+          currencyTestRecord(
+            '3',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+
+    test('91 days back is outside the window', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 3, 2), // 91 days before asOf
+              landings: const CircuitCounts(dayFullStop: 3),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+
+    test('a different type or class does not count', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: const Aircraft(
+          registration: 'G-REF',
+          manufacturer: 'Piper',
+          model: 'Arrow',
+          category: AircraftCategory.aeroplane,
+          engineType: EngineType.piston,
+          engineCount: 1,
+          operatingSurface: OperatingSurface.land,
+          requiresMultiCrew: false,
+        ),
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 3),
+            ),
+            aircraft: const Aircraft(
+              registration: 'G-JET',
+              manufacturer: 'Cessna',
+              model: 'Citation',
+              category: AircraftCategory.aeroplane,
+              engineType: EngineType.turbofan,
+              engineCount: 2,
+              operatingSurface: OperatingSurface.land,
+              requiresMultiCrew: false,
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('us.faa.61_57_a.takeoff_landing_currency (#48)', () {
+    final rule = _loadRule(
+      'assets/rules/faa/61_57_a_takeoff_landing_currency.yaml',
+    );
+
+    test('metadata matches the regulation', () {
+      expect(rule.citation, '§61.57(a)');
+      expect(rule.jurisdictionId, 'us.faa.part61');
+    });
+
+    test('takeoffs and landings are counted independently', () {
+      // docs/entry-form.md 5's own example: a pilot who took over mid-flight
+      // has zero takeoffs and one landing. Three such flights give 3
+      // landings but 0 takeoffs, so currency is not met.
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                takeoffs: const CircuitCounts(), // none -- took over mid-flight
+              ),
+            ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isFalse);
+      expect(result.components, hasLength(2));
+      expect(result.components[0].satisfied, isFalse); // takeoffs
+      expect(result.components[1].satisfied, isTrue); // landings
+    });
+
+    test(
+      'requires the same type when the aircraft is type-rated, not merely the same class',
+      () {
+        final asOf = CalendarDate(2024, 6, 1);
+        final subject = EvaluationSubject(
+          referenceAircraft: _typeRatedAircraft,
+          flights: [
+            for (var i = 0; i < 3; i++)
+              currencyTestRecord(
+                '$i',
+                currencyTestFlight(
+                  date: CalendarDate(2024, 5, i + 1),
+                  landings: const CircuitCounts(dayFullStop: 1),
+                  takeoffs: const CircuitCounts(dayFullStop: 1),
+                ),
+                // Same engine/class shape as the reference, but a different
+                // type rating -- §61.57(a) still requires the specific type.
+                aircraft: const Aircraft(
+                  registration: 'G-OTHERJET',
+                  manufacturer: 'Embraer',
+                  model: 'Phenom 100',
+                  icaoTypeDesignator: 'E50P',
+                  typeRatingDesignator: 'E50P',
+                  category: AircraftCategory.aeroplane,
+                  engineType: EngineType.turbofan,
+                  engineCount: 2,
+                  operatingSurface: OperatingSurface.land,
+                  requiresMultiCrew: false,
+                ),
+              ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          subject,
+          asOf,
+        );
+
+        expect(result.satisfied, isFalse);
+      },
+    );
+  });
+
+  group('us.faa.61_57_a2.tailwheel_takeoff_landing_currency (#48)', () {
+    final rule = _loadRule(
+      'assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml',
+    );
+
+    test(
+      'a touch-and-go does not count toward the tailwheel-specific rule',
+      () {
+        final asOf = CalendarDate(2024, 6, 1);
+        final subject = EvaluationSubject(
+          referenceAircraft: testAircraft,
+          flights: [
+            for (var i = 0; i < 3; i++)
+              currencyTestRecord(
+                '$i',
+                currencyTestFlight(
+                  date: CalendarDate(2024, 5, i + 1),
+                  landings: const CircuitCounts(dayTouchAndGo: 1),
+                  takeoffs: const CircuitCounts(dayTouchAndGo: 1),
+                ),
+              ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          subject,
+          asOf,
+        );
+
+        expect(result.satisfied, isFalse);
+      },
+    );
+
+    test('full-stop takeoffs and landings satisfy it', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                takeoffs: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+  });
+
+  group('us.faa.61_57_b.night_takeoff_landing_currency (#48)', () {
+    final rule = _loadRule(
+      'assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml',
+    );
+
+    test('metadata matches the regulation', () {
+      expect(rule.citation, '§61.57(b)');
+    });
+
+    test('a night touch-and-go does not satisfy the FAA night rule', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(nightTouchAndGo: 1),
+                takeoffs: const CircuitCounts(nightTouchAndGo: 1),
+              ),
+            ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+
+    test('the same night touch-and-gos would satisfy an EASA-shaped night '
+        'requirement that has no full-stop condition -- the #48 divergence: '
+        'EASA night passenger recency (#46) accepts any landing type, FAA '
+        "doesn't", () {
+      final easaShapedNightRequirement = Requirement.flightEventCount(
+        event: CountableFlightEvent.landings,
+        count: 1,
+        window: RuleWindow.rollingDays(90),
+        conditions: [FlightCondition.dayNight(DayNight.night)],
+      );
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(nightTouchAndGo: 1),
+            ),
+          ),
+        ],
+      );
+
+      final faaResult = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+      final easaShapedResult = evaluator.evaluateRequirement(
+        easaShapedNightRequirement,
+        subject,
+        asOf,
+      );
+
+      expect(faaResult.satisfied, isFalse);
+      expect(easaShapedResult.satisfied, isTrue);
+    });
+
+    test('full-stop night takeoffs and landings satisfy it', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(nightFullStop: 1),
+                takeoffs: const CircuitCounts(nightFullStop: 1),
+              ),
+            ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stacked on #122 — base branch is `feat/m3-rule-engine-core`, not `main`.

- EASA FCL.060(b)(1) passenger recency and FAA §61.57(a)/(a)(2)/(b) takeoff-and-landing currency (#45, #48), authored as YAML against the #40-#43 engine.
- One new engine primitive: `AircraftMatch.classOrTypeIfRequired`, for §61.57(a)'s "same class, same type if a type rating is required" — which of the two applies depends on the *reference* aircraft, so it couldn't be expressed as a static choice in existing values. No other evaluator changes were needed to add these rules.
- FAA takeoffs/landings are counted independently (`allOf` of two `flight_event_count` requirements), matching `docs/entry-form.md`'s own reasoning that a pilot taking over mid-flight has zero takeoffs and one landing; EASA's rule collapses to a landing count alone since an approach is implicit in every landing, per that same doc.
- The tailwheel full-stop variant (§61.57(a)(2)) is a separate rule id rather than a conditional inside `61_57_a`: which rule applies depends on `Aircraft.requiredQualifications`, already fully expressed on the aircraft model, so the engine doesn't need to learn anything about qualifications.
- `nextToExpire` (#44): the soonest-lapsing result across several rule evaluations, correctly excluding unsatisfied requirements (not "already expired", just not current) and requirements that never lapse (can't be "next" to do something they never do) from the comparison.
- A verified finding, not a change: `CircuitCounts.night*` is confirmed (via `faa_night_time.dart`'s own dartdoc) to already be the currency-relevant day/night split as a raw pilot-entered fact, not something to recompute from civil twilight — so `FlightCondition.dayNight` reading it directly is correct, not a shortcut.

Closes #44, #45, #48.

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_currency_rules.dart` — 4 rule files clean
- [x] `flutter test --coverage` — 444 passing, 22 new
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 94.2%
- [x] `dart run tool/check_schema_snapshot.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)