### PR TITLE
Medical certificate validity: pilot profile, model and persistence

### DIFF
--- a/assets/rules/easa/med_a045_class1_validity.yaml
+++ b/assets/rules/easa/med_a045_class1_validity.yaml
@@ -1,0 +1,15 @@
+# MED.A.045: a Class 1 medical certificate must be currently valid to
+# exercise the privileges of a commercial or ATP licence.
+#
+# Validity itself is computed by medical_certificate_validity.dart, not
+# expressed here -- age-banding and the single-pilot-commercial 6-month
+# reduction are real logic, not data. This rule only asks the generic
+# question the engine already knows how to answer: is there a currently
+# valid held record of this kind.
+id: eu.easa.med_a045.class1_validity
+jurisdiction: eu.easa.part-fcl
+citation: "MED.A.045"
+effective_from: 2011-11-08
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: medical_certificate.easaClass1

--- a/assets/rules/easa/med_a045_class2_validity.yaml
+++ b/assets/rules/easa/med_a045_class2_validity.yaml
@@ -1,0 +1,14 @@
+# MED.A.045: a Class 2 medical certificate must be currently valid to
+# exercise PPL privileges.
+#
+# Validity itself is computed by medical_certificate_validity.dart --
+# 60/24/12-month age bands, each of the first two additionally capped at a
+# fixed birthday (the "birthday-crossing" case: a certificate issued at 39
+# does not run the full 60 months, it is clawed back to the 42nd birthday).
+id: eu.easa.med_a045.class2_validity
+jurisdiction: eu.easa.part-fcl
+citation: "MED.A.045"
+effective_from: 2011-11-08
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: medical_certificate.easaClass2

--- a/assets/rules/faa/61_23_first_class_medical_validity.yaml
+++ b/assets/rules/faa/61_23_first_class_medical_validity.yaml
@@ -1,0 +1,14 @@
+# Sec.61.23(d): a first-class medical certificate must be currently valid
+# to exercise the corresponding privileges.
+#
+# Validity here covers the private/recreational/student tier only --
+# medical_certificate_validity.dart's dartdoc explains why: this app has no
+# "which privilege is this flight" fact to key ATP/commercial tiering on
+# yet.
+id: us.faa.61_23.first_class_medical_validity
+jurisdiction: us.faa.part61
+citation: "§61.23(d)"
+effective_from: 1997-08-04
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: medical_certificate.faaFirstClass

--- a/assets/rules/faa/61_23_second_class_medical_validity.yaml
+++ b/assets/rules/faa/61_23_second_class_medical_validity.yaml
@@ -1,0 +1,10 @@
+# Sec.61.23(d): a second-class medical certificate must be currently valid
+# to exercise the corresponding privileges. Private/recreational/student
+# tier only -- see 61_23_first_class_medical_validity.yaml's comment.
+id: us.faa.61_23.second_class_medical_validity
+jurisdiction: us.faa.part61
+citation: "§61.23(d)"
+effective_from: 1997-08-04
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: medical_certificate.faaSecondClass

--- a/assets/rules/faa/61_23_third_class_medical_validity.yaml
+++ b/assets/rules/faa/61_23_third_class_medical_validity.yaml
@@ -1,0 +1,10 @@
+# Sec.61.23(d): a third-class medical certificate must be currently valid
+# to exercise the corresponding privileges. Private/recreational/student
+# tier only -- see 61_23_first_class_medical_validity.yaml's comment.
+id: us.faa.61_23.third_class_medical_validity
+jurisdiction: us.faa.part61
+citation: "§61.23(d)"
+effective_from: 1997-08-04
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: medical_certificate.faaThirdClass

--- a/drift_schemas/drift_schema_v2.json
+++ b/drift_schemas/drift_schema_v2.json
@@ -1,0 +1,1424 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pilot_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_of_birth",
+            "getter_name": "dateOfBirth",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "medical_certificates",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "certificate_class",
+            "getter_name": "certificateClass",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pilot_profile",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pilot_profile\" (\"id\" TEXT NOT NULL, \"date_of_birth\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "medical_certificates",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"medical_certificates\" (\"id\" TEXT NOT NULL, \"certificate_class\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -7,6 +7,7 @@ import 'open_with_backup.dart';
 import 'tables/aircraft_tables.dart';
 import 'tables/custom_aerodrome_table.dart';
 import 'tables/flight_tables.dart';
+import 'tables/pilot_record_tables.dart';
 
 part 'database.g.dart';
 
@@ -20,13 +21,15 @@ part 'database.g.dart';
     FlightRouteLegsTable,
     FlightApproachesTable,
     FlightRevisionsTable,
+    PilotProfileTable,
+    MedicalCertificatesTable,
   ],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase(super.executor);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   // SQLite does not enforce foreign keys — including this schema's
   // `onDelete: KeyAction.cascade` on the flight/aircraft child tables —
@@ -36,6 +39,18 @@ class AppDatabase extends _$AppDatabase {
   // was added.
   @override
   MigrationStrategy get migration => MigrationStrategy(
+    // #51: adds pilot_profile and medical_certificates. Neither references
+    // an existing table, so the upgrade is two plain CREATE TABLEs — no
+    // data migration, nothing to backfill. ADR-0010's file-level backup
+    // (`open_with_backup.dart`) still covers this against an interrupted
+    // upgrade; this is the first real exercise of the framework it
+    // describes, which until now had only run against a throwaway fixture.
+    onUpgrade: (Migrator m, int from, int to) async {
+      if (from < 2) {
+        await m.createTable(pilotProfileTable);
+        await m.createTable(medicalCertificatesTable);
+      }
+    },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
     },

--- a/lib/data/mappers/pilot_record_mapper.dart
+++ b/lib/data/mappers/pilot_record_mapper.dart
@@ -1,0 +1,37 @@
+import '../../domain/model/calendar_date.dart';
+import '../../domain/pilot_record/medical_certificate.dart' as domain;
+import '../../domain/pilot_record/pilot_profile.dart' as domain;
+import '../database.dart';
+
+PilotProfileRow pilotProfileToRow(
+  domain.PilotProfile profile, {
+  required String id,
+}) {
+  return PilotProfileRow(id: id, dateOfBirth: profile.dateOfBirth.toString());
+}
+
+domain.PilotProfile pilotProfileFromRow(PilotProfileRow row) {
+  return domain.PilotProfile(dateOfBirth: CalendarDate.parse(row.dateOfBirth));
+}
+
+MedicalCertificateRow medicalCertificateToRow(
+  domain.MedicalCertificate certificate, {
+  required String id,
+}) {
+  return MedicalCertificateRow(
+    id: id,
+    certificateClass: certificate.certificateClass.name,
+    jurisdictionId: certificate.jurisdictionId,
+    issueDate: certificate.issueDate.toString(),
+  );
+}
+
+domain.MedicalCertificate medicalCertificateFromRow(MedicalCertificateRow row) {
+  return domain.MedicalCertificate(
+    certificateClass: domain.MedicalCertificateClass.values.byName(
+      row.certificateClass,
+    ),
+    jurisdictionId: row.jurisdictionId,
+    issueDate: CalendarDate.parse(row.issueDate),
+  );
+}

--- a/lib/data/repositories/medical_certificate_repository.dart
+++ b/lib/data/repositories/medical_certificate_repository.dart
@@ -1,0 +1,43 @@
+import '../../domain/pilot_record/medical_certificate.dart' as domain;
+import '../database.dart';
+import '../mappers/pilot_record_mapper.dart';
+import '../ulid.dart';
+
+/// Write and read access to held medical certificates. A current, editable
+/// reference record like `aircraft` — no draft/committed lifecycle.
+class MedicalCertificateRepository {
+  MedicalCertificateRepository(this._db);
+
+  final AppDatabase _db;
+
+  /// Inserts a new certificate (returning its generated id), or replaces
+  /// the row when [id] names one already stored.
+  Future<String> upsert(
+    domain.MedicalCertificate certificate, {
+    String? id,
+  }) async {
+    final resolvedId = id ?? generateUlid();
+    await _db
+        .into(_db.medicalCertificatesTable)
+        .insertOnConflictUpdate(
+          medicalCertificateToRow(certificate, id: resolvedId),
+        );
+    return resolvedId;
+  }
+
+  Future<domain.MedicalCertificate?> find(String id) async {
+    final row = await (_db.select(
+      _db.medicalCertificatesTable,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    return row == null ? null : medicalCertificateFromRow(row);
+  }
+
+  Future<List<domain.MedicalCertificate>> findAll() async {
+    final rows = await _db.select(_db.medicalCertificatesTable).get();
+    return [for (final row in rows) medicalCertificateFromRow(row)];
+  }
+
+  Future<void> delete(String id) => (_db.delete(
+    _db.medicalCertificatesTable,
+  )..where((t) => t.id.equals(id))).go();
+}

--- a/lib/data/repositories/pilot_profile_repository.dart
+++ b/lib/data/repositories/pilot_profile_repository.dart
@@ -1,0 +1,26 @@
+import '../../domain/pilot_record/pilot_profile.dart' as domain;
+import '../database.dart';
+import '../mappers/pilot_record_mapper.dart';
+
+/// Write and read access to the single [domain.PilotProfile] this
+/// installation holds. No draft/committed lifecycle, no id parameter on
+/// [save] — CLAUDE.md scopes this app to one pilot, so there is exactly
+/// one row, always at [singletonId].
+class PilotProfileRepository {
+  PilotProfileRepository(this._db);
+
+  final AppDatabase _db;
+
+  static const singletonId = 'singleton';
+
+  Future<void> save(domain.PilotProfile profile) => _db
+      .into(_db.pilotProfileTable)
+      .insertOnConflictUpdate(pilotProfileToRow(profile, id: singletonId));
+
+  Future<domain.PilotProfile?> find() async {
+    final row = await (_db.select(
+      _db.pilotProfileTable,
+    )..where((t) => t.id.equals(singletonId))).getSingleOrNull();
+    return row == null ? null : pilotProfileFromRow(row);
+  }
+}

--- a/lib/data/tables/pilot_record_tables.dart
+++ b/lib/data/tables/pilot_record_tables.dart
@@ -1,0 +1,34 @@
+import 'package:drift/drift.dart';
+
+/// Mirrors `PilotProfile` (#51) — always exactly one row, at the fixed id
+/// [PilotProfileRepository.singletonId]: CLAUDE.md scopes this app to one
+/// pilot's own legal record, never a list of pilots.
+@DataClassName('PilotProfileRow')
+class PilotProfileTable extends Table {
+  @override
+  String get tableName => 'pilot_profile';
+
+  TextColumn get id => text()();
+  TextColumn get dateOfBirth => text()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Mirrors `MedicalCertificate` (#51) — a current, editable reference
+/// record like `aircraft`, not a draft/committed flight: a pilot corrects a
+/// mistyped issue date the same way they correct a mistyped aircraft
+/// registration.
+@DataClassName('MedicalCertificateRow')
+class MedicalCertificatesTable extends Table {
+  @override
+  String get tableName => 'medical_certificates';
+
+  TextColumn get id => text()();
+  TextColumn get certificateClass => text()();
+  TextColumn get jurisdictionId => text()();
+  TextColumn get issueDate => text()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/domain/currency/currency_expiry_projection.dart
+++ b/lib/domain/currency/currency_expiry_projection.dart
@@ -15,6 +15,30 @@ class NextExpiry {
   final CalendarDate expiresOn;
 }
 
+/// Whether [expiresOn] falls within [leadDays] of [asOf] — #51's
+/// "warnings surfaced ahead of expiry, with a configurable lead time".
+/// [leadDays] is always caller-supplied, never a fixed default baked in
+/// here: how much warning is useful differs by what's expiring (a medical
+/// certificate deserves more notice than a 90-day landing count) and is a
+/// UI/settings concern, not this function's to decide.
+///
+/// `false` once [expiresOn] is already in the past relative to [asOf] —
+/// that is [RuleResult.satisfied] turning `false`, a different state from
+/// "still current but about to lapse". Meaningful only when called for a
+/// requirement that is currently satisfied; an unsatisfied requirement's
+/// [RuleResult.expiresOn] is already null.
+bool isNearingExpiry(
+  CalendarDate expiresOn,
+  CalendarDate asOf, {
+  required int leadDays,
+}) {
+  if (expiresOn < asOf) {
+    return false;
+  }
+  final warningStart = expiresOn.addDays(-leadDays);
+  return asOf >= warningStart;
+}
+
 /// Across every rule evaluation in [evaluations], the one that lapses
 /// soonest — #44's "combined next thing to expire view across all
 /// applicable requirements".

--- a/lib/domain/pilot_record/medical_certificate.dart
+++ b/lib/domain/pilot_record/medical_certificate.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/calendar_date.dart';
+
+part 'medical_certificate.freezed.dart';
+
+/// A medical certificate the pilot holds, as issued — class, issuing
+/// authority and issue date only.
+///
+/// Validity is computed, never stored: see
+/// `medical_certificate_validity.dart`. The duration depends on the
+/// pilot's age at issue and, for EASA, on age bands the certificate can
+/// age *into* during its own life (MED.A.045's birthday-crossing case) —
+/// storing a `validUntil` here would be exactly the derived-quantity
+/// mistake CLAUDE.md rule 1 warns against for `Flight`, one layer up.
+///
+/// UK Part-MED, the LAPL medical and the UK PMD are deliberately not
+/// covered: CLAUDE.md scopes UK CAA as "planned", not current, and
+/// `docs/ratings-and-endorsements.md` marks those specific rows ⚠️
+/// unverified in any case.
+@freezed
+abstract class MedicalCertificate with _$MedicalCertificate {
+  const factory MedicalCertificate({
+    required MedicalCertificateClass certificateClass,
+
+    /// The jurisdiction profile id this certificate was issued under, e.g.
+    /// `eu.easa.part-fcl`, `us.faa.part61`.
+    required String jurisdictionId,
+
+    required CalendarDate issueDate,
+  }) = _MedicalCertificate;
+}
+
+enum MedicalCertificateClass {
+  easaClass1,
+  easaClass2,
+  faaFirstClass,
+  faaSecondClass,
+  faaThirdClass,
+}

--- a/lib/domain/pilot_record/medical_certificate_validity.dart
+++ b/lib/domain/pilot_record/medical_certificate_validity.dart
@@ -1,0 +1,120 @@
+import '../currency/held_record.dart';
+import '../currency/rule_window.dart';
+import '../model/calendar_date.dart';
+import 'medical_certificate.dart';
+
+/// Computes the [HeldRecord] a [MedicalCertificate] currently materialises
+/// to, for a `held_record_currently_valid` currency rule (#51) to consume.
+///
+/// Real logic in Dart, not YAML, per CLAUDE.md's "declarative stops" rule:
+/// age-banded duration is exactly the kind of thing a rule author
+/// references by name rather than expresses inline.
+///
+/// **Scope boundary, deliberate.** FAA medical validity genuinely depends
+/// on which privilege is being exercised on a given flight — `§61.23(d)`'s
+/// duration table gives three different answers for the same certificate
+/// depending on whether the flight is flown under ATP, commercial or
+/// private/recreational/student privileges. This app has no "which
+/// privilege" fact anywhere yet, so only the private/recreational/student
+/// tier is modelled; commercial and ATP tiering is deferred until that
+/// fact exists. Likewise EASA Class 1's reduction to 6 months for
+/// single-pilot commercial air transport of passengers at age 40+ (or 60
+/// regardless of operation) is not modelled — the same missing fact.
+///
+/// **⚠️ Source note.** EASA figures were cross-checked against two
+/// secondary summaries of `MED.A.045` that initially disagreed on Class
+/// 1's structure; the figures here match the source that also correctly
+/// described Class 2's birthday-cap mechanism. Confirm against the current
+/// AMC/GM before this becomes load-bearing, per CLAUDE.md's
+/// regulatory-text caveat.
+HeldRecord medicalCertificateHeldRecord(
+  MedicalCertificate certificate,
+  CalendarDate dateOfBirth,
+) {
+  return HeldRecord(
+    kind: _heldRecordKind(certificate.certificateClass),
+    validFrom: certificate.issueDate,
+    validUntil: _validUntil(certificate, dateOfBirth),
+  );
+}
+
+String _heldRecordKind(MedicalCertificateClass certificateClass) =>
+    'medical_certificate.${certificateClass.name}';
+
+CalendarDate _validUntil(
+  MedicalCertificate certificate,
+  CalendarDate dateOfBirth,
+) {
+  final ageAtIssue = _ageAt(dateOfBirth, certificate.issueDate);
+
+  switch (certificate.certificateClass) {
+    case MedicalCertificateClass.easaClass1:
+      // Flat 12 months -- the single-pilot-commercial-passenger 6-month
+      // reduction at 40+/60 is deferred; see the scope boundary above.
+      return RuleWindow.calendarMonths(12).expiryFrom(certificate.issueDate);
+
+    case MedicalCertificateClass.easaClass2:
+      return _easaClass2ValidUntil(
+        certificate.issueDate,
+        dateOfBirth,
+        ageAtIssue,
+      );
+
+    case MedicalCertificateClass.faaFirstClass:
+    case MedicalCertificateClass.faaSecondClass:
+    case MedicalCertificateClass.faaThirdClass:
+      // §61.23(d), private/recreational/student/sport tier only -- no
+      // birthday clawback, unlike EASA: the full nominal duration stands
+      // even if the holder ages into the next band before it lapses.
+      final months = ageAtIssue < 40 ? 60 : 24;
+      return RuleWindow.calendarMonths(
+        months,
+      ).expiryFrom(certificate.issueDate);
+  }
+}
+
+/// MED.A.045: 60/24/12 months by age band at issue, each of the first two
+/// bands additionally capped at a fixed birthday -- "a certificate can
+/// shorten its own validity partway through its life" (#51). A certificate
+/// issued at 39 does not get the full 60 months; it is clawed back to the
+/// 42nd birthday. Whichever of the nominal duration and the cap is
+/// *earlier* governs.
+CalendarDate _easaClass2ValidUntil(
+  CalendarDate issueDate,
+  CalendarDate dateOfBirth,
+  int ageAtIssue,
+) {
+  final (months, capAge) = switch (ageAtIssue) {
+    < 40 => (60, 42),
+    < 50 => (24, 51),
+    _ => (12, null),
+  };
+
+  final nominal = RuleWindow.calendarMonths(months).expiryFrom(issueDate);
+  if (capAge == null) {
+    return nominal;
+  }
+  final cap = _nthBirthday(dateOfBirth, capAge);
+  return nominal < cap ? nominal : cap;
+}
+
+int _ageAt(CalendarDate dateOfBirth, CalendarDate date) {
+  var age = date.year - dateOfBirth.year;
+  final hadBirthdayYet =
+      date.month > dateOfBirth.month ||
+      (date.month == dateOfBirth.month && date.day >= dateOfBirth.day);
+  if (!hadBirthdayYet) {
+    age -= 1;
+  }
+  return age;
+}
+
+/// [dateOfBirth]'s [n]th anniversary, clamped to the last real day of the
+/// month for a 29 February birthday landing on a non-leap year.
+CalendarDate _nthBirthday(CalendarDate dateOfBirth, int n) {
+  final year = dateOfBirth.year + n;
+  final isLeapFeb29 = dateOfBirth.month == 2 && dateOfBirth.day == 29;
+  final isLeapYear = (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+  final day = (isLeapFeb29 && !isLeapYear) ? 28 : dateOfBirth.day;
+  return CalendarDate(year, dateOfBirth.month, day);
+}

--- a/lib/domain/pilot_record/pilot_profile.dart
+++ b/lib/domain/pilot_record/pilot_profile.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/calendar_date.dart';
+
+part 'pilot_profile.freezed.dart';
+
+/// The logbook holder's own facts, needed by currency rules that turn on
+/// age — EASA medical certificate validity banding (`MED.A.045`) chief
+/// among them.
+///
+/// Singleton, not a list: CLAUDE.md scopes this app to one pilot's own
+/// legal record, never multiple pilots, so there is exactly one
+/// [PilotProfile] per installation. `PilotProfileRepository` enforces that
+/// at the persistence layer rather than this model carrying an id nothing
+/// would ever vary.
+@freezed
+abstract class PilotProfile with _$PilotProfile {
+  const factory PilotProfile({required CalendarDate dateOfBirth}) =
+      _PilotProfile;
+}

--- a/test/data/database_migration_test.dart
+++ b/test/data/database_migration_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/open_with_backup.dart';
+import 'package:easa_digital_log/data/repositories/medical_certificate_repository.dart';
+import 'package:easa_digital_log/data/repositories/pilot_profile_repository.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/medical_certificate.dart';
+import 'package:easa_digital_log/domain/pilot_record/pilot_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+/// Creates a v1-shaped database file directly with sqlite3, seeded with one
+/// aircraft row — the only way to get a real "v1 database" to migrate from,
+/// since `AircraftsTable` only ever represents the *current* schema. Column
+/// order and names mirror `lib/data/tables/aircraft_tables.dart` exactly;
+/// only `aircraft` is seeded — the other seven v1 tables aren't needed to
+/// prove #51's migration step behaves, and hand-duplicating their DDL here
+/// would just be more surface area to drift out of sync with the real
+/// tables for no extra coverage.
+void _seedV1Database(String path) {
+  final db = sqlite3.sqlite3.open(path);
+  try {
+    db.execute('''
+      CREATE TABLE aircraft (
+        id TEXT NOT NULL,
+        registration TEXT NOT NULL UNIQUE,
+        manufacturer TEXT NOT NULL,
+        model TEXT NOT NULL,
+        icao_type_designator TEXT NULL,
+        category TEXT NOT NULL,
+        engine_type TEXT NOT NULL,
+        engine_count INTEGER NOT NULL,
+        operating_surface TEXT NOT NULL,
+        requires_multi_crew INTEGER NOT NULL,
+        type_rating_designator TEXT NULL,
+        PRIMARY KEY (id)
+      )
+    ''');
+    db.execute(
+      'INSERT INTO aircraft (id, registration, manufacturer, model, '
+      'category, engine_type, engine_count, operating_surface, '
+      'requires_multi_crew) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        'aircraft-1',
+        'G-ABCD',
+        'Cessna',
+        '152',
+        'aeroplane',
+        'piston',
+        1,
+        'land',
+        0,
+      ],
+    );
+    db.execute('PRAGMA user_version = 1');
+  } finally {
+    db.close();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+  late File dbFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('database_migration_test');
+    dbFile = File(p.join(tempDir.path, 'app.sqlite'));
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  test(
+    '#51: migrating a real v1 database to v2 preserves existing data and '
+    'adds pilot_profile/medical_certificates, usable through their repositories',
+    () async {
+      _seedV1Database(dbFile.path);
+
+      final db = await openWithBackup(dbFile, () async {
+        final database = AppDatabase(NativeDatabase(dbFile));
+        await database.customStatement('SELECT 1');
+        return database;
+      });
+      addTearDown(db.close);
+
+      final aircraftRows = await db.select(db.aircraftsTable).get();
+      expect(aircraftRows, hasLength(1));
+      expect(aircraftRows.single.registration, 'G-ABCD');
+
+      final pilotProfiles = PilotProfileRepository(db);
+      const profile = PilotProfile(dateOfBirth: CalendarDate(1990, 1, 1));
+      await pilotProfiles.save(profile);
+      expect(await pilotProfiles.find(), profile);
+
+      final medicalCertificates = MedicalCertificateRepository(db);
+      const certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass2,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 1),
+      );
+      final id = await medicalCertificates.upsert(certificate);
+      expect(await medicalCertificates.find(id), certificate);
+    },
+  );
+}

--- a/test/data/database_test.dart
+++ b/test/data/database_test.dart
@@ -3,10 +3,10 @@ import 'package:easa_digital_log/data/database.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('opens an in-memory database with all eight tables', () async {
+  test('opens an in-memory database with all ten tables', () async {
     final db = AppDatabase(NativeDatabase.memory());
     addTearDown(db.close);
 
-    expect(db.allTables, hasLength(8));
+    expect(db.allTables, hasLength(10));
   });
 }

--- a/test/data/repositories/medical_certificate_repository_test.dart
+++ b/test/data/repositories/medical_certificate_repository_test.dart
@@ -1,0 +1,63 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/medical_certificate_repository.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/medical_certificate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late MedicalCertificateRepository repository;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    repository = MedicalCertificateRepository(db);
+  });
+
+  tearDown(() => db.close());
+
+  const class2 = MedicalCertificate(
+    certificateClass: MedicalCertificateClass.easaClass2,
+    jurisdictionId: 'eu.easa.part-fcl',
+    issueDate: CalendarDate(2024, 1, 15),
+  );
+
+  test('round-trips through upsert and find', () async {
+    final id = await repository.upsert(class2);
+
+    expect(await repository.find(id), class2);
+  });
+
+  test('upsert with an existing id replaces the row', () async {
+    final id = await repository.upsert(class2);
+    final renewed = class2.copyWith(issueDate: const CalendarDate(2029, 1, 20));
+
+    await repository.upsert(renewed, id: id);
+
+    expect(await repository.find(id), renewed);
+  });
+
+  test(
+    'findAll returns every held certificate, e.g. an EASA and an FAA one held together',
+    () async {
+      const faaThird = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.faaThirdClass,
+        jurisdictionId: 'us.faa.part61',
+        issueDate: CalendarDate(2024, 3, 1),
+      );
+      await repository.upsert(class2);
+      await repository.upsert(faaThird);
+
+      final all = await repository.findAll();
+
+      expect(all, unorderedEquals([class2, faaThird]));
+    },
+  );
+
+  test('delete removes the certificate', () async {
+    final id = await repository.upsert(class2);
+    await repository.delete(id);
+
+    expect(await repository.find(id), isNull);
+  });
+}

--- a/test/data/repositories/pilot_profile_repository_test.dart
+++ b/test/data/repositories/pilot_profile_repository_test.dart
@@ -1,0 +1,47 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/pilot_profile_repository.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/pilot_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late PilotProfileRepository repository;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    repository = PilotProfileRepository(db);
+  });
+
+  tearDown(() => db.close());
+
+  test('find returns null before anything has been saved', () async {
+    expect(await repository.find(), isNull);
+  });
+
+  test('round-trips through save and find', () async {
+    const profile = PilotProfile(dateOfBirth: CalendarDate(1990, 6, 15));
+
+    await repository.save(profile);
+
+    expect(await repository.find(), profile);
+  });
+
+  test(
+    'saving again replaces the single row rather than adding a second one',
+    () async {
+      await repository.save(
+        const PilotProfile(dateOfBirth: CalendarDate(1990, 6, 15)),
+      );
+      await repository.save(
+        const PilotProfile(dateOfBirth: CalendarDate(1985, 1, 1)),
+      );
+
+      expect(
+        await repository.find(),
+        const PilotProfile(dateOfBirth: CalendarDate(1985, 1, 1)),
+      );
+    },
+  );
+}

--- a/test/domain/currency/currency_expiry_projection_test.dart
+++ b/test/domain/currency/currency_expiry_projection_test.dart
@@ -85,6 +85,66 @@ void main() {
     });
   });
 
+  group('isNearingExpiry', () {
+    test('true once within the lead time', () {
+      expect(
+        isNearingExpiry(
+          CalendarDate(2024, 9, 10),
+          CalendarDate(2024, 9, 1),
+          leadDays: 30,
+        ),
+        isTrue,
+      );
+    });
+
+    test('false while still outside the lead time', () {
+      expect(
+        isNearingExpiry(
+          CalendarDate(2024, 12, 1),
+          CalendarDate(2024, 9, 1),
+          leadDays: 30,
+        ),
+        isFalse,
+      );
+    });
+
+    test('true exactly at the lead-time boundary', () {
+      expect(
+        isNearingExpiry(
+          CalendarDate(2024, 10, 1), // exactly 30 days after asOf
+          CalendarDate(2024, 9, 1),
+          leadDays: 30,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'false once already lapsed -- that is "not current", not "nearing"',
+      () {
+        expect(
+          isNearingExpiry(
+            CalendarDate(2024, 8, 1),
+            CalendarDate(2024, 9, 1),
+            leadDays: 30,
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'the lead time is a caller-supplied parameter, not a fixed default',
+      () {
+        final expiresOn = CalendarDate(2024, 9, 15);
+        final asOf = CalendarDate(2024, 9, 1);
+
+        expect(isNearingExpiry(expiresOn, asOf, leadDays: 7), isFalse);
+        expect(isNearingExpiry(expiresOn, asOf, leadDays: 14), isTrue);
+      },
+    );
+  });
+
   group('nextToExpire against the real evaluator', () {
     const evaluator = CurrencyRuleEvaluator();
     final rule = CurrencyRule(

--- a/test/domain/pilot_record/medical_certificate_rules_test.dart
+++ b/test/domain/pilot_record/medical_certificate_rules_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/medical_certificate.dart';
+import 'package:easa_digital_log/domain/pilot_record/medical_certificate_validity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+CurrencyRule _loadRule(String path) =>
+    parseCurrencyRuleYaml(File(path).readAsStringSync());
+
+void main() {
+  const evaluator = CurrencyRuleEvaluator();
+
+  group('eu.easa.med_a045.class2_validity end to end', () {
+    final rule = _loadRule('assets/rules/easa/med_a045_class2_validity.yaml');
+
+    test(
+      'currently valid just inside the birthday cap, not just inside the nominal duration',
+      () {
+        // Issued at 39; nominal 60 months would run past the 42nd birthday,
+        // but the cap governs -- so asking "am I current" the day before the
+        // 42nd birthday must say yes, and the day of/after must say no, even
+        // though the nominal 60-month window hasn't elapsed either way.
+        final dateOfBirth = CalendarDate(1985, 3, 10);
+        final certificate = MedicalCertificate(
+          certificateClass: MedicalCertificateClass.easaClass2,
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(2024, 1, 15),
+        );
+        final heldRecord = medicalCertificateHeldRecord(
+          certificate,
+          dateOfBirth,
+        );
+
+        final dayBeforeCap = evaluator.evaluateRequirement(
+          rule.requirement,
+          EvaluationSubject(flights: const [], heldRecords: [heldRecord]),
+          CalendarDate(2027, 3, 9),
+        );
+        final onCapDate = evaluator.evaluateRequirement(
+          rule.requirement,
+          EvaluationSubject(flights: const [], heldRecords: [heldRecord]),
+          CalendarDate(2027, 3, 11),
+        );
+
+        expect(dayBeforeCap.satisfied, isTrue);
+        expect(onCapDate.satisfied, isFalse);
+      },
+    );
+
+    test('not current with no medical certificate on file at all', () {
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        const EvaluationSubject(flights: []),
+        CalendarDate(2024, 1, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('us.faa.61_23.third_class_medical_validity end to end', () {
+    final rule = _loadRule(
+      'assets/rules/faa/61_23_third_class_medical_validity.yaml',
+    );
+
+    test(
+      'the same FAA certificate stays valid across a birthday EASA would have clawed back',
+      () {
+        final dateOfBirth = CalendarDate(1985, 3, 10);
+        final certificate = MedicalCertificate(
+          certificateClass: MedicalCertificateClass.faaThirdClass,
+          jurisdictionId: 'us.faa.part61',
+          issueDate: CalendarDate(2024, 1, 15),
+        );
+        final heldRecord = medicalCertificateHeldRecord(
+          certificate,
+          dateOfBirth,
+        );
+
+        // EASA Class 2 with this same issue date/DOB lapses 2027-03-10 (the
+        // capped 42nd birthday) -- see the class2_validity test above. FAA's
+        // equivalent has no cap and runs the full 60 months.
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          EvaluationSubject(flights: const [], heldRecords: [heldRecord]),
+          CalendarDate(2027, 3, 11),
+        );
+
+        expect(result.satisfied, isTrue);
+      },
+    );
+  });
+}

--- a/test/domain/pilot_record/medical_certificate_validity_test.dart
+++ b/test/domain/pilot_record/medical_certificate_validity_test.dart
@@ -1,0 +1,198 @@
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/medical_certificate.dart';
+import 'package:easa_digital_log/domain/pilot_record/medical_certificate_validity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EASA Class 2 (age-banded, MED.A.045)', () {
+    test('issued well under 40: 60 months, no cap triggered', () {
+      final certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass2,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 15),
+      );
+      final dateOfBirth = CalendarDate(1999, 6, 1); // 24 at issue
+
+      final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+      expect(record.validFrom, CalendarDate(2024, 1, 15));
+      expect(record.validUntil, CalendarDate(2029, 1, 31));
+    });
+
+    test(
+      'the birthday-crossing trap: issued at 39, capped at the 42nd birthday, not issue+60mo',
+      () {
+        final dateOfBirth = CalendarDate(1985, 3, 10);
+        final certificate = MedicalCertificate(
+          certificateClass: MedicalCertificateClass.easaClass2,
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(
+            2024,
+            1,
+            15,
+          ), // holder is 38, turns 39 on 2024-03-10
+        );
+
+        final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+        // Nominal 60-month validity would run to 2029-01-31, well past the
+        // holder's 42nd birthday (2027-03-10) -- the cap wins.
+        expect(record.validUntil, CalendarDate(2027, 3, 10));
+      },
+    );
+
+    test('issued at 40-49: 24 months', () {
+      final dateOfBirth = CalendarDate(1979, 1, 1);
+      final certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass2,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 6, 1), // 45 at issue
+      );
+
+      final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+      expect(record.validUntil, CalendarDate(2026, 6, 30));
+    });
+
+    test(
+      'issued at 49, capped at the 51st birthday rather than the full 24 months',
+      () {
+        final dateOfBirth = CalendarDate(1975, 4, 20);
+        final certificate = MedicalCertificate(
+          certificateClass: MedicalCertificateClass.easaClass2,
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(2024, 6, 1), // 49 at issue
+        );
+
+        final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+        // Nominal 24 months would run to 2026-06-30, past the 51st birthday
+        // (2026-04-20).
+        expect(record.validUntil, CalendarDate(2026, 4, 20));
+      },
+    );
+
+    test('issued at 50 or older: 12 months, no cap needed', () {
+      final dateOfBirth = CalendarDate(1970, 1, 1);
+      final certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass2,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 6, 1), // 54 at issue
+      );
+
+      final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+      expect(record.validUntil, CalendarDate(2025, 6, 30));
+    });
+
+    test('a leap-day birthday caps on Feb 28 in a non-leap target year', () {
+      final dateOfBirth = CalendarDate(1984, 2, 29);
+      final certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass2,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2023, 6, 1), // 39 at issue
+      );
+
+      final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+      // 42nd birthday would be 2026-02-29, but 2026 is not a leap year.
+      expect(record.validUntil, CalendarDate(2026, 2, 28));
+    });
+  });
+
+  group('EASA Class 1 (flat, single-pilot commercial reduction deferred)', () {
+    test('12 months regardless of age', () {
+      final certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass1,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 15),
+      );
+      final dateOfBirth = CalendarDate(1960, 1, 1); // 64 at issue
+
+      final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+      expect(record.validUntil, CalendarDate(2025, 1, 31));
+    });
+  });
+
+  group(
+    'FAA (§61.23(d), private/recreational/student tier -- no clawback cap)',
+    () {
+      test(
+        'issued under 40: 60 months, full duration even if a birthday falls within it',
+        () {
+          final dateOfBirth = CalendarDate(1985, 3, 10);
+          final certificate = MedicalCertificate(
+            certificateClass: MedicalCertificateClass.faaThirdClass,
+            jurisdictionId: 'us.faa.part61',
+            issueDate: CalendarDate(
+              2024,
+              1,
+              15,
+            ), // 38, turns 40 well within the window
+          );
+
+          final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+          // Unlike EASA Class 2, the FAA table has no cap -- the full 60
+          // months stands even though the holder turns 40 partway through.
+          expect(record.validUntil, CalendarDate(2029, 1, 31));
+        },
+      );
+
+      test('issued at 40 or older: 24 months', () {
+        final dateOfBirth = CalendarDate(1980, 1, 1);
+        final certificate = MedicalCertificate(
+          certificateClass: MedicalCertificateClass.faaFirstClass,
+          jurisdictionId: 'us.faa.part61',
+          issueDate: CalendarDate(2024, 6, 1), // 44 at issue
+        );
+
+        final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+
+        expect(record.validUntil, CalendarDate(2026, 6, 30));
+      });
+
+      test('all three FAA classes use the same private-tier table', () {
+        final dateOfBirth = CalendarDate(1990, 1, 1);
+        final issueDate = CalendarDate(2024, 1, 1); // 34 at issue
+        for (final certificateClass in [
+          MedicalCertificateClass.faaFirstClass,
+          MedicalCertificateClass.faaSecondClass,
+          MedicalCertificateClass.faaThirdClass,
+        ]) {
+          final certificate = MedicalCertificate(
+            certificateClass: certificateClass,
+            jurisdictionId: 'us.faa.part61',
+            issueDate: issueDate,
+          );
+          final record = medicalCertificateHeldRecord(certificate, dateOfBirth);
+          expect(
+            record.validUntil,
+            CalendarDate(2029, 1, 31),
+            reason: certificateClass.name,
+          );
+        }
+      });
+    },
+  );
+
+  test(
+    'validFrom is the issue date and the held-record kind names the class',
+    () {
+      final certificate = MedicalCertificate(
+        certificateClass: MedicalCertificateClass.easaClass1,
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 15),
+      );
+
+      final record = medicalCertificateHeldRecord(
+        certificate,
+        CalendarDate(1990, 1, 1),
+      );
+
+      expect(record.validFrom, CalendarDate(2024, 1, 15));
+      expect(record.kind, 'medical_certificate.easaClass1');
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Stacked on #123 — base branch is `feat/m3-first-currency-rules`, not `main`.

- New `PilotProfile` (date of birth) and `MedicalCertificate` domain models, with drift persistence. `PilotProfile` is a singleton — CLAUDE.md scopes this app to one pilot, never a list.
- `schemaVersion` bumped 1 → 2 with a real `onUpgrade` migration, verified against an actual v1-shaped sqlite file (not just the fixture harness) — per ADR-0010's own note, the migration framework had been proven against a throwaway fixture but never actually run against `AppDatabase` until now.
- Validity is computed, never stored, via `medical_certificate_validity.dart`:
  - EASA `MED.A.045` Class 2: 60/24/12-month age bands, the first two additionally capped at a fixed birthday — a certificate issued at 39 is clawed back to the 42nd birthday, not the full 60 months ("the birthday-crossing trap" from #51's own text). Class 1: flat 12 months.
  - FAA `§61.23(d)`, private/recreational/student tier: 60/24 months, **no** clawback — the same certificate that lapses early under EASA runs its full nominal duration under FAA. Both directions are tested against the same inputs.
- Two scope boundaries, deliberate and documented rather than silently guessed: EASA Class 1's single-pilot-commercial 6-month reduction, and FAA's ATP/commercial privilege tiering, are both deferred — both need a "which privilege is this flight" fact that doesn't exist anywhere in the app, and I didn't want to invent one outside #51's own scope. (Discussed and confirmed private-tier-only scope before writing any code.)
- ⚠️ Flagged in code: the EASA figures come from two secondary sources that initially disagreed on Class 1's structure; used the one that also correctly described Class 2's birthday-cap mechanism. Should be confirmed against the current AMC/GM before load-bearing, matching CLAUDE.md's own regulatory-text caveat.
- `isNearingExpiry` rounds out #44's expiry projection with the configurable-lead-time warning #51 asks for — generic to any currency result, not medical-specific.
- Five new rule files (EASA Class 1/2, FAA first/second/third) wired through the existing engine with zero evaluator changes.

Closes #51.

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_currency_rules.dart` — 9 rule files clean
- [x] `dart run tool/check_schema_snapshot.dart` — v2 snapshot committed
- [x] `flutter test --coverage` — 471 passing, including a real v1→v2 migration test seeded with raw sqlite3 (not the fixture harness)
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 94.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)