### PR TITLE
Held ratings and endorsements: model, persistence, currency wiring

### DIFF
--- a/drift_schemas/drift_schema_v3.json
+++ b/drift_schemas/drift_schema_v3.json
@@ -1,0 +1,1606 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pilot_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_of_birth",
+            "getter_name": "dateOfBirth",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "medical_certificates",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "certificate_class",
+            "getter_name": "certificateClass",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_aircraft_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_granted",
+            "getter_name": "dateGranted",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_name",
+            "getter_name": "signatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_credential_number",
+            "getter_name": "signatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_ratings",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "designator",
+            "getter_name": "designator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "expiry_date",
+            "getter_name": "expiryDate",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "language_proficiency_level",
+            "getter_name": "languageProficiencyLevel",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pilot_profile",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pilot_profile\" (\"id\" TEXT NOT NULL, \"date_of_birth\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "medical_certificates",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"medical_certificates\" (\"id\" TEXT NOT NULL, \"certificate_class\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_aircraft_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_aircraft_qualifications\" (\"id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"date_granted\" TEXT NOT NULL, \"signatory_name\" TEXT NULL, \"signatory_credential_number\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_ratings",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_ratings\" (\"id\" TEXT NOT NULL, \"kind\" TEXT NOT NULL, \"designator\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, \"expiry_date\" TEXT NULL, \"language_proficiency_level\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -7,6 +7,7 @@ import 'open_with_backup.dart';
 import 'tables/aircraft_tables.dart';
 import 'tables/custom_aerodrome_table.dart';
 import 'tables/flight_tables.dart';
+import 'tables/held_qualification_tables.dart';
 import 'tables/pilot_record_tables.dart';
 
 part 'database.g.dart';
@@ -23,13 +24,15 @@ part 'database.g.dart';
     FlightRevisionsTable,
     PilotProfileTable,
     MedicalCertificatesTable,
+    HeldAircraftQualificationsTable,
+    HeldRatingsTable,
   ],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase(super.executor);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   // SQLite does not enforce foreign keys — including this schema's
   // `onDelete: KeyAction.cascade` on the flight/aircraft child tables —
@@ -39,16 +42,19 @@ class AppDatabase extends _$AppDatabase {
   // was added.
   @override
   MigrationStrategy get migration => MigrationStrategy(
-    // #51: adds pilot_profile and medical_certificates. Neither references
-    // an existing table, so the upgrade is two plain CREATE TABLEs — no
-    // data migration, nothing to backfill. ADR-0010's file-level backup
-    // (`open_with_backup.dart`) still covers this against an interrupted
-    // upgrade; this is the first real exercise of the framework it
-    // describes, which until now had only run against a throwaway fixture.
     onUpgrade: (Migrator m, int from, int to) async {
+      // #51: adds pilot_profile and medical_certificates. Neither
+      // references an existing table, so the upgrade is two plain CREATE
+      // TABLEs — no data migration, nothing to backfill.
       if (from < 2) {
         await m.createTable(pilotProfileTable);
         await m.createTable(medicalCertificatesTable);
+      }
+      // #52: adds held_aircraft_qualifications and held_ratings, same
+      // shape of upgrade as #51's.
+      if (from < 3) {
+        await m.createTable(heldAircraftQualificationsTable);
+        await m.createTable(heldRatingsTable);
       }
     },
     beforeOpen: (details) async {

--- a/lib/data/mappers/held_qualification_mapper.dart
+++ b/lib/data/mappers/held_qualification_mapper.dart
@@ -1,0 +1,56 @@
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/pilot_record/held_aircraft_qualification.dart' as domain;
+import '../../domain/pilot_record/held_rating.dart' as domain;
+import '../database.dart';
+
+HeldAircraftQualificationRow heldAircraftQualificationToRow(
+  domain.HeldAircraftQualification held, {
+  required String id,
+}) {
+  return HeldAircraftQualificationRow(
+    id: id,
+    qualification: held.qualification.name,
+    jurisdictionId: held.jurisdictionId,
+    dateGranted: held.dateGranted.toString(),
+    signatoryName: held.signatoryName,
+    signatoryCredentialNumber: held.signatoryCredentialNumber,
+  );
+}
+
+domain.HeldAircraftQualification heldAircraftQualificationFromRow(
+  HeldAircraftQualificationRow row,
+) {
+  return domain.HeldAircraftQualification(
+    qualification: AircraftQualification.values.byName(row.qualification),
+    jurisdictionId: row.jurisdictionId,
+    dateGranted: CalendarDate.parse(row.dateGranted),
+    signatoryName: row.signatoryName,
+    signatoryCredentialNumber: row.signatoryCredentialNumber,
+  );
+}
+
+HeldRatingRow heldRatingToRow(domain.HeldRating held, {required String id}) {
+  return HeldRatingRow(
+    id: id,
+    kind: held.kind.name,
+    designator: held.designator,
+    jurisdictionId: held.jurisdictionId,
+    issueDate: held.issueDate.toString(),
+    expiryDate: held.expiryDate?.toString(),
+    languageProficiencyLevel: held.languageProficiencyLevel,
+  );
+}
+
+domain.HeldRating heldRatingFromRow(HeldRatingRow row) {
+  return domain.HeldRating(
+    kind: domain.HeldRatingKind.values.byName(row.kind),
+    designator: row.designator,
+    jurisdictionId: row.jurisdictionId,
+    issueDate: CalendarDate.parse(row.issueDate),
+    expiryDate: row.expiryDate == null
+        ? null
+        : CalendarDate.parse(row.expiryDate!),
+    languageProficiencyLevel: row.languageProficiencyLevel,
+  );
+}

--- a/lib/data/repositories/held_aircraft_qualification_repository.dart
+++ b/lib/data/repositories/held_aircraft_qualification_repository.dart
@@ -1,0 +1,42 @@
+import '../../domain/pilot_record/held_aircraft_qualification.dart' as domain;
+import '../database.dart';
+import '../mappers/held_qualification_mapper.dart';
+import '../ulid.dart';
+
+/// Write and read access to held aircraft-feature qualifications. A
+/// current, editable reference record like `aircraft` — no
+/// draft/committed lifecycle.
+class HeldAircraftQualificationRepository {
+  HeldAircraftQualificationRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<String> upsert(
+    domain.HeldAircraftQualification held, {
+    String? id,
+  }) async {
+    final resolvedId = id ?? generateUlid();
+    await _db
+        .into(_db.heldAircraftQualificationsTable)
+        .insertOnConflictUpdate(
+          heldAircraftQualificationToRow(held, id: resolvedId),
+        );
+    return resolvedId;
+  }
+
+  Future<domain.HeldAircraftQualification?> find(String id) async {
+    final row = await (_db.select(
+      _db.heldAircraftQualificationsTable,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    return row == null ? null : heldAircraftQualificationFromRow(row);
+  }
+
+  Future<List<domain.HeldAircraftQualification>> findAll() async {
+    final rows = await _db.select(_db.heldAircraftQualificationsTable).get();
+    return [for (final row in rows) heldAircraftQualificationFromRow(row)];
+  }
+
+  Future<void> delete(String id) => (_db.delete(
+    _db.heldAircraftQualificationsTable,
+  )..where((t) => t.id.equals(id))).go();
+}

--- a/lib/data/repositories/held_rating_repository.dart
+++ b/lib/data/repositories/held_rating_repository.dart
@@ -1,0 +1,36 @@
+import '../../domain/pilot_record/held_rating.dart' as domain;
+import '../database.dart';
+import '../mappers/held_qualification_mapper.dart';
+import '../ulid.dart';
+
+/// Write and read access to held ratings and certificates. A current,
+/// editable reference record like `aircraft` — no draft/committed
+/// lifecycle.
+class HeldRatingRepository {
+  HeldRatingRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<String> upsert(domain.HeldRating held, {String? id}) async {
+    final resolvedId = id ?? generateUlid();
+    await _db
+        .into(_db.heldRatingsTable)
+        .insertOnConflictUpdate(heldRatingToRow(held, id: resolvedId));
+    return resolvedId;
+  }
+
+  Future<domain.HeldRating?> find(String id) async {
+    final row = await (_db.select(
+      _db.heldRatingsTable,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    return row == null ? null : heldRatingFromRow(row);
+  }
+
+  Future<List<domain.HeldRating>> findAll() async {
+    final rows = await _db.select(_db.heldRatingsTable).get();
+    return [for (final row in rows) heldRatingFromRow(row)];
+  }
+
+  Future<void> delete(String id) =>
+      (_db.delete(_db.heldRatingsTable)..where((t) => t.id.equals(id))).go();
+}

--- a/lib/data/tables/held_qualification_tables.dart
+++ b/lib/data/tables/held_qualification_tables.dart
@@ -1,0 +1,38 @@
+import 'package:drift/drift.dart';
+
+/// Mirrors `HeldAircraftQualification` (#52) — a current, editable
+/// reference record like `aircraft`.
+@DataClassName('HeldAircraftQualificationRow')
+class HeldAircraftQualificationsTable extends Table {
+  @override
+  String get tableName => 'held_aircraft_qualifications';
+
+  TextColumn get id => text()();
+  TextColumn get qualification => text()();
+  TextColumn get jurisdictionId => text()();
+  TextColumn get dateGranted => text()();
+  TextColumn get signatoryName => text().nullable()();
+  TextColumn get signatoryCredentialNumber => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Mirrors `HeldRating` (#52) — a current, editable reference record like
+/// `aircraft`.
+@DataClassName('HeldRatingRow')
+class HeldRatingsTable extends Table {
+  @override
+  String get tableName => 'held_ratings';
+
+  TextColumn get id => text()();
+  TextColumn get kind => text()();
+  TextColumn get designator => text()();
+  TextColumn get jurisdictionId => text()();
+  TextColumn get issueDate => text()();
+  TextColumn get expiryDate => text().nullable()();
+  IntColumn get languageProficiencyLevel => integer().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/domain/pilot_record/held_aircraft_qualification.dart
+++ b/lib/domain/pilot_record/held_aircraft_qualification.dart
@@ -1,0 +1,44 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/aircraft.dart';
+import '../model/calendar_date.dart';
+
+part 'held_aircraft_qualification.freezed.dart';
+
+/// One aircraft-feature qualification the pilot holds — EASA differences
+/// training or an FAA `§61.31` endorsement — #52.
+///
+/// Keyed on [AircraftQualification] directly, the same enum
+/// `Aircraft.requiredQualifications` uses, so a held record and a
+/// required one compare directly with no name-mapping layer between them
+/// (#52's own acceptance criterion, and #105's whole premise).
+///
+/// **No expiry field, on either authority.** EASA differences training and
+/// FAA `§61.31` endorsements are *both* non-expiring
+/// (`docs/ratings-and-endorsements.md` §1, §3) — unlike [HeldRating], which
+/// genuinely needs one on the EASA side. Forcing a nullable field that is
+/// always null for every value this type can hold would be the kind of
+/// field a reader has to double-check is never populated; leaving it off
+/// entirely says the same thing in the type itself.
+///
+/// [signatoryName]/[signatoryCredentialNumber]/[signedOn] mirror
+/// `Countersignature`'s identity fields, deliberately without its
+/// [CountersignatureStatus] workflow: this is a self-attested record the
+/// pilot enters from their own logbook, not an interactive instructor
+/// sign-in flow — CLAUDE.md lists that workflow under "Deliberately out of
+/// scope for now".
+@freezed
+abstract class HeldAircraftQualification with _$HeldAircraftQualification {
+  const factory HeldAircraftQualification({
+    required AircraftQualification qualification,
+
+    /// The jurisdiction profile id this record was granted under, e.g.
+    /// `eu.easa.part-fcl`, `us.faa.part61`.
+    required String jurisdictionId,
+
+    required CalendarDate dateGranted,
+
+    String? signatoryName,
+    String? signatoryCredentialNumber,
+  }) = _HeldAircraftQualification;
+}

--- a/lib/domain/pilot_record/held_qualification_records.dart
+++ b/lib/domain/pilot_record/held_qualification_records.dart
@@ -1,0 +1,56 @@
+import '../currency/held_record.dart';
+import '../currency/rule_window.dart';
+import '../model/calendar_date.dart';
+import 'held_aircraft_qualification.dart';
+import 'held_rating.dart';
+
+/// [HeldAircraftQualification] projected to the generic [HeldRecord] shape
+/// the currency engine consumes — #52. Never expires, on either authority
+/// (see the class dartdoc), so this is a straight field copy with no
+/// computation at all.
+HeldRecord heldAircraftQualificationHeldRecord(HeldAircraftQualification held) {
+  return HeldRecord(
+    kind:
+        'aircraft_qualification.${held.jurisdictionId}.'
+        '${held.qualification.name}',
+    validFrom: held.dateGranted,
+    validUntil: null,
+  );
+}
+
+/// FCL.055's fixed per-level validity: Level 6 never expires, Level 5 is
+/// valid 6 years, Level 4 is valid 4 years — EASA's implemented figure,
+/// not ICAO Doc 9835's own 3-year recommendation for Level 4, which EASA
+/// did not adopt as-is.
+const Map<int, int> _languageProficiencyValidityMonths = {5: 72, 4: 48};
+
+/// [HeldRating] projected to the generic [HeldRecord] shape the currency
+/// engine consumes — #52.
+///
+/// Every kind but [HeldRatingKind.languageProficiency] passes
+/// [HeldRating.expiryDate] straight through — it is already the raw fact
+/// the licence states, not something to recompute (see the class
+/// dartdoc). Language proficiency is the one case with real logic: the
+/// duration is fixed per level, so it is worth computing from
+/// [HeldRating.languageProficiencyLevel] rather than trusting a
+/// hand-entered date to match FCL.055 exactly.
+HeldRecord heldRatingHeldRecord(HeldRating held) {
+  return HeldRecord(
+    kind: 'rating.${held.jurisdictionId}.${held.kind.name}.${held.designator}',
+    validFrom: held.issueDate,
+    validUntil: held.kind == HeldRatingKind.languageProficiency
+        ? _languageProficiencyExpiry(
+            held.issueDate,
+            held.languageProficiencyLevel,
+          )
+        : held.expiryDate,
+  );
+}
+
+CalendarDate? _languageProficiencyExpiry(CalendarDate issueDate, int? level) {
+  final months = _languageProficiencyValidityMonths[level];
+  if (months == null) {
+    return null; // Level 6, or an unrecognised level -- never expires.
+  }
+  return RuleWindow.calendarMonths(months).expiryFrom(issueDate);
+}

--- a/lib/domain/pilot_record/held_rating.dart
+++ b/lib/domain/pilot_record/held_rating.dart
@@ -1,0 +1,65 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/calendar_date.dart';
+
+part 'held_rating.freezed.dart';
+
+/// One privilege rating or certificate the pilot holds — a class or type
+/// rating, an instrument rating, an instructor certificate, or a language
+/// proficiency endorsement — #52.
+///
+/// **[expiryDate] is a stored raw fact, not a computed one.** Unlike
+/// medical certificate validity (`medical_certificate_validity.dart`),
+/// which genuinely depends on age-band logic worth computing, a rating's
+/// expiry is simply what the issuing authority printed on the licence at
+/// the last issue or revalidation — the pilot transcribes it, the same way
+/// they transcribe an aircraft's registration. `docs/ratings-and-
+/// endorsements.md` §1, §6: EASA-side records carry that expiry and gate
+/// legality on it (lapsed = grounded); FAA-side ratings — type rating,
+/// instrument rating — never expire and [expiryDate] stays null for them,
+/// never a forced date. [languageProficiencyLevel] 6 is the one EASA-side
+/// exception that also never expires; see [heldRatingHeldRecord] for the
+/// one case ([HeldRatingKind.languageProficiency]) where a duration *is*
+/// computed, from `FCL.055`'s fixed per-level periods.
+///
+/// [jurisdictionId] is what keeps two licences' rating sets independent —
+/// an EASA instrument rating and an FAA instrument rating are two
+/// [HeldRating]s with the same [kind] and different [jurisdictionId]s, and
+/// nothing about this type lets one satisfy a currency check scoped to the
+/// other (#52's "independent rating sets that do not interfere").
+@freezed
+abstract class HeldRating with _$HeldRating {
+  const factory HeldRating({
+    required HeldRatingKind kind,
+
+    /// Identifies which specific rating within [kind], e.g. `SEP(land)`,
+    /// `MEP(land)` for [HeldRatingKind.classRating]; the type-certificate
+    /// designator for [HeldRatingKind.typeRating] — deliberately the same
+    /// string space as `Aircraft.typeRatingDesignator`, so two
+    /// registrations of one type resolve to the one held record (#52); a
+    /// certificate identifier such as `CFI` for
+    /// [HeldRatingKind.instructorCertificate]; a language name such as
+    /// `english` for [HeldRatingKind.languageProficiency].
+    required String designator,
+
+    required String jurisdictionId,
+
+    required CalendarDate issueDate,
+
+    /// Null means never expires — the ordinary FAA case, and the EASA
+    /// language-proficiency Level 6 case ([languageProficiencyLevel] `6`).
+    CalendarDate? expiryDate,
+
+    /// Set only when [kind] is [HeldRatingKind.languageProficiency] — the
+    /// ICAO/`FCL.055` level (4, 5 or 6) this record certifies.
+    int? languageProficiencyLevel,
+  }) = _HeldRating;
+}
+
+enum HeldRatingKind {
+  classRating,
+  typeRating,
+  instrumentRating,
+  instructorCertificate,
+  languageProficiency,
+}

--- a/test/data/database_migration_test.dart
+++ b/test/data/database_migration_test.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 import 'package:drift/native.dart';
 import 'package:easa_digital_log/data/database.dart';
 import 'package:easa_digital_log/data/open_with_backup.dart';
+import 'package:easa_digital_log/data/repositories/held_rating_repository.dart';
 import 'package:easa_digital_log/data/repositories/medical_certificate_repository.dart';
 import 'package:easa_digital_log/data/repositories/pilot_profile_repository.dart';
 import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_rating.dart';
 import 'package:easa_digital_log/domain/pilot_record/medical_certificate.dart';
 import 'package:easa_digital_log/domain/pilot_record/pilot_profile.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -61,6 +63,31 @@ void _seedV1Database(String path) {
   }
 }
 
+/// As [_seedV1Database], but already at v2 (the `pilot_profile` and
+/// `medical_certificates` tables from #51 already exist and have a row),
+/// to exercise the migration path a pilot who upgrades straight from v2 —
+/// not from the very first v1 release — actually takes: the `from < 2`
+/// block must be skipped and only `from < 3` must run.
+void _seedV2Database(String path) {
+  final db = sqlite3.sqlite3.open(path);
+  try {
+    db.execute('''
+      CREATE TABLE pilot_profile (
+        id TEXT NOT NULL,
+        date_of_birth TEXT NOT NULL,
+        PRIMARY KEY (id)
+      )
+    ''');
+    db.execute('INSERT INTO pilot_profile (id, date_of_birth) VALUES (?, ?)', [
+      'singleton',
+      '1990-01-01',
+    ]);
+    db.execute('PRAGMA user_version = 2');
+  } finally {
+    db.close();
+  }
+}
+
 void main() {
   late Directory tempDir;
   late File dbFile;
@@ -102,6 +129,38 @@ void main() {
       );
       final id = await medicalCertificates.upsert(certificate);
       expect(await medicalCertificates.find(id), certificate);
+    },
+  );
+
+  test(
+    '#52: migrating a real v2 database to v3 preserves existing pilot_profile '
+    'data and adds held_ratings, without re-running the v1->v2 step',
+    () async {
+      _seedV2Database(dbFile.path);
+
+      final db = await openWithBackup(dbFile, () async {
+        final database = AppDatabase(NativeDatabase(dbFile));
+        await database.customStatement('SELECT 1');
+        return database;
+      });
+      addTearDown(db.close);
+
+      final pilotProfiles = PilotProfileRepository(db);
+      expect(
+        await pilotProfiles.find(),
+        const PilotProfile(dateOfBirth: CalendarDate(1990, 1, 1)),
+      );
+
+      final heldRatings = HeldRatingRepository(db);
+      const rating = HeldRating(
+        kind: HeldRatingKind.instrumentRating,
+        designator: 'IR',
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 1),
+        expiryDate: CalendarDate(2025, 1, 1),
+      );
+      final id = await heldRatings.upsert(rating);
+      expect(await heldRatings.find(id), rating);
     },
   );
 }

--- a/test/data/database_test.dart
+++ b/test/data/database_test.dart
@@ -3,10 +3,10 @@ import 'package:easa_digital_log/data/database.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('opens an in-memory database with all ten tables', () async {
+  test('opens an in-memory database with all twelve tables', () async {
     final db = AppDatabase(NativeDatabase.memory());
     addTearDown(db.close);
 
-    expect(db.allTables, hasLength(10));
+    expect(db.allTables, hasLength(12));
   });
 }

--- a/test/data/repositories/held_aircraft_qualification_repository_test.dart
+++ b/test/data/repositories/held_aircraft_qualification_repository_test.dart
@@ -1,0 +1,55 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/held_aircraft_qualification_repository.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_aircraft_qualification.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late HeldAircraftQualificationRepository repository;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    repository = HeldAircraftQualificationRepository(db);
+  });
+
+  tearDown(() => db.close());
+
+  const heldVp = HeldAircraftQualification(
+    qualification: AircraftQualification.easaVariablePitchPropeller,
+    jurisdictionId: 'eu.easa.part-fcl',
+    dateGranted: CalendarDate(2020, 1, 1),
+    signatoryName: 'A. Instructor',
+    signatoryCredentialNumber: 'FI-123',
+  );
+
+  test('round-trips through upsert and find', () async {
+    final id = await repository.upsert(heldVp);
+
+    expect(await repository.find(id), heldVp);
+  });
+
+  test('findAll returns every held qualification', () async {
+    const heldTailwheel = HeldAircraftQualification(
+      qualification: AircraftQualification.faaTailwheel,
+      jurisdictionId: 'us.faa.part61',
+      dateGranted: CalendarDate(2021, 6, 1),
+    );
+    await repository.upsert(heldVp);
+    await repository.upsert(heldTailwheel);
+
+    expect(
+      await repository.findAll(),
+      unorderedEquals([heldVp, heldTailwheel]),
+    );
+  });
+
+  test('delete removes the qualification', () async {
+    final id = await repository.upsert(heldVp);
+    await repository.delete(id);
+
+    expect(await repository.find(id), isNull);
+  });
+}

--- a/test/data/repositories/held_rating_repository_test.dart
+++ b/test/data/repositories/held_rating_repository_test.dart
@@ -1,0 +1,90 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/held_rating_repository.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_rating.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late HeldRatingRepository repository;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    repository = HeldRatingRepository(db);
+  });
+
+  tearDown(() => db.close());
+
+  const sep = HeldRating(
+    kind: HeldRatingKind.classRating,
+    designator: 'SEP(land)',
+    jurisdictionId: 'eu.easa.part-fcl',
+    issueDate: CalendarDate(2024, 1, 1),
+    expiryDate: CalendarDate(2026, 1, 1),
+  );
+
+  test(
+    'round-trips through upsert and find, including a null expiryDate',
+    () async {
+      const faaType = HeldRating(
+        kind: HeldRatingKind.typeRating,
+        designator: 'A320',
+        jurisdictionId: 'us.faa.part61',
+        issueDate: CalendarDate(2024, 1, 1),
+      );
+
+      final sepId = await repository.upsert(sep);
+      final faaTypeId = await repository.upsert(faaType);
+
+      expect(await repository.find(sepId), sep);
+      expect(await repository.find(faaTypeId), faaType);
+    },
+  );
+
+  test('round-trips a language proficiency level', () async {
+    const english = HeldRating(
+      kind: HeldRatingKind.languageProficiency,
+      designator: 'english',
+      jurisdictionId: 'eu.easa.part-fcl',
+      issueDate: CalendarDate(2024, 1, 1),
+      languageProficiencyLevel: 6,
+    );
+
+    final id = await repository.upsert(english);
+
+    expect(await repository.find(id), english);
+  });
+
+  test('upsert with an existing id replaces the row', () async {
+    final id = await repository.upsert(sep);
+    final revalidated = sep.copyWith(
+      issueDate: const CalendarDate(2026, 1, 1),
+      expiryDate: const CalendarDate(2028, 1, 1),
+    );
+
+    await repository.upsert(revalidated, id: id);
+
+    expect(await repository.find(id), revalidated);
+  });
+
+  test('findAll returns every held rating', () async {
+    const faaType = HeldRating(
+      kind: HeldRatingKind.typeRating,
+      designator: 'A320',
+      jurisdictionId: 'us.faa.part61',
+      issueDate: CalendarDate(2024, 1, 1),
+    );
+    await repository.upsert(sep);
+    await repository.upsert(faaType);
+
+    expect(await repository.findAll(), unorderedEquals([sep, faaType]));
+  });
+
+  test('delete removes the rating', () async {
+    final id = await repository.upsert(sep);
+    await repository.delete(id);
+
+    expect(await repository.find(id), isNull);
+  });
+}

--- a/test/domain/pilot_record/held_qualification_currency_test.dart
+++ b/test/domain/pilot_record/held_qualification_currency_test.dart
@@ -1,0 +1,139 @@
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_aircraft_qualification.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_qualification_records.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_rating.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const evaluator = CurrencyRuleEvaluator();
+
+  test(
+    'an EASA and an FAA instrument rating do not interfere with each other',
+    () {
+      // #52: "a pilot holding both an EASA and an FAA licence has independent
+      // rating sets that do not interfere." The FAA IR never expires; the
+      // EASA IR has lapsed. Checking "am I current on my EASA IR" must not
+      // be satisfied by the still-valid FAA one just because both are
+      // nominally "an instrument rating".
+      final easaIr = HeldRating(
+        kind: HeldRatingKind.instrumentRating,
+        designator: 'IR',
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2020, 1, 1),
+        expiryDate: CalendarDate(2021, 1, 1), // lapsed
+      );
+      final faaIr = HeldRating(
+        kind: HeldRatingKind.instrumentRating,
+        designator: 'IR',
+        jurisdictionId: 'us.faa.part61',
+        issueDate: CalendarDate(2020, 1, 1),
+        // no expiryDate -- FAA instrument ratings never expire.
+      );
+      final subject = EvaluationSubject(
+        flights: const [],
+        heldRecords: [
+          heldRatingHeldRecord(easaIr),
+          heldRatingHeldRecord(faaIr),
+        ],
+      );
+
+      final easaRequirement = Requirement.heldRecordCurrentlyValid(
+        'rating.eu.easa.part-fcl.instrumentRating.IR',
+      );
+      final faaRequirement = Requirement.heldRecordCurrentlyValid(
+        'rating.us.faa.part61.instrumentRating.IR',
+      );
+
+      final asOf = CalendarDate(2024, 1, 1);
+      expect(
+        evaluator.evaluateRequirement(easaRequirement, subject, asOf).satisfied,
+        isFalse,
+      );
+      expect(
+        evaluator.evaluateRequirement(faaRequirement, subject, asOf).satisfied,
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'a type rating keys on the same designator string Aircraft carries, joining two registrations of one type',
+    () {
+      const airbus1 = Aircraft(
+        registration: 'G-ONE',
+        manufacturer: 'Airbus',
+        model: 'A320',
+        typeRatingDesignator: 'A320',
+        category: AircraftCategory.aeroplane,
+        engineType: EngineType.turbofan,
+        engineCount: 2,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: true,
+      );
+      const airbus2 = Aircraft(
+        registration: 'G-TWO',
+        manufacturer: 'Airbus',
+        model: 'A320',
+        typeRatingDesignator: 'A320',
+        category: AircraftCategory.aeroplane,
+        engineType: EngineType.turbofan,
+        engineCount: 2,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: true,
+      );
+      // One held rating, naming the type once.
+      final held = HeldRating(
+        kind: HeldRatingKind.typeRating,
+        designator: 'A320',
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 1),
+        expiryDate: CalendarDate(2025, 1, 1),
+      );
+
+      // The held record's kind is built from the rating's own designator,
+      // independent of which specific registration is being asked about --
+      // it resolves the same way for either airframe.
+      expect(
+        held.designator,
+        airbus1.typeRatingDesignator,
+        reason: 'same string space as Aircraft.typeRatingDesignator',
+      );
+      expect(held.designator, airbus2.typeRatingDesignator);
+      expect(heldRatingHeldRecord(held).kind, contains('A320'));
+    },
+  );
+
+  test(
+    'differences training is a raw fact with no expiry, so it is always currently valid once granted',
+    () {
+      final held = HeldAircraftQualification(
+        qualification: AircraftQualification.easaRetractableUndercarriage,
+        jurisdictionId: 'eu.easa.part-fcl',
+        dateGranted: CalendarDate(2015, 1, 1),
+        signatoryName: 'A. Instructor',
+        signatoryCredentialNumber: 'FI-42',
+      );
+      final requirement = Requirement.heldRecordCurrentlyValid(
+        'aircraft_qualification.eu.easa.part-fcl.easaRetractableUndercarriage',
+      );
+      final subject = EvaluationSubject(
+        flights: const [],
+        heldRecords: [heldAircraftQualificationHeldRecord(held)],
+      );
+
+      // Ten years after being granted, with no revalidation of any kind.
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        subject,
+        CalendarDate(2025, 1, 1),
+      );
+
+      expect(result.satisfied, isTrue);
+      expect(result.expiresOn, isNull);
+    },
+  );
+}

--- a/test/domain/pilot_record/held_qualification_records_test.dart
+++ b/test/domain/pilot_record/held_qualification_records_test.dart
@@ -1,0 +1,138 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_aircraft_qualification.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_qualification_records.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_rating.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('heldAircraftQualificationHeldRecord', () {
+    test('never expires, regardless of authority', () {
+      final held = HeldAircraftQualification(
+        qualification: AircraftQualification.easaVariablePitchPropeller,
+        jurisdictionId: 'eu.easa.part-fcl',
+        dateGranted: CalendarDate(2020, 1, 1),
+        signatoryName: 'A. Instructor',
+        signatoryCredentialNumber: 'FI-123',
+      );
+
+      final record = heldAircraftQualificationHeldRecord(held);
+
+      expect(record.validFrom, CalendarDate(2020, 1, 1));
+      expect(record.validUntil, isNull);
+      expect(
+        record.kind,
+        'aircraft_qualification.eu.easa.part-fcl.easaVariablePitchPropeller',
+      );
+    });
+
+    test('an FAA endorsement also never expires', () {
+      final held = HeldAircraftQualification(
+        qualification: AircraftQualification.faaHighPerformance,
+        jurisdictionId: 'us.faa.part61',
+        dateGranted: CalendarDate(2020, 1, 1),
+      );
+
+      expect(heldAircraftQualificationHeldRecord(held).validUntil, isNull);
+    });
+  });
+
+  group('heldRatingHeldRecord', () {
+    test('a class rating\'s stored expiry passes through unchanged', () {
+      final held = HeldRating(
+        kind: HeldRatingKind.classRating,
+        designator: 'SEP(land)',
+        jurisdictionId: 'eu.easa.part-fcl',
+        issueDate: CalendarDate(2024, 1, 1),
+        expiryDate: CalendarDate(2026, 1, 1),
+      );
+
+      final record = heldRatingHeldRecord(held);
+
+      expect(record.validFrom, CalendarDate(2024, 1, 1));
+      expect(record.validUntil, CalendarDate(2026, 1, 1));
+      expect(record.kind, 'rating.eu.easa.part-fcl.classRating.SEP(land)');
+    });
+
+    test('an FAA type rating with no stored expiry never expires', () {
+      final held = HeldRating(
+        kind: HeldRatingKind.typeRating,
+        designator: 'A320',
+        jurisdictionId: 'us.faa.part61',
+        issueDate: CalendarDate(2024, 1, 1),
+      );
+
+      expect(heldRatingHeldRecord(held).validUntil, isNull);
+    });
+
+    test(
+      'two type ratings sharing a designator but different jurisdictions do not interfere',
+      () {
+        final easa = HeldRating(
+          kind: HeldRatingKind.typeRating,
+          designator: 'A320',
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(2024, 1, 1),
+          expiryDate: CalendarDate(2025, 1, 1),
+        );
+        final faa = HeldRating(
+          kind: HeldRatingKind.typeRating,
+          designator: 'A320',
+          jurisdictionId: 'us.faa.part61',
+          issueDate: CalendarDate(2024, 1, 1),
+        );
+
+        final easaRecord = heldRatingHeldRecord(easa);
+        final faaRecord = heldRatingHeldRecord(faa);
+
+        expect(easaRecord.kind, isNot(faaRecord.kind));
+        expect(easaRecord.validUntil, isNotNull);
+        expect(faaRecord.validUntil, isNull);
+      },
+    );
+
+    group('language proficiency (FCL.055), duration computed from level', () {
+      test('level 6 never expires, even if a stray expiryDate was stored', () {
+        final held = HeldRating(
+          kind: HeldRatingKind.languageProficiency,
+          designator: 'english',
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(2024, 1, 15),
+          languageProficiencyLevel: 6,
+        );
+
+        expect(heldRatingHeldRecord(held).validUntil, isNull);
+      });
+
+      test('level 5 is valid for 6 years', () {
+        final held = HeldRating(
+          kind: HeldRatingKind.languageProficiency,
+          designator: 'english',
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(2024, 1, 15),
+          languageProficiencyLevel: 5,
+        );
+
+        expect(
+          heldRatingHeldRecord(held).validUntil,
+          CalendarDate(2030, 1, 31),
+        );
+      });
+
+      test('level 4 is valid for 4 years', () {
+        final held = HeldRating(
+          kind: HeldRatingKind.languageProficiency,
+          designator: 'english',
+          jurisdictionId: 'eu.easa.part-fcl',
+          issueDate: CalendarDate(2024, 1, 15),
+          languageProficiencyLevel: 4,
+        );
+
+        expect(
+          heldRatingHeldRecord(held).validUntil,
+          CalendarDate(2028, 1, 31),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stacked on #124 — base branch is `feat/m3-medical-certificate-validity`, not `main`.

- `HeldAircraftQualification` (EASA differences training, FAA `§61.31` endorsements) keys directly on the `AircraftQualification` enum `Aircraft.requiredQualifications` already uses — no name-mapping layer between a held record and a required one, which is #105's whole premise. No expiry field at all, on either authority: both are permanent, so a nullable field that's always null would just be noise.
- `HeldRating` covers class/type ratings, the instrument rating, instructor certificates and language proficiency. Its expiry is stored as a raw fact (what the licence states), not computed — unlike medical certificates, a rating's validity is fixed by the issuing authority at issue/revalidation, not something this app derives.
- Language proficiency is the one exception worth computing: `FCL.055`'s fixed per-level durations (Level 6 permanent, Level 5 six years, Level 4 four years — EASA's own implemented figure, not ICAO Doc 9835's 3-year recommendation, verified before use).
- Held type ratings key on the same `typeRatingDesignator` string `Aircraft` carries, so two registrations of one type resolve to the one held record — tested directly.
- `jurisdictionId` keeps an EASA and an FAA rating of the same kind from interfering — tested against the real currency evaluator, not just the model (a lapsed EASA IR + a never-expiring FAA IR: asking about one must not be satisfied by the other).
- `schemaVersion` 2 → 3, with **both** a v1→v3 and a dedicated v2→v3 migration path verified against real sqlite files (not just the fixture harness) — the v2→v3 test specifically exercises the "skip the earlier upgrade block, run only the new one" path a pilot upgrading from an already-migrated v2 install would actually take.
- No new rule YAML files: #52 is about the model existing correctly for #105 and the PR4 rules (#46, #47, #49, #50) to consume, not a named regulation of its own the way `MED.A.045`/`§61.23` were for #51.

Closes #52 (the held-qualification half — differences training / endorsements / class / type / instrument / instructor / language proficiency tracking, independence across licences, and the type-rating designator join. `Aircraft.requiredQualifications` vs. held comparison and the entry-time warning are #105, still ahead).

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_currency_rules.dart` — 9 rule files clean (unchanged, no new rule files this PR)
- [x] `dart run tool/check_schema_snapshot.dart` — v3 snapshot committed
- [x] `flutter test --coverage` — 491 passing, including two real migration tests (v1→v3, v2→v3) against raw sqlite3-seeded files
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 94.5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)