### PR TITLE
SEP class rating revalidation

### DIFF
--- a/assets/rules/easa/fcl740a_sep_land_revalidation.yaml
+++ b/assets/rules/easa/fcl740a_sep_land_revalidation.yaml
@@ -1,0 +1,100 @@
+# FCL.740.A(b)(1)(i): within the 12 months preceding a SEP(land) class
+# rating's expiry, 12 hours of flight time in the class, including 6 hours
+# as PIC, 12 take-offs and 12 landings, and a training flight of at least
+# 1 hour with an instructor. Alternatively, a class-rating proficiency
+# check (FCL.740.A(b)(1)(ii)).
+#
+# The window is anchored to the rating's own expiry date, not to today --
+# "within the 12 months preceding expiry" is a fixed calendar window that
+# does not slide as the evaluation date changes, unlike an ordinary
+# rolling-day recency rule. anchor_held_record_kind names the specific SEP
+# rating this window is computed from.
+#
+# Scope: this rule is authored for SEP(land) specifically. MEP, SEP(sea)
+# and TMG class ratings need their own rule files with the same shape --
+# a different anchor_held_record_kind designator and, for MEP, different
+# hour/count figures per docs/jurisdiction-matrix.md 5 -- rather than one
+# rule trying to parametrise over "whichever class rating the pilot
+# holds", which the schema has no mechanism for and which would make a
+# single rule's citation ambiguous.
+#
+# The training-flight instructor requirement reads PilotCapacity.instructor
+# via the instructor_aboard condition -- present, in any capacity, not
+# specifically InstructorCapacity.flightInstructor, since FCL.740.A does
+# not distinguish how the instructor was acting, only that one was aboard
+# for that flight.
+id: eu.easa.fcl740a.sep_land_revalidation
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.740.A(b)(1)"
+effective_from: 2011-11-08
+requirement:
+  kind: any_of
+  of:
+    - kind: all_of
+      of:
+        - kind: flight_event_hours
+          event: landings
+          hours: 12
+          window:
+            kind: calendar_months
+            months: 12
+            anchor: held_record_expiry
+            anchor_held_record_kind: rating.eu.easa.part-fcl.classRating.SEP(land)
+          conditions:
+            - kind: aircraft_match
+              level: same_class
+        - kind: flight_event_hours
+          event: landings
+          hours: 6
+          window:
+            kind: calendar_months
+            months: 12
+            anchor: held_record_expiry
+            anchor_held_record_kind: rating.eu.easa.part-fcl.classRating.SEP(land)
+          conditions:
+            - kind: aircraft_match
+              level: same_class
+            - kind: capacity
+              value: command_authority
+        - kind: flight_event_count
+          event: takeoffs
+          count: 12
+          window:
+            kind: calendar_months
+            months: 12
+            anchor: held_record_expiry
+            anchor_held_record_kind: rating.eu.easa.part-fcl.classRating.SEP(land)
+          conditions:
+            - kind: aircraft_match
+              level: same_class
+        - kind: flight_event_count
+          event: landings
+          count: 12
+          window:
+            kind: calendar_months
+            months: 12
+            anchor: held_record_expiry
+            anchor_held_record_kind: rating.eu.easa.part-fcl.classRating.SEP(land)
+          conditions:
+            - kind: aircraft_match
+              level: same_class
+        - kind: flight_event_hours
+          event: landings
+          hours: 1
+          window:
+            kind: calendar_months
+            months: 12
+            anchor: held_record_expiry
+            anchor_held_record_kind: rating.eu.easa.part-fcl.classRating.SEP(land)
+          conditions:
+            - kind: aircraft_match
+              level: same_class
+            - kind: instructor_aboard
+    - kind: flight_event_count
+      event: easa_class_rating_proficiency_check
+      count: 1
+      window:
+        kind: calendar_months
+        months: 12
+        anchor: held_record_expiry
+        anchor_held_record_kind: rating.eu.easa.part-fcl.classRating.SEP(land)

--- a/assets/rules/schema/currency-rule.schema.json
+++ b/assets/rules/schema/currency-rule.schema.json
@@ -84,6 +84,20 @@
           },
           "required": ["level"],
           "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "capacity" },
+            "value": { "enum": ["command_authority"] }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "kind": { "const": "instructor_aboard" }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/lib/domain/currency/currency_rule_evaluator.dart
+++ b/lib/domain/currency/currency_rule_evaluator.dart
@@ -2,6 +2,7 @@ import '../model/aircraft.dart';
 import '../model/calendar_date.dart';
 import '../model/flight.dart';
 import '../model/flight_duration.dart';
+import '../model/pilot_capacity.dart';
 import '../repository/flight_read_repository.dart';
 import 'currency_rule.dart';
 import 'evaluation_subject.dart';
@@ -65,7 +66,7 @@ class CurrencyRuleEvaluator {
 
     final occurrences = <_Occurrence<int>>[];
     for (final record in subject.flights) {
-      if (!_passesAircraftMatch(
+      if (!_passesFlightLevelConditions(
         record,
         requirement.conditions,
         subject.referenceAircraft,
@@ -122,7 +123,7 @@ class CurrencyRuleEvaluator {
 
     final occurrences = <_Occurrence<FlightDuration>>[];
     for (final record in subject.flights) {
-      if (!_passesAircraftMatch(
+      if (!_passesFlightLevelConditions(
         record,
         requirement.conditions,
         subject.referenceAircraft,
@@ -342,7 +343,9 @@ int _circuitCount(CircuitCounts counts, List<FlightCondition> conditions) {
       case ConditionKind.landingType:
         landingType = condition.landingType;
       case ConditionKind.aircraftMatch:
-        break; // Applied at the flight-filter level, not here.
+      case ConditionKind.capacity:
+      case ConditionKind.instructorAboard:
+        break; // Applied at the flight-level gate, not here.
     }
   }
 
@@ -361,37 +364,59 @@ int _circuitCount(CircuitCounts counts, List<FlightCondition> conditions) {
   return total;
 }
 
-/// Whether [record] passes every [ConditionKind.aircraftMatch] condition in
-/// [conditions] against [referenceAircraft].
+/// Whether [record] passes every flight-level gate condition in
+/// [conditions] — [ConditionKind.aircraftMatch] against [referenceAircraft],
+/// [ConditionKind.capacity] against `record.flight.capacity`, and
+/// [ConditionKind.instructorAboard]. [ConditionKind.dayNight]/
+/// [ConditionKind.landingType] are not gates: they select a [CircuitCounts]
+/// sub-field inside [_circuitCount] instead, since they narrow *how much*
+/// a qualifying flight contributes rather than *whether* it does.
 ///
 /// Throws [StateError] if an aircraft-match condition is present but
 /// [referenceAircraft] is null — a rule asking "same type as what?" with
 /// nothing supplied to compare against is a caller error, not a state to
 /// silently treat as passing or failing.
-bool _passesAircraftMatch(
+bool _passesFlightLevelConditions(
   FlightRecord record,
   List<FlightCondition> conditions,
   Aircraft? referenceAircraft,
 ) {
   for (final condition in conditions) {
-    if (condition.kind != ConditionKind.aircraftMatch) {
-      continue;
-    }
-    if (referenceAircraft == null) {
-      throw StateError(
-        'Requirement has an aircraftMatch condition but '
-        'EvaluationSubject.referenceAircraft is null',
-      );
-    }
-    if (!_aircraftMatches(
-      record.aircraft,
-      referenceAircraft,
-      condition.aircraftMatch!,
-    )) {
-      return false;
+    switch (condition.kind) {
+      case ConditionKind.aircraftMatch:
+        if (referenceAircraft == null) {
+          throw StateError(
+            'Requirement has an aircraftMatch condition but '
+            'EvaluationSubject.referenceAircraft is null',
+          );
+        }
+        if (!_aircraftMatches(
+          record.aircraft,
+          referenceAircraft,
+          condition.aircraftMatch!,
+        )) {
+          return false;
+        }
+      case ConditionKind.capacity:
+        if (!_passesCapacity(record.flight.capacity, condition.capacity!)) {
+          return false;
+        }
+      case ConditionKind.instructorAboard:
+        if (record.flight.capacity.instructor == null) {
+          return false;
+        }
+      case ConditionKind.dayNight:
+      case ConditionKind.landingType:
+        break; // Applied inside _circuitCount, not here.
     }
   }
   return true;
+}
+
+bool _passesCapacity(PilotCapacity capacity, CapacityRequirement requirement) {
+  return switch (requirement) {
+    CapacityRequirement.commandAuthority => capacity.commandAuthority,
+  };
 }
 
 bool _aircraftMatches(Aircraft flown, Aircraft reference, AircraftMatch level) {
@@ -452,6 +477,8 @@ String _describeEvent(
       case ConditionKind.landingType:
         landingType = condition.landingType;
       case ConditionKind.aircraftMatch:
+      case ConditionKind.capacity:
+      case ConditionKind.instructorAboard:
         break;
     }
   }

--- a/lib/domain/currency/currency_rule_yaml.dart
+++ b/lib/domain/currency/currency_rule_yaml.dart
@@ -210,6 +210,10 @@ const Map<String, AircraftMatch> _aircraftMatchValues = {
   'class_or_type_if_required': AircraftMatch.classOrTypeIfRequired,
 };
 
+const Map<String, CapacityRequirement> _capacityValues = {
+  'command_authority': CapacityRequirement.commandAuthority,
+};
+
 List<FlightCondition> _parseConditions(YamlMap yaml, String ruleId) {
   final conditions = yaml['conditions'];
   if (conditions == null) {
@@ -276,10 +280,28 @@ FlightCondition _parseCondition(Object? entry, String ruleId) {
         );
       }
       return FlightCondition.aircraftMatch(match);
+    case 'capacity':
+      final value = _requiredString(
+        entry,
+        'value',
+        ruleId,
+        context: 'condition',
+      );
+      final capacity = _capacityValues[value];
+      if (capacity == null) {
+        throw FormatException(
+          'Currency rule "$ruleId": condition "value" must be one of '
+          '${_capacityValues.keys.join(', ')}, got "$value"',
+        );
+      }
+      return FlightCondition.capacity(capacity);
+    case 'instructor_aboard':
+      return FlightCondition.instructorAboard();
     default:
       throw FormatException(
         'Currency rule "$ruleId": condition "kind" must be "day_night", '
-        '"landing_type" or "aircraft_match", got "$kindText"',
+        '"landing_type", "aircraft_match", "capacity" or '
+        '"instructor_aboard", got "$kindText"',
       );
   }
 }

--- a/lib/domain/currency/flight_condition.dart
+++ b/lib/domain/currency/flight_condition.dart
@@ -4,16 +4,16 @@ part 'flight_condition.freezed.dart';
 
 /// A filter on which flights contribute toward a [Requirement] — #40's
 /// "conditions on the flights that count: aircraft class, day/night,
-/// full-stop landings, aircraft type match". Exactly these three kinds and
-/// no more: they are the complete list #40's acceptance criteria name: a new
-/// kind is a schema change (#40), not something a rule author should be able
-/// to invent inline.
+/// full-stop landings, aircraft type match", grown by #47 with two more:
+/// [capacity] (FCL.740.A's "6 hours as PIC") and [instructorAboard]
+/// (its training-flight requirement). A new kind is still a schema change,
+/// not something a rule author should be able to invent inline.
 ///
 /// One flat class with a [kind] discriminator, matching this codebase's
 /// existing union style (see `Countersignature`, `CapacityFilter`) rather
 /// than a sealed class — there is no precedent for sealed unions here and
-/// introducing the first one for a three-variant type is not worth the
-/// inconsistency.
+/// introducing the first one for a growing-but-still-small variant count
+/// is not worth the inconsistency.
 @freezed
 abstract class FlightCondition with _$FlightCondition {
   const factory FlightCondition({
@@ -21,6 +21,7 @@ abstract class FlightCondition with _$FlightCondition {
     DayNight? dayNight,
     LandingType? landingType,
     AircraftMatch? aircraftMatch,
+    CapacityRequirement? capacity,
   }) = _FlightCondition;
 
   factory FlightCondition.dayNight(DayNight value) =>
@@ -31,9 +32,30 @@ abstract class FlightCondition with _$FlightCondition {
 
   factory FlightCondition.aircraftMatch(AircraftMatch value) =>
       FlightCondition(kind: ConditionKind.aircraftMatch, aircraftMatch: value);
+
+  factory FlightCondition.capacity(CapacityRequirement value) =>
+      FlightCondition(kind: ConditionKind.capacity, capacity: value);
+
+  /// Whether an instructor was aboard — `PilotCapacity.instructor != null`,
+  /// regardless of [InstructorCapacity]. No extra value: unlike [capacity],
+  /// this condition is a pure presence gate.
+  factory FlightCondition.instructorAboard() =>
+      const FlightCondition(kind: ConditionKind.instructorAboard);
 }
 
-enum ConditionKind { dayNight, landingType, aircraftMatch }
+enum ConditionKind {
+  dayNight,
+  landingType,
+  aircraftMatch,
+  capacity,
+  instructorAboard,
+}
+
+/// A raw fact on `PilotCapacity` a [FlightCondition.capacity] condition can
+/// gate a flight on. Only [commandAuthority] exists so far — the one
+/// FCL.740.A needs ("6 hours as PIC") — grown when another rule needs
+/// another one.
+enum CapacityRequirement { commandAuthority }
 
 enum DayNight { day, night }
 

--- a/test/domain/currency/currency_rule_evaluator_test.dart
+++ b/test/domain/currency/currency_rule_evaluator_test.dart
@@ -8,10 +8,41 @@ import 'package:easa_digital_log/domain/model/aircraft.dart';
 import 'package:easa_digital_log/domain/model/calendar_date.dart';
 import 'package:easa_digital_log/domain/model/flight.dart';
 import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
 import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'currency_test_helpers.dart';
+
+const _picCapacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _dualCapacity = PilotCapacity(
+  commandAuthority: false,
+  soleManipulator: true,
+  soleOccupant: false,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+  instructor: InstructorPresence(
+    capacity: InstructorCapacity.flightInstructor,
+    influencedFlight: false,
+    name: 'A. Instructor',
+  ),
+);
 
 Flight _flight({
   required CalendarDate date,
@@ -21,6 +52,7 @@ Flight _flight({
   int holdingProceduresCount = 0,
   bool trackingPerformed = false,
   Set<AlternativeComplianceEvent> alternativeComplianceEvents = const {},
+  PilotCapacity? capacity,
   String aircraftRegistration = 'G-TEST',
 }) => currencyTestFlight(
   date: date,
@@ -30,6 +62,7 @@ Flight _flight({
   holdingProceduresCount: holdingProceduresCount,
   trackingPerformed: trackingPerformed,
   alternativeComplianceEvents: alternativeComplianceEvents,
+  capacity: capacity,
   aircraftRegistration: aircraftRegistration,
 );
 
@@ -521,6 +554,94 @@ void main() {
           isTrue,
         );
       });
+    },
+  );
+
+  group(
+    'flightEventHours with capacity and instructorAboard conditions (#47)',
+    () {
+      test('capacity: commandAuthority only counts flights flown as PIC', () {
+        final requirement = Requirement.flightEventHours(
+          event: CountableFlightEvent.landings,
+          hours: const FlightDuration(60),
+          window: RuleWindow.rollingDays(365),
+          conditions: [
+            FlightCondition.capacity(CapacityRequirement.commandAuthority),
+          ],
+        );
+        final asOf = CalendarDate(2024, 6, 1);
+        final subject = EvaluationSubject(
+          flights: [
+            _record(
+              'pic',
+              _flight(
+                date: CalendarDate(2024, 5, 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                capacity: _picCapacity,
+              ),
+            ),
+            _record(
+              'dual',
+              _flight(
+                date: CalendarDate(2024, 5, 2),
+                landings: const CircuitCounts(dayFullStop: 1),
+                capacity: _dualCapacity,
+              ),
+            ),
+          ],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          requirement,
+          subject,
+          asOf,
+        );
+
+        expect(result.satisfied, isTrue);
+        expect(result.contributingFlightIds, ['pic']);
+      });
+
+      test(
+        'instructorAboard only counts flights with an instructor present',
+        () {
+          final requirement = Requirement.flightEventHours(
+            event: CountableFlightEvent.landings,
+            hours: const FlightDuration(60),
+            window: RuleWindow.rollingDays(365),
+            conditions: [FlightCondition.instructorAboard()],
+          );
+          final asOf = CalendarDate(2024, 6, 1);
+          final subject = EvaluationSubject(
+            flights: [
+              _record(
+                'solo',
+                _flight(
+                  date: CalendarDate(2024, 5, 1),
+                  landings: const CircuitCounts(dayFullStop: 1),
+                  capacity: _picCapacity,
+                ),
+              ),
+              _record(
+                'with-instructor',
+                _flight(
+                  date: CalendarDate(2024, 5, 2),
+                  landings: const CircuitCounts(dayFullStop: 1),
+                  capacity: _dualCapacity,
+                ),
+              ),
+            ],
+          );
+
+          final result = evaluator.evaluateRequirement(
+            requirement,
+            subject,
+            asOf,
+          );
+
+          expect(result.satisfied, isTrue);
+          expect(result.contributingFlightIds, ['with-instructor']);
+        },
+      );
     },
   );
 

--- a/test/domain/currency/currency_rule_yaml_test.dart
+++ b/test/domain/currency/currency_rule_yaml_test.dart
@@ -88,6 +88,31 @@ requirement:
       ]);
     });
 
+    test('parses capacity and instructor_aboard conditions', () {
+      const yaml = '''
+id: x
+jurisdiction: eu.easa.part-fcl
+citation: "x"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_hours
+  event: landings
+  hours: 6
+  window: { kind: rolling_days, days: 365 }
+  conditions:
+    - kind: capacity
+      value: command_authority
+    - kind: instructor_aboard
+''';
+
+      final rule = parseCurrencyRuleYaml(yaml);
+
+      expect(rule.requirement.conditions, [
+        FlightCondition.capacity(CapacityRequirement.commandAuthority),
+        FlightCondition.instructorAboard(),
+      ]);
+    });
+
     test('parses the class_or_type_if_required aircraft match level', () {
       const yaml = '''
 id: x

--- a/test/domain/pilot_record/sep_revalidation_rule_test.dart
+++ b/test/domain/pilot_record/sep_revalidation_rule_test.dart
@@ -1,0 +1,230 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_yaml.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../currency/currency_test_helpers.dart';
+
+CurrencyRule _loadRule(String path) =>
+    parseCurrencyRuleYaml(File(path).readAsStringSync());
+
+const _picCapacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _dualWithInstructorCapacity = PilotCapacity(
+  commandAuthority: false,
+  soleManipulator: true,
+  soleOccupant: false,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+  instructor: InstructorPresence(
+    capacity: InstructorCapacity.flightInstructor,
+    influencedFlight: false,
+    name: 'A. Instructor',
+  ),
+);
+
+void main() {
+  const evaluator = CurrencyRuleEvaluator();
+
+  group('eu.easa.fcl740a.sep_land_revalidation (#47)', () {
+    final rule = _loadRule(
+      'assets/rules/easa/fcl740a_sep_land_revalidation.yaml',
+    );
+    final sepRating = HeldRecord(
+      kind: 'rating.eu.easa.part-fcl.classRating.SEP(land)',
+      validFrom: CalendarDate(2023, 1, 1),
+      validUntil: CalendarDate(2025, 1, 1),
+    );
+
+    test('metadata matches the regulation', () {
+      expect(rule.citation, 'FCL.740.A(b)(1)');
+    });
+
+    test(
+      '12 hours (6 as PIC), 12 takeoffs and landings, and a training flight: satisfied',
+      () {
+        final flights = [
+          for (var i = 0; i < 6; i++)
+            currencyTestRecord(
+              'pic-$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 2, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                takeoffs: const CircuitCounts(dayFullStop: 1),
+                capacity: _picCapacity,
+              ),
+            ),
+          for (var i = 0; i < 6; i++)
+            currencyTestRecord(
+              'dual-$i',
+              currencyTestFlight(
+                date: CalendarDate(2024, 3, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                takeoffs: const CircuitCounts(dayFullStop: 1),
+                capacity: _dualWithInstructorCapacity,
+              ),
+            ),
+        ];
+        final subject = EvaluationSubject(
+          referenceAircraft: testAircraft,
+          flights: flights,
+          heldRecords: [sepRating],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          subject,
+          CalendarDate(2024, 8, 1),
+        );
+
+        expect(result.satisfied, isTrue);
+      },
+    );
+
+    test('12 hours and 12 landings but only 3 as PIC: unsatisfied', () {
+      final flights = [
+        for (var i = 0; i < 3; i++)
+          currencyTestRecord(
+            'pic-$i',
+            currencyTestFlight(
+              date: CalendarDate(2024, 2, i + 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+              takeoffs: const CircuitCounts(dayFullStop: 1),
+              capacity: _picCapacity,
+            ),
+          ),
+        for (var i = 0; i < 9; i++)
+          currencyTestRecord(
+            'dual-$i',
+            currencyTestFlight(
+              date: CalendarDate(2024, 3, i + 1),
+              landings: const CircuitCounts(dayFullStop: 1),
+              takeoffs: const CircuitCounts(dayFullStop: 1),
+              capacity: _dualWithInstructorCapacity,
+            ),
+          ),
+      ];
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: flights,
+        heldRecords: [sepRating],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        CalendarDate(2024, 8, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+
+    test('a class-rating proficiency check alone satisfies it', () {
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: [
+          currencyTestRecord(
+            '1',
+            currencyTestFlight(
+              date: CalendarDate(2024, 6, 1),
+              alternativeComplianceEvents: const {
+                AlternativeComplianceEvent.easaClassRatingProficiencyCheck,
+              },
+            ),
+          ),
+        ],
+        heldRecords: [sepRating],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        CalendarDate(2024, 8, 1),
+      );
+
+      expect(result.satisfied, isTrue);
+    });
+
+    test(
+      'the requirement is met, but entirely outside the 12-month pre-expiry window: unsatisfied',
+      () {
+        // Same activity as the fully-satisfied case above, but flown in 2022 --
+        // right after a previous revalidation, well before the window
+        // [2024-01-01, 2025-01-01] this rating's 2025-01-01 expiry implies.
+        final flights = [
+          for (var i = 0; i < 6; i++)
+            currencyTestRecord(
+              'pic-$i',
+              currencyTestFlight(
+                date: CalendarDate(2022, 2, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                takeoffs: const CircuitCounts(dayFullStop: 1),
+                capacity: _picCapacity,
+              ),
+            ),
+          for (var i = 0; i < 6; i++)
+            currencyTestRecord(
+              'dual-$i',
+              currencyTestFlight(
+                date: CalendarDate(2022, 3, i + 1),
+                landings: const CircuitCounts(dayFullStop: 1),
+                takeoffs: const CircuitCounts(dayFullStop: 1),
+                capacity: _dualWithInstructorCapacity,
+              ),
+            ),
+        ];
+        final subject = EvaluationSubject(
+          referenceAircraft: testAircraft,
+          flights: flights,
+          heldRecords: [sepRating],
+        );
+
+        final result = evaluator.evaluateRequirement(
+          rule.requirement,
+          subject,
+          CalendarDate(2024, 8, 1),
+        );
+
+        expect(result.satisfied, isFalse);
+      },
+    );
+
+    test('no activity and no proficiency check: unsatisfied', () {
+      final subject = EvaluationSubject(
+        referenceAircraft: testAircraft,
+        flights: const [],
+        heldRecords: [sepRating],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        subject,
+        CalendarDate(2024, 8, 1),
+      );
+
+      expect(result.satisfied, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Based on `main` directly — no stack this time, everything from the previous chunk is merged.

- FCL.740.A(b)(1)'s own `all_of` of five sub-requirements over one expiry-anchored 12-month window: 12 hours in class, 6 of those as PIC, 12 takeoffs, 12 landings, and a >=1 hour training flight with an instructor aboard — or, as an `any_of` alternative, a class-rating proficiency check via #121's event marker.
- Two new `FlightCondition` kinds: `capacity` (PIC, gating on `PilotCapacity.commandAuthority`) and `instructorAboard` (gating on `PilotCapacity.instructor != null`) — both flight-level gates alongside `aircraftMatch`, not per-landing sub-count selectors the way `dayNight`/`landingType` are. No other evaluator changes needed.
- Authored for SEP(land) specifically, documented as such: MEP/SEP(sea)/TMG need their own rule files with their own `anchor_held_record_kind` and, for MEP, different hour figures per `docs/jurisdiction-matrix.md` §5 — the schema has no mechanism for one rule to parametrise over "whichever class rating the pilot holds," and trying to make one rule cover all of them would make its own citation ambiguous.
- Tested against the issue's own explicit trap: the same hours/landings/training activity that satisfies the rule when flown within the 12 months before expiry does **not** satisfy it when flown right after the *previous* revalidation instead — proving the expiry-anchored window actually excludes old activity, not just that the arithmetic is correct in isolation.

Closes #47.

## Test plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `dart run tool/check_layering.dart`
- [x] `dart run tool/check_domain_types.dart`
- [x] `dart run tool/check_currency_rules.dart` — 14 rule files clean
- [x] `dart run tool/check_schema_snapshot.dart`
- [x] `flutter test --coverage` — 519 passing
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 95.3%

🤖 Generated with [Claude Code](https://claude.com/claude-code)