### PR TITLE
Alternative-compliance events and three recency rules

### DIFF
--- a/assets/rules/easa/fcl060_b3_night_passenger_recency.yaml
+++ b/assets/rules/easa/fcl060_b3_night_passenger_recency.yaml
@@ -1,0 +1,49 @@
+# FCL.060(b)(3): carrying passengers at night requires that at least one of
+# the three take-offs and landings required by FCL.060(b)(1) was performed
+# at night, unless the pilot holds a valid instrument rating.
+#
+# Modelled as FCL.060(b)(1)'s own 3-landing requirement (duplicated here --
+# there is no cross-rule reference mechanism, and b(3) is meaningless
+# without b(1) already being satisfied by the *same* three landings) ANDed
+# with an alternative: at least one of those landings at night, OR holding
+# an IR. The IR alternative is a pilot prerequisite, not special-cased in
+# code -- it is an ordinary held_record_currently_valid branch of the
+# any_of, exactly like #40's "alternative means of compliance" wording
+# describes.
+#
+# The day/night split read for the night condition is
+# Flight.landings.night* -- the pilot-entered raw fact, the same one
+# #45/#48 read. EASA has one definition of night (FCL.010, civil
+# twilight), so this is also "the EASA night window" -- there is no second,
+# currency-specific window the way FAA's Sec.61.57(b) has.
+id: eu.easa.fcl060.b3_night_passenger_recency
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.060(b)(3)"
+effective_from: 2011-11-08
+requirement:
+  kind: all_of
+  of:
+    - kind: flight_event_count
+      event: landings
+      count: 3
+      window:
+        kind: rolling_days
+        days: 90
+      conditions:
+        - kind: aircraft_match
+          level: same_type_or_class
+    - kind: any_of
+      of:
+        - kind: flight_event_count
+          event: landings
+          count: 1
+          window:
+            kind: rolling_days
+            days: 90
+          conditions:
+            - kind: day_night
+              value: night
+            - kind: aircraft_match
+              level: same_type_or_class
+        - kind: held_record_currently_valid
+          held_record_kind: rating.eu.easa.part-fcl.instrumentRating.IR

--- a/assets/rules/faa/61_56_flight_review.yaml
+++ b/assets/rules/faa/61_56_flight_review.yaml
@@ -1,0 +1,33 @@
+# Sec.61.56: a flight review within the preceding 24 calendar months, or a
+# qualifying alternative -- here, an instrument proficiency check, which
+# Sec.61.56(a)(1) accepts in place of a flight review.
+#
+# Calendar-month semantics, not 730 days: valid through the end of the 24th
+# month regardless of which day of the month the review fell on (#49's own
+# acceptance criterion, and RuleWindow.calendarMonths' whole reason for
+# existing as a distinct window kind from rolling_days).
+#
+# Scope: completion of an FAA WINGS pilot proficiency program phase is
+# also a qualifying alternative under Sec.61.56(a)(1), but is deliberately
+# not modelled here -- it is a multi-flight program completion tracked by
+# FAASTeam, not a fact any single Flight can carry the way a flight review
+# or an IPC can. No raw fact captures it anywhere in this app yet.
+id: us.faa.61_56.flight_review
+jurisdiction: us.faa.part61
+citation: "§61.56"
+effective_from: 1997-08-04
+requirement:
+  kind: any_of
+  of:
+    - kind: flight_event_count
+      event: faa_flight_review
+      count: 1
+      window:
+        kind: calendar_months
+        months: 24
+    - kind: flight_event_count
+      event: faa_instrument_proficiency_check
+      count: 1
+      window:
+        kind: calendar_months
+        months: 24

--- a/assets/rules/faa/61_57_c_instrument_currency.yaml
+++ b/assets/rules/faa/61_57_c_instrument_currency.yaml
@@ -1,0 +1,62 @@
+# Sec.61.57(c): within the preceding 6 calendar months, six instrument
+# approaches, holding procedures, and intercepting and tracking a course
+# through the use of navigational electronic systems -- or an instrument
+# proficiency check.
+#
+# Pairs with 61_57_c_instrument_currency_grace_period.yaml, which is the
+# same requirement over a 12-month window instead of 6. Sec.61.57(c) is a
+# two-stage state, not a boolean: within 6 months, current; between 6 and
+# 12, "lapsed but in grace" -- the pilot can still self-cure by flying the
+# same six approaches etc, no IPC required; past 12 months, an IPC becomes
+# mandatory and self-cure is no longer available. Two separate rules over
+# two window sizes express this without any new engine mechanism: evaluate
+# both, and if the 6-month rule fails but the 12-month rule succeeds, the
+# pilot is in the grace window. If neither succeeds, an IPC is required.
+# Combining the two results into that three-state message is a caller
+# concern (a future currency dashboard), not this rule's.
+#
+# Holding is "at least one performed", not a specific count -- the
+# regulation does not give holding its own number the way it gives
+# approaches six. Intercepting and tracking is Flight.trackingPerformed, a
+# presence fact.
+#
+# Scope: approaches, holding and tracking performed in an FSTD (FFS/FTD/
+# ATD) also count toward this currency, per the regulation's own "aircraft,
+# full flight simulator, flight training device, or aviation training
+# device" wording -- deliberately not modelled here. FSTD sessions are a
+# separate domain model (fstd.dart) from Flight, and EvaluationSubject has
+# no path to consume them yet; wiring that in is a distinct piece of work
+# from adding this rule.
+id: us.faa.61_57_c.instrument_currency
+jurisdiction: us.faa.part61
+citation: "§61.57(c)"
+effective_from: 1997-08-04
+requirement:
+  kind: any_of
+  of:
+    - kind: all_of
+      of:
+        - kind: flight_event_count
+          event: approaches
+          count: 6
+          window:
+            kind: calendar_months
+            months: 6
+        - kind: flight_event_count
+          event: holding_procedures
+          count: 1
+          window:
+            kind: calendar_months
+            months: 6
+        - kind: flight_event_count
+          event: tracking_performed
+          count: 1
+          window:
+            kind: calendar_months
+            months: 6
+    - kind: flight_event_count
+      event: faa_instrument_proficiency_check
+      count: 1
+      window:
+        kind: calendar_months
+        months: 6

--- a/assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml
+++ b/assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml
@@ -1,0 +1,42 @@
+# Sec.61.57(c)'s 6-month-plus-6-month grace extension: the same six
+# approaches/holding/tracking requirement (or an IPC) as
+# 61_57_c_instrument_currency.yaml, but over the preceding 12 calendar
+# months instead of 6.
+#
+# See that file's comment for the full two-stage-state explanation. A
+# pilot who fails the 6-month rule but satisfies this one is "lapsed but
+# in grace": still able to regain currency by flying the requirement
+# again, no IPC required yet. A pilot who fails both needs an IPC.
+id: us.faa.61_57_c.instrument_currency_grace_period
+jurisdiction: us.faa.part61
+citation: "§61.57(c)"
+effective_from: 1997-08-04
+requirement:
+  kind: any_of
+  of:
+    - kind: all_of
+      of:
+        - kind: flight_event_count
+          event: approaches
+          count: 6
+          window:
+            kind: calendar_months
+            months: 12
+        - kind: flight_event_count
+          event: holding_procedures
+          count: 1
+          window:
+            kind: calendar_months
+            months: 12
+        - kind: flight_event_count
+          event: tracking_performed
+          count: 1
+          window:
+            kind: calendar_months
+            months: 12
+    - kind: flight_event_count
+      event: faa_instrument_proficiency_check
+      count: 1
+      window:
+        kind: calendar_months
+        months: 12

--- a/assets/rules/schema/currency-rule.schema.json
+++ b/assets/rules/schema/currency-rule.schema.json
@@ -39,7 +39,16 @@
     },
     "countableEvent": {
       "type": "string",
-      "enum": ["landings", "takeoffs", "approaches", "holding_procedures"]
+      "enum": [
+        "landings",
+        "takeoffs",
+        "approaches",
+        "holding_procedures",
+        "tracking_performed",
+        "faa_flight_review",
+        "faa_instrument_proficiency_check",
+        "easa_class_rating_proficiency_check"
+      ]
     },
     "condition": {
       "type": "object",

--- a/drift_schemas/drift_schema_v4.json
+++ b/drift_schemas/drift_schema_v4.json
@@ -1,0 +1,1616 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "alternative_compliance_events",
+            "getter_name": "alternativeComplianceEvents",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pilot_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_of_birth",
+            "getter_name": "dateOfBirth",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "medical_certificates",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "certificate_class",
+            "getter_name": "certificateClass",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_aircraft_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_granted",
+            "getter_name": "dateGranted",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_name",
+            "getter_name": "signatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_credential_number",
+            "getter_name": "signatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_ratings",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "designator",
+            "getter_name": "designator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "expiry_date",
+            "getter_name": "expiryDate",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "language_proficiency_level",
+            "getter_name": "languageProficiencyLevel",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"alternative_compliance_events\" TEXT NOT NULL DEFAULT '', \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pilot_profile",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pilot_profile\" (\"id\" TEXT NOT NULL, \"date_of_birth\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "medical_certificates",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"medical_certificates\" (\"id\" TEXT NOT NULL, \"certificate_class\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_aircraft_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_aircraft_qualifications\" (\"id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"date_granted\" TEXT NOT NULL, \"signatory_name\" TEXT NULL, \"signatory_credential_number\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_ratings",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_ratings\" (\"id\" TEXT NOT NULL, \"kind\" TEXT NOT NULL, \"designator\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, \"expiry_date\" TEXT NULL, \"language_proficiency_level\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -32,7 +32,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.executor);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   // SQLite does not enforce foreign keys — including this schema's
   // `onDelete: KeyAction.cascade` on the flight/aircraft child tables —
@@ -55,6 +55,18 @@ class AppDatabase extends _$AppDatabase {
       if (from < 3) {
         await m.createTable(heldAircraftQualificationsTable);
         await m.createTable(heldRatingsTable);
+      }
+      // #121: adds alternativeComplianceEvents to the existing flights
+      // table. Unlike the previous two steps, this alters a table that can
+      // already hold real rows (M2's dev seed data) rather than creating a
+      // new one — addColumn backfills the column's default ('', via the
+      // table definition's withDefault) on every existing row, so no
+      // explicit UPDATE is needed to keep old flights readable.
+      if (from < 4) {
+        await m.addColumn(
+          flightsTable,
+          flightsTable.alternativeComplianceEvents,
+        );
       }
     },
     beforeOpen: (details) async {

--- a/lib/data/mappers/flight_mapper.dart
+++ b/lib/data/mappers/flight_mapper.dart
@@ -48,6 +48,9 @@ FlightRow flightToRow(
     seriesGroupId: flight.seriesGroupId,
     airworthinessBasis: flight.airworthinessBasis?.name,
     remarks: flight.remarks,
+    alternativeComplianceEvents: flight.alternativeComplianceEvents
+        .map((event) => event.name)
+        .join(','),
     capacityCommandAuthority: capacity.commandAuthority,
     capacitySoleManipulator: capacity.soleManipulator,
     capacitySoleOccupant: capacity.soleOccupant,
@@ -219,6 +222,12 @@ domain.Flight flightFromRow(
     ],
     holdingProceduresCount: row.holdingProceduresCount,
     trackingPerformed: row.trackingPerformed,
+    alternativeComplianceEvents: row.alternativeComplianceEvents.isEmpty
+        ? const {}
+        : row.alternativeComplianceEvents
+              .split(',')
+              .map(domain.AlternativeComplianceEvent.values.byName)
+              .toSet(),
     seriesGroupId: row.seriesGroupId,
     airworthinessBasis: row.airworthinessBasis == null
         ? null

--- a/lib/data/tables/flight_tables.dart
+++ b/lib/data/tables/flight_tables.dart
@@ -42,6 +42,15 @@ class FlightsTable extends Table {
   TextColumn get airworthinessBasis => text().nullable()();
   TextColumn get remarks => text()();
 
+  /// #121: comma-joined [AlternativeComplianceEvent] names, e.g.
+  /// `'faaFlightReview,faaInstrumentProficiencyCheck'`. Empty string, not
+  /// null, when the set is empty — matches [Flight.remarks]'s "empty
+  /// string, not null, when there is nothing to say" convention, and the
+  /// set is small enough (three possible values) that a comma-joined
+  /// column is simpler than a child table.
+  TextColumn get alternativeComplianceEvents =>
+      text().withDefault(const Constant(''))();
+
   // Flattened PilotCapacity.
   BoolColumn get capacityCommandAuthority => boolean()();
   BoolColumn get capacitySoleManipulator => boolean()();

--- a/lib/domain/currency/currency_rule.dart
+++ b/lib/domain/currency/currency_rule.dart
@@ -124,13 +124,23 @@ enum RequirementKind {
 /// A per-flight numeric fact [Requirement.flightEventCount] and
 /// [Requirement.flightEventHours] can sum across a flight set.
 ///
-/// Deliberately only the events already on `Flight` (M1) — `landings` and
-/// `takeoffs` read [Flight.landings]/[Flight.takeoffs] narrowed by
-/// [FlightCondition.dayNight] and [FlightCondition.landingType];
+/// `landings` and `takeoffs` read [Flight.landings]/[Flight.takeoffs]
+/// narrowed by [FlightCondition.dayNight] and [FlightCondition.landingType];
 /// `approaches` sums [Approach.count]; `holdingProcedures` reads
-/// [Flight.holdingProceduresCount]. Growing this enum when #121 lands
-/// (flight-review/IPC/proficiency-check markers) is the kind of one-name
+/// [Flight.holdingProceduresCount]; `trackingPerformed` reads
+/// [Flight.trackingPerformed] as a presence fact (0 or 1, not a count);
+/// the three alt-compliance values (#121) read
+/// [Flight.alternativeComplianceEvents] the same way — each is a growth of
+/// this enum with one more `_eventCount` dispatch case, the kind of
 /// addition CLAUDE.md's jurisdiction-primitive acceptance test describes,
-/// not "touching the evaluator" in the sense #42 warns against — the
-/// evaluator's dispatch does not change shape, it gains one more case.
-enum CountableFlightEvent { landings, takeoffs, approaches, holdingProcedures }
+/// not "touching the evaluator" in the sense #42 warns against.
+enum CountableFlightEvent {
+  landings,
+  takeoffs,
+  approaches,
+  holdingProcedures,
+  trackingPerformed,
+  faaFlightReview,
+  faaInstrumentProficiencyCheck,
+  easaClassRatingProficiencyCheck,
+}

--- a/lib/domain/currency/currency_rule_evaluator.dart
+++ b/lib/domain/currency/currency_rule_evaluator.dart
@@ -309,6 +309,26 @@ int _eventCount(
       return total;
     case CountableFlightEvent.holdingProcedures:
       return flight.holdingProceduresCount;
+    case CountableFlightEvent.trackingPerformed:
+      return flight.trackingPerformed ? 1 : 0;
+    case CountableFlightEvent.faaFlightReview:
+      return flight.alternativeComplianceEvents.contains(
+            AlternativeComplianceEvent.faaFlightReview,
+          )
+          ? 1
+          : 0;
+    case CountableFlightEvent.faaInstrumentProficiencyCheck:
+      return flight.alternativeComplianceEvents.contains(
+            AlternativeComplianceEvent.faaInstrumentProficiencyCheck,
+          )
+          ? 1
+          : 0;
+    case CountableFlightEvent.easaClassRatingProficiencyCheck:
+      return flight.alternativeComplianceEvents.contains(
+            AlternativeComplianceEvent.easaClassRatingProficiencyCheck,
+          )
+          ? 1
+          : 0;
   }
 }
 
@@ -404,6 +424,12 @@ String _eventLabel(CountableFlightEvent event) => switch (event) {
   CountableFlightEvent.takeoffs => 'takeoffs',
   CountableFlightEvent.approaches => 'approaches',
   CountableFlightEvent.holdingProcedures => 'holding procedures',
+  CountableFlightEvent.trackingPerformed => 'tracking tasks performed',
+  CountableFlightEvent.faaFlightReview => 'flight reviews',
+  CountableFlightEvent.faaInstrumentProficiencyCheck =>
+    'instrument proficiency checks',
+  CountableFlightEvent.easaClassRatingProficiencyCheck =>
+    'class rating proficiency checks',
 };
 
 /// [_eventLabel] qualified by [conditions]' day/night and landing-type

--- a/lib/domain/currency/currency_rule_yaml.dart
+++ b/lib/domain/currency/currency_rule_yaml.dart
@@ -121,6 +121,12 @@ const Map<String, CountableFlightEvent> _events = {
   'takeoffs': CountableFlightEvent.takeoffs,
   'approaches': CountableFlightEvent.approaches,
   'holding_procedures': CountableFlightEvent.holdingProcedures,
+  'tracking_performed': CountableFlightEvent.trackingPerformed,
+  'faa_flight_review': CountableFlightEvent.faaFlightReview,
+  'faa_instrument_proficiency_check':
+      CountableFlightEvent.faaInstrumentProficiencyCheck,
+  'easa_class_rating_proficiency_check':
+      CountableFlightEvent.easaClassRatingProficiencyCheck,
 };
 
 CountableFlightEvent _requiredEvent(YamlMap yaml, String ruleId) {

--- a/lib/domain/model/flight.dart
+++ b/lib/domain/model/flight.dart
@@ -175,6 +175,24 @@ abstract class Flight with _$Flight {
     /// projection or export issue currently consumes it.
     String? seriesGroupId,
 
+    /// Which alternative-compliance events, if any, this flight constitutes
+    /// — a flight review, an instrument proficiency check, a class-rating
+    /// proficiency check. A set, not a single nullable value: one flight
+    /// can be flown specifically to serve more than one purpose at once —
+    /// an IPC that is also used to satisfy the flight review requirement
+    /// under `§61.56(a)`, for instance.
+    ///
+    /// Unbackfillable, the same way [seriesGroupId] is: nobody can
+    /// reconstruct in five years whether a given flight was flown *as* a
+    /// pilot's flight review — #121, discovered while sequencing M3's
+    /// currency rules, since #47/#49/#50 all need it and nothing previously
+    /// captured it. Examiner/instructor identity and countersignature for
+    /// these events are the existing [PilotCapacity.instructor] and
+    /// [PilotCapacity.countersignature] fields, not duplicated here — a
+    /// flight has one examiner, not one per event it happens to satisfy.
+    @Default(<AlternativeComplianceEvent>{})
+    Set<AlternativeComplianceEvent> alternativeComplianceEvents,
+
     /// `§61.51(j)`: which of the four categories of aircraft qualify for
     /// FAA-loggable flight time by registry and airworthiness basis. Null
     /// when not recorded — irrelevant to an EASA-only pilot, and the
@@ -303,4 +321,22 @@ enum AirworthinessBasis {
   /// `§61.51(j)(4)`: a public aircraft operation under 49 U.S.C.
   /// 40102(a)(41) and 40125.
   publicAircraftOperation,
+}
+
+/// An event a flight can constitute that substitutes for ordinary
+/// recency — #121. Exactly the events the currency rules built so far
+/// need; a new kind is a deliberate addition here, not something a rule
+/// author should be able to invent inline.
+enum AlternativeComplianceEvent {
+  /// `§61.56`: satisfies the biennial flight review requirement.
+  faaFlightReview,
+
+  /// `§61.57(c)`: an instrument proficiency check — also a qualifying
+  /// alternative to [faaFlightReview] under `§61.56(a)`.
+  faaInstrumentProficiencyCheck,
+
+  /// `FCL.740.A`: a class-rating proficiency check, the alternative to the
+  /// hours/landings/training-flight revalidation route for SEP, MEP and
+  /// TMG class ratings.
+  easaClassRatingProficiencyCheck,
 }

--- a/test/data/database_migration_test.dart
+++ b/test/data/database_migration_test.dart
@@ -14,11 +14,76 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
+/// The `flights` table's shape from v1 through v3 -- unchanged by #51/#52,
+/// only altered by #121 (v4). Column names mirror
+/// `lib/data/tables/flight_tables.dart`'s drift-generated snake_case
+/// exactly. Shared by [_seedV1Database] and [_seedV3Database]: a real v1
+/// install has this table even though neither #51's nor #52's migration
+/// step touches it, and skipping its creation would make #121's `addColumn`
+/// step fail with "no such table" the moment a seed test exercises it.
+const String _createFlightsTableV1ThroughV3 = '''
+  CREATE TABLE flights (
+    id TEXT NOT NULL,
+    aircraft_id TEXT NOT NULL REFERENCES aircraft (id),
+    pre_planned_navigation INTEGER NOT NULL,
+    off_blocks INTEGER NOT NULL,
+    on_blocks INTEGER NOT NULL,
+    takeoff INTEGER NULL,
+    landing INTEGER NULL,
+    other_pilot_name TEXT NULL,
+    other_pilot_credential_number TEXT NULL,
+    carrying_passengers INTEGER NOT NULL,
+    takeoffs_day_full_stop INTEGER NOT NULL,
+    takeoffs_day_touch_and_go INTEGER NOT NULL,
+    takeoffs_night_full_stop INTEGER NOT NULL,
+    takeoffs_night_touch_and_go INTEGER NOT NULL,
+    landings_day_full_stop INTEGER NOT NULL,
+    landings_day_touch_and_go INTEGER NOT NULL,
+    landings_night_full_stop INTEGER NOT NULL,
+    landings_night_touch_and_go INTEGER NOT NULL,
+    ifr_flight_plan_filed INTEGER NOT NULL,
+    actual_instrument_minutes INTEGER NOT NULL,
+    simulated_instrument_minutes INTEGER NOT NULL,
+    holding_procedures_count INTEGER NOT NULL,
+    tracking_performed INTEGER NOT NULL,
+    series_group_id TEXT NULL,
+    airworthiness_basis TEXT NULL,
+    remarks TEXT NOT NULL,
+    capacity_command_authority INTEGER NOT NULL,
+    capacity_sole_manipulator INTEGER NOT NULL,
+    capacity_sole_occupant INTEGER NOT NULL,
+    capacity_multi_pilot_operation INTEGER NOT NULL,
+    capacity_additional_crew_required_by_rule INTEGER NOT NULL,
+    capacity_acting_as_instructor INTEGER NOT NULL,
+    capacity_acting_as_examiner INTEGER NOT NULL,
+    capacity_picus_claimed INTEGER NOT NULL,
+    capacity_pic_intervention_not_required INTEGER NOT NULL,
+    capacity_manipulation_time_minutes INTEGER NULL,
+    capacity_solo_endorsement_held INTEGER NULL,
+    capacity_endorsing_instructor_name TEXT NULL,
+    capacity_instructor_capacity TEXT NULL,
+    capacity_instructor_influenced_flight INTEGER NULL,
+    capacity_instructor_name TEXT NULL,
+    capacity_instructor_credential_number TEXT NULL,
+    capacity_instructor_credential_expiry TEXT NULL,
+    capacity_other_pilot_role TEXT NULL,
+    capacity_countersignature_status TEXT NULL,
+    capacity_countersignature_signatory_name TEXT NULL,
+    capacity_countersignature_signatory_credential_number TEXT NULL,
+    capacity_countersignature_signatory_credential_expiry TEXT NULL,
+    capacity_countersignature_signed_at INTEGER NULL,
+    committed_at INTEGER NULL,
+    tombstoned_at INTEGER NULL,
+    PRIMARY KEY (id)
+  )
+''';
+
 /// Creates a v1-shaped database file directly with sqlite3, seeded with one
 /// aircraft row — the only way to get a real "v1 database" to migrate from,
 /// since `AircraftsTable` only ever represents the *current* schema. Column
-/// order and names mirror `lib/data/tables/aircraft_tables.dart` exactly;
-/// only `aircraft` is seeded — the other seven v1 tables aren't needed to
+/// order and names mirror `lib/data/tables/aircraft_tables.dart` exactly.
+/// `flights` is created empty (no row) — enough for #121's `addColumn` step
+/// to have a table to alter; the other five v1 tables aren't needed to
 /// prove #51's migration step behaves, and hand-duplicating their DDL here
 /// would just be more surface area to drift out of sync with the real
 /// tables for no extra coverage.
@@ -57,6 +122,7 @@ void _seedV1Database(String path) {
         0,
       ],
     );
+    db.execute(_createFlightsTableV1ThroughV3);
     db.execute('PRAGMA user_version = 1');
   } finally {
     db.close();
@@ -82,7 +148,109 @@ void _seedV2Database(String path) {
       'singleton',
       '1990-01-01',
     ]);
+    // #121's `from < 4` step alters `flights` regardless of which earlier
+    // version this database started at, so every seed at v3 or below needs
+    // the table present, empty or not.
+    db.execute(_createFlightsTableV1ThroughV3);
     db.execute('PRAGMA user_version = 2');
+  } finally {
+    db.close();
+  }
+}
+
+/// As [_seedV2Database], but at v3, with a `flights` row already on
+/// disk — to prove #121's `addColumn` step preserves existing flight data
+/// and backfills the new column's default rather than, say, requiring every
+/// row to be rewritten by the app first. `pilot_profile`/`held_*` are
+/// omitted for the same reason [_seedV1Database] omits the other v1
+/// tables: irrelevant to the one step under test here, and the `from < 2`/
+/// `from < 3` migration blocks never run for a database already at v3, so
+/// their absence doesn't trip anything.
+void _seedV3Database(String path) {
+  final db = sqlite3.sqlite3.open(path);
+  try {
+    db.execute('''
+      CREATE TABLE aircraft (
+        id TEXT NOT NULL,
+        registration TEXT NOT NULL UNIQUE,
+        manufacturer TEXT NOT NULL,
+        model TEXT NOT NULL,
+        icao_type_designator TEXT NULL,
+        category TEXT NOT NULL,
+        engine_type TEXT NOT NULL,
+        engine_count INTEGER NOT NULL,
+        operating_surface TEXT NOT NULL,
+        requires_multi_crew INTEGER NOT NULL,
+        type_rating_designator TEXT NULL,
+        PRIMARY KEY (id)
+      )
+    ''');
+    db.execute(
+      'INSERT INTO aircraft (id, registration, manufacturer, model, '
+      'category, engine_type, engine_count, operating_surface, '
+      'requires_multi_crew) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        'aircraft-1',
+        'G-ABCD',
+        'Cessna',
+        '152',
+        'aeroplane',
+        'piston',
+        1,
+        'land',
+        0,
+      ],
+    );
+    db.execute(_createFlightsTableV1ThroughV3);
+    db.execute(
+      'INSERT INTO flights (id, aircraft_id, pre_planned_navigation, '
+      'off_blocks, on_blocks, carrying_passengers, takeoffs_day_full_stop, '
+      'takeoffs_day_touch_and_go, takeoffs_night_full_stop, '
+      'takeoffs_night_touch_and_go, landings_day_full_stop, '
+      'landings_day_touch_and_go, landings_night_full_stop, '
+      'landings_night_touch_and_go, ifr_flight_plan_filed, '
+      'actual_instrument_minutes, simulated_instrument_minutes, '
+      'holding_procedures_count, tracking_performed, remarks, '
+      'capacity_command_authority, capacity_sole_manipulator, '
+      'capacity_sole_occupant, capacity_multi_pilot_operation, '
+      'capacity_additional_crew_required_by_rule, '
+      'capacity_acting_as_instructor, capacity_acting_as_examiner, '
+      'capacity_picus_claimed, capacity_pic_intervention_not_required) '
+      'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '
+      '?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        'flight-1',
+        'aircraft-1',
+        0,
+        1000,
+        2000,
+        0,
+        1,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        'a pre-existing flight',
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ],
+    );
+    db.execute('PRAGMA user_version = 3');
   } finally {
     db.close();
   }
@@ -163,4 +331,22 @@ void main() {
       expect(await heldRatings.find(id), rating);
     },
   );
+
+  test('#121: migrating a real v3 database to v4 preserves an existing flight '
+      'and backfills alternativeComplianceEvents to empty', () async {
+    _seedV3Database(dbFile.path);
+
+    final db = await openWithBackup(dbFile, () async {
+      final database = AppDatabase(NativeDatabase(dbFile));
+      await database.customStatement('SELECT 1');
+      return database;
+    });
+    addTearDown(db.close);
+
+    final flightRows = await db.select(db.flightsTable).get();
+    expect(flightRows, hasLength(1));
+    expect(flightRows.single.id, 'flight-1');
+    expect(flightRows.single.remarks, 'a pre-existing flight');
+    expect(flightRows.single.alternativeComplianceEvents, isEmpty);
+  });
 }

--- a/test/data/flight_history_test.dart
+++ b/test/data/flight_history_test.dart
@@ -32,6 +32,7 @@ FlightRow _row({String remarks = 'current', int? tombstonedAt}) {
     seriesGroupId: null,
     airworthinessBasis: null,
     remarks: remarks,
+    alternativeComplianceEvents: '',
     capacityCommandAuthority: true,
     capacitySoleManipulator: true,
     capacitySoleOccupant: true,

--- a/test/domain/currency/currency_rule_evaluator_test.dart
+++ b/test/domain/currency/currency_rule_evaluator_test.dart
@@ -19,6 +19,8 @@ Flight _flight({
   CircuitCounts? takeoffs,
   List<Approach> approaches = const [],
   int holdingProceduresCount = 0,
+  bool trackingPerformed = false,
+  Set<AlternativeComplianceEvent> alternativeComplianceEvents = const {},
   String aircraftRegistration = 'G-TEST',
 }) => currencyTestFlight(
   date: date,
@@ -26,6 +28,8 @@ Flight _flight({
   takeoffs: takeoffs,
   approaches: approaches,
   holdingProceduresCount: holdingProceduresCount,
+  trackingPerformed: trackingPerformed,
+  alternativeComplianceEvents: alternativeComplianceEvents,
   aircraftRegistration: aircraftRegistration,
 );
 
@@ -430,6 +434,95 @@ void main() {
       },
     );
   });
+
+  group(
+    'flightEventCount over alt-compliance events and tracking (#121, #50)',
+    () {
+      test('a flight review event counts as a presence check', () {
+        final requirement = Requirement.flightEventCount(
+          event: CountableFlightEvent.faaFlightReview,
+          count: 1,
+          window: RuleWindow.calendarMonths(24),
+        );
+        final subject = EvaluationSubject(
+          flights: [
+            _record(
+              '1',
+              _flight(
+                date: CalendarDate(2024, 1, 1),
+                alternativeComplianceEvents: const {
+                  AlternativeComplianceEvent.faaFlightReview,
+                },
+              ),
+            ),
+          ],
+        );
+
+        expect(
+          evaluator
+              .evaluateRequirement(
+                requirement,
+                subject,
+                CalendarDate(2024, 6, 1),
+              )
+              .satisfied,
+          isTrue,
+        );
+      });
+
+      test(
+        'an unrelated flight with no alt-compliance events does not count',
+        () {
+          final requirement = Requirement.flightEventCount(
+            event: CountableFlightEvent.faaInstrumentProficiencyCheck,
+            count: 1,
+            window: RuleWindow.calendarMonths(6),
+          );
+          final subject = EvaluationSubject(
+            flights: [_record('1', _flight(date: CalendarDate(2024, 1, 1)))],
+          );
+
+          expect(
+            evaluator
+                .evaluateRequirement(
+                  requirement,
+                  subject,
+                  CalendarDate(2024, 6, 1),
+                )
+                .satisfied,
+            isFalse,
+          );
+        },
+      );
+
+      test('trackingPerformed is read as a presence fact, not a count', () {
+        final requirement = Requirement.flightEventCount(
+          event: CountableFlightEvent.trackingPerformed,
+          count: 1,
+          window: RuleWindow.calendarMonths(6),
+        );
+        final subject = EvaluationSubject(
+          flights: [
+            _record(
+              '1',
+              _flight(date: CalendarDate(2024, 1, 1), trackingPerformed: true),
+            ),
+          ],
+        );
+
+        expect(
+          evaluator
+              .evaluateRequirement(
+                requirement,
+                subject,
+                CalendarDate(2024, 6, 1),
+              )
+              .satisfied,
+          isTrue,
+        );
+      });
+    },
+  );
 
   group('flightEventHours', () {
     test('sums flight duration, not count', () {

--- a/test/domain/currency/currency_test_helpers.dart
+++ b/test/domain/currency/currency_test_helpers.dart
@@ -18,6 +18,9 @@ Flight currencyTestFlight({
   CircuitCounts? takeoffs,
   List<Approach> approaches = const [],
   int holdingProceduresCount = 0,
+  bool trackingPerformed = false,
+  Set<AlternativeComplianceEvent> alternativeComplianceEvents = const {},
+  PilotCapacity? capacity,
   String aircraftRegistration = 'G-TEST',
 }) {
   final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
@@ -27,17 +30,19 @@ Flight currencyTestFlight({
     prePlannedNavigation: false,
     offBlocks: offBlocks,
     onBlocks: offBlocks.add(const Duration(hours: 1)),
-    capacity: const PilotCapacity(
-      commandAuthority: true,
-      soleManipulator: true,
-      soleOccupant: true,
-      multiPilotOperation: false,
-      additionalCrewRequiredByRule: false,
-      actingAsInstructor: false,
-      actingAsExaminer: false,
-      picusClaimed: false,
-      picInterventionNotRequired: false,
-    ),
+    capacity:
+        capacity ??
+        const PilotCapacity(
+          commandAuthority: true,
+          soleManipulator: true,
+          soleOccupant: true,
+          multiPilotOperation: false,
+          additionalCrewRequiredByRule: false,
+          actingAsInstructor: false,
+          actingAsExaminer: false,
+          picusClaimed: false,
+          picInterventionNotRequired: false,
+        ),
     carryingPassengers: false,
     takeoffs: takeoffs ?? const CircuitCounts(),
     landings: landings ?? const CircuitCounts(),
@@ -46,7 +51,8 @@ Flight currencyTestFlight({
     simulatedInstrumentTime: FlightDuration.zero,
     approaches: approaches,
     holdingProceduresCount: holdingProceduresCount,
-    trackingPerformed: false,
+    trackingPerformed: trackingPerformed,
+    alternativeComplianceEvents: alternativeComplianceEvents,
     remarks: '',
   );
 }

--- a/test/domain/pilot_record/alt_compliance_rules_test.dart
+++ b/test/domain/pilot_record/alt_compliance_rules_test.dart
@@ -1,0 +1,416 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../currency/currency_test_helpers.dart';
+
+CurrencyRule _loadRule(String path) =>
+    parseCurrencyRuleYaml(File(path).readAsStringSync());
+
+void main() {
+  const evaluator = CurrencyRuleEvaluator();
+
+  group('eu.easa.fcl060.b3_night_passenger_recency (#46)', () {
+    final rule = _loadRule(
+      'assets/rules/easa/fcl060_b3_night_passenger_recency.yaml',
+    );
+
+    test('metadata matches the regulation', () {
+      expect(rule.citation, 'FCL.060(b)(3)');
+    });
+
+    test('3 landings with 1 at night, no IR held: satisfied', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(nightFullStop: 1),
+            ),
+          ),
+          currencyTestRecord(
+            '2',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 2),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+          currencyTestRecord(
+            '3',
+            currencyTestFlight(
+              date: CalendarDate(2024, 5, 3),
+              landings: const CircuitCounts(dayFullStop: 1),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+
+    test('3 landings, none at night, but a valid IR is held: satisfied', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+        ],
+        heldRecords: [
+          HeldRecord(
+            kind: 'rating.eu.easa.part-fcl.instrumentRating.IR',
+            validFrom: CalendarDate(2023, 1, 1),
+            validUntil: CalendarDate(2025, 1, 1),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+
+    test('3 landings, none at night, no IR held: unsatisfied', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+
+    test(
+      'only 2 landings total, one at night, no IR: unsatisfied -- the b1 base is not met',
+      () {
+        final asOf = CalendarDate(2024, 6, 1);
+        final subject = EvaluationSubject(
+          referenceAircraft: testAircraft,
+          flights: [
+            currencyTestRecord(
+              '1',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, 1),
+                landings: const CircuitCounts(nightFullStop: 1),
+              ),
+            ),
+            currencyTestRecord(
+              '2',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, 2),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          subject,
+          asOf,
+        );
+
+        expect(result.satisfied, isFalse);
+      },
+    );
+
+    test('an expired IR does not substitute for the night landing', () {
+      final asOf = CalendarDate(2024, 6, 1);
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          for (var i = 0; i < 3; i++)
+            currencyTestRecord(
+              '$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 5, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+              ),
+            ),
+        ],
+        heldRecords: [
+          HeldRecord(
+            kind: 'rating.eu.easa.part-fcl.instrumentRating.IR',
+            validFrom: CalendarDate(2018, 1, 1),
+            validUntil: CalendarDate(2019, 1, 1), // lapsed
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('us.faa.61_56.flight_review (#49)', () {
+    final rule = _loadRule('assets/rules/faa/61_56_flight_review.yaml');
+
+    test('metadata matches the regulation', () {
+      expect(rule.citation, '§61.56');
+    });
+
+    test('valid through the end of the 24th calendar month, not 730 days', () {
+      final subject = EvaluationSubject(
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2022, 1, 31),
+              alternativeComplianceEvents: const {
+                AlternativeComplianceEvent.faaFlightReview,
+              },
+            ),
+          ),
+        ],
+      );
+
+      final lastValidDay = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        CalendarDate(2024, 1, 31),
+      );
+      final firstLapsedDay = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        CalendarDate(2024, 2, 1),
+      );
+
+      expect(lastValidDay.satisfied, isTrue);
+      expect(firstLapsedDay.satisfied, isFalse);
+    });
+
+    test(
+      'an instrument proficiency check satisfies it in place of a flight review',
+      () {
+        final subject = EvaluationSubject(
+          flights: [
+            currencyTestRecord(
+              '1',
+              currencyTestFlight(
+                date: CalendarDate(2023, 6, 1),
+                alternativeComplianceEvents: const {
+                  AlternativeComplianceEvent.faaInstrumentProficiencyCheck,
+                },
+              ),
+            ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          subject,
+          CalendarDate(2024, 1, 1),
+        );
+
+        expect(result.satisfied, isTrue);
+      },
+    );
+
+    test('no flight review and no IPC: unsatisfied', () {
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        const EvaluationSubject(flights: []),
+        CalendarDate(2024, 1, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('us.faa.61_57_c instrument currency + grace period (#50)', () {
+    final currentRule = _loadRule(
+      'assets/rules/faa/61_57_c_instrument_currency.yaml',
+    );
+    final graceRule = _loadRule(
+      'assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml',
+    );
+
+    Flight instrumentFlight(CalendarDate date) => currencyTestFlight(
+      date: date,
+      approaches: const [
+        Approach(
+          type: ApproachType.ils,
+          aerodromeIcao: 'EGXX',
+          runway: '27',
+          count: 6,
+        ),
+      ],
+      holdingProceduresCount: 1,
+      trackingPerformed: true,
+    );
+
+    test(
+      'six approaches, holding and tracking within 6 months: fully current',
+      () {
+        final subject = EvaluationSubject(
+          flights: [
+            currencyTestRecord('1', instrumentFlight(CalendarDate(2024, 1, 1))),
+          ],
+        );
+        final asOf = CalendarDate(2024, 6, 1);
+
+        expect(
+          evaluator
+              .evaluateRequirement(currentRule.requirement, subject, asOf)
+              .satisfied,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'lapsed but in grace: fails the 6-month rule, passes the 12-month one',
+      () {
+        // 8 months old: outside the 6-month window, inside the 12-month one.
+        final subject = EvaluationSubject(
+          flights: [
+            currencyTestRecord('1', instrumentFlight(CalendarDate(2024, 1, 1))),
+          ],
+        );
+        final asOf = CalendarDate(2024, 9, 1);
+
+        final current = evaluator.evaluateRequirement(
+          currentRule.requirement,
+          subject,
+          asOf,
+        );
+        final inGrace = evaluator.evaluateRequirement(
+          graceRule.requirement,
+          subject,
+          asOf,
+        );
+
+        expect(current.satisfied, isFalse);
+        expect(inGrace.satisfied, isTrue);
+      },
+    );
+
+    test('lapsed past grace: fails both, an IPC is required', () {
+      // 13 months old: outside even the 12-month grace window.
+      final subject = EvaluationSubject(
+        flights: [
+          currencyTestRecord('1', instrumentFlight(CalendarDate(2023, 1, 1))),
+        ],
+      );
+      final asOf = CalendarDate(2024, 2, 1);
+
+      final current = evaluator.evaluateRequirement(
+        currentRule.requirement,
+        subject,
+        asOf,
+      );
+      final inGrace = evaluator.evaluateRequirement(
+        graceRule.requirement,
+        subject,
+        asOf,
+      );
+
+      expect(current.satisfied, isFalse);
+      expect(inGrace.satisfied, isFalse);
+    });
+
+    test('an IPC alone satisfies currency without any approaches at all', () {
+      final subject = EvaluationSubject(
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 3, 1),
+              alternativeComplianceEvents: const {
+                AlternativeComplianceEvent.faaInstrumentProficiencyCheck,
+              },
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        currentRule.requirement,
+        subject,
+        CalendarDate(2024, 6, 1),
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+
+    test(
+      'five approaches is not enough -- the count is exactly six, not "several"',
+      () {
+        final subject = EvaluationSubject(
+          flights: [
+            currencyTestRecord(
+              '1',
+              currencyTestFlight(
+                date: CalendarDate(2024, 1, 1),
+                approaches: const [
+                  Approach(
+                    type: ApproachType.ils,
+                    aerodromeIcao: 'EGXX',
+                    runway: '27',
+                    count: 5,
+                  ),
+                ],
+                holdingProceduresCount: 1,
+                trackingPerformed: true,
+              ),
+            ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          currentRule.requirement,
+          subject,
+          CalendarDate(2024, 6, 1),
+        );
+
+        expect(result.satisfied, isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Stacked on #125 — base branch is `feat/m3-ratings-and-endorsements`, not `main`.

- `Flight.alternativeComplianceEvents` (#121): a `Set<AlternativeComplianceEvent>` (flight review / IPC / EASA class-rating proficiency check) — a set because one flight can serve more than one purpose. Persisted via `schemaVersion` 3→4, the **first** migration that alters an existing table with real rows (`flights`) rather than only creating new ones — verified against a seeded v3 sqlite file with an existing flight row, not just checked structurally.
- `CountableFlightEvent` grows the three matching cases plus `trackingPerformed` (read as a presence fact, 0/1, off `Flight.trackingPerformed`) — exactly the "one more `_eventCount` case" growth #42's design anticipated; no evaluator restructuring.
- **#46** (EASA night passenger recency, `FCL.060(b)(3)`): duplicates `(b)(1)`'s own 3-landing requirement (no cross-rule reference mechanism exists in the schema) ANDed with `any_of[1 night landing, currently-valid IR]` — the IR alternative is an ordinary held-record branch, not special-cased in code.
- **#49** (FAA flight review, `§61.56`): a flight review or an IPC within 24 calendar months. Tested at the exact month-boundary and from the 31st, per the issue's own AC.
- **#50** (FAA instrument currency, `§61.57(c)`): expressed as **two separate rule files** over a 6-month and a 12-month window, rather than inventing new result-type machinery for the "lapsed but in grace" two-stage state the issue calls for. Fails-6-passes-12 = in grace, can self-cure; fails-both = IPC required. Combining the two into a UI message is left to whichever caller reads them, the same pattern `nextToExpire` (#44) already established.
- Two scope boundaries carried over from #50's own issue text, documented rather than silently cut: FSTD-session credit toward `§61.57(c)` (FSTD sessions are a separate domain model with no path into `EvaluationSubject` yet), and WINGS phase completion (`§61.56`'s other alternative — not a single-flight fact).

Closes #46, #49, #50, #121.

#47 (SEP revalidation) is deliberately **not** in this PR — it needs an expiry-anchored window, PIC-hours-within-total-hours, and an instructor-aboard training-flight condition, genuinely more involved than these three, so it gets its own PR next.

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_currency_rules.dart` — 13 rule files clean
- [x] `dart run tool/check_schema_snapshot.dart` — v4 snapshot committed
- [x] `flutter test --coverage` — 510 passing, including a real v3→v4 migration test with a pre-existing flight row
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 94.9%

🤖 Generated with [Claude Code](https://claude.com/claude-code)