### PR TITLE
M3 close-out: qualification gap check, golden logbook, rule-authoring docs

### DIFF
--- a/assets/rules/README.md
+++ b/assets/rules/README.md
@@ -1,0 +1,228 @@
+# Authoring a currency rule
+
+#54. This is the artefact meant to survive contact with future-you at 11pm, trying to add a
+rule and unsure what a field means. If something here goes stale, fix the doc in the same PR
+that changes the shape it's describing — see `lib/domain/currency/currency_rule_yaml.dart` for
+the parser this document is describing, and `assets/rules/schema/currency-rule.schema.json` for
+the JSON Schema every file here is validated against (`dart run tool/check_currency_rules.dart`,
+also run in CI).
+
+**Why YAML at all.** CLAUDE.md's "currency rules are data" section is the reasoning: thresholds,
+windows, counts and rule composition are data; deriving a quantity from raw facts is real logic
+and belongs in Dart. A rule file should never need a matching change in
+`currency_rule_evaluator.dart` — if it does, the schema is missing an expression, which is a
+bigger conversation than adding one rule.
+
+## Where a rule file lives
+
+`assets/rules/<authority>/<short_name>.yaml`, e.g. `assets/rules/easa/fcl060_b1_passenger_recency.yaml`.
+The filename is not load-bearing (nothing parses it), but keep it recognisably tied to the
+citation so a directory listing is itself useful.
+
+## Top-level fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | yes | Stable identity across every version of this rule, e.g. `easa.fcl060.b1_passenger_recency`. This is what `CurrencyRuleLoader.resolve` is called with — a caller asks for a rule by `id` and an evaluation date, never by filename. Never changes once a rule exists, even when the regulation is renumbered; add a comment noting the renumbering instead. |
+| `jurisdiction` | yes | The jurisdiction profile id this rule belongs to, e.g. `eu.easa.part-fcl`, `us.faa.part61` — see `assets/jurisdictions/`. |
+| `citation` | yes | The regulation this rule implements, e.g. `"FCL.740.A(b)(1)"`, `"§61.57(c)"`. Shown to the pilot alongside the result — see CLAUDE.md's citation convention. |
+| `effective_from` | yes | `YYYY-MM-DD`. The date this *version* of the rule took effect. See "When a regulation changes" below. |
+| `expires_on` | no | `YYYY-MM-DD`. The date this version was superseded. Omit while a version is still current. |
+| `requirement` | yes | The rule's logic tree — see below. |
+
+## The requirement tree
+
+A `requirement` is one of five `kind`s. `flight_event_count`, `flight_event_hours` and
+`held_record_currently_valid` are leaves; `all_of` and `any_of` compose other requirements
+(including each other) to arbitrary depth.
+
+### `flight_event_count` / `flight_event_hours`
+
+"N of some countable thing, within a window, optionally narrowed by conditions."
+
+```yaml
+kind: flight_event_count   # or flight_event_hours
+event: landings            # see the event list below
+count: 3                   # flight_event_count only
+hours: 6                   # flight_event_hours only — decimal, e.g. 6.5
+window: { kind: rolling_days, days: 90 }
+conditions:                # optional; omit entirely for "no narrowing"
+  - kind: aircraft_match
+    level: same_type_or_class
+```
+
+Events, exactly the ones a rule implemented so far needs — adding a new one is a schema change,
+not something a rule author invents inline:
+
+`landings`, `takeoffs`, `approaches`, `holding_procedures`, `tracking_performed`,
+`faa_flight_review`, `faa_instrument_proficiency_check`, `easa_class_rating_proficiency_check`.
+
+The last three are "alternative means of compliance" — a flight tagged as *being* a flight
+review, an IPC, or a class-rating proficiency check (`Flight.alternativeComplianceEvents`),
+rather than an ordinary count of landings or hours.
+
+### `held_record_currently_valid`
+
+"Is there a currently-valid held document of this kind." No window — validity is a range on the
+held record itself (`HeldRecord.validFrom`/`validUntil`), not something the rule computes.
+
+```yaml
+kind: held_record_currently_valid
+held_record_kind: medical_certificate.easaClass2
+```
+
+`held_record_kind` is a string key, not an enum — it has to match whatever the pilot-record
+layer projects into a `HeldRecord.kind` (see `lib/domain/pilot_record/held_qualification_records.dart`
+and `medical_certificate_validity.dart` for the projections currently in use). There is no
+compile-time check that the string is spelled right; a typo here silently never matches anything,
+which is why every rule needs a test asserting it against a held record of the right kind.
+
+### `all_of` / `any_of`
+
+Composition, matching plain English: every sub-requirement must hold, or at least one must.
+
+```yaml
+kind: any_of
+of:
+  - kind: flight_event_count
+    event: landings
+    count: 3
+    window: { kind: rolling_days, days: 90 }
+  - kind: held_record_currently_valid
+    held_record_kind: proficiency_check
+```
+
+Nest freely — `assets/rules/easa/fcl740a_sep_land_revalidation.yaml` is `any_of` a five-way
+`all_of` and a single leaf, and is the deepest example in the current rule set. When a
+composite fails, `RuleResult.components` carries each sub-result, so a caller can point at
+exactly which branch is missing something instead of showing one opaque "not current" — see
+CLAUDE.md's "not current, with no explanation, is a bug."
+
+## Windows
+
+Two kinds, because "3 in the preceding 90 days" and "24 calendar months" are genuinely
+different shapes, not the same thing spelled two ways:
+
+```yaml
+window: { kind: rolling_days, days: 90 }
+```
+
+```yaml
+window:
+  kind: calendar_months
+  months: 24
+  anchor: held_record_expiry          # optional; default is evaluation_date
+  anchor_held_record_kind: eu.easa.sep_class_rating   # required when anchor is held_record_expiry
+```
+
+`calendar_months` runs to the end of a specific month regardless of which day of the month the
+anchor fell on — 24 calendar months, not 730 days. Use it for anything the regulation states in
+months (flight reviews, medical validity, rating revalidation); use `rolling_days` for anything
+the regulation states as a day count (the 90-day passenger-carrying rules).
+
+`anchor: held_record_expiry` is for a window that runs against a *document's* expiry rather
+than against today — FCL.740.A(b)(1)'s "within the 12 months preceding the rating's expiry" is
+the current example. This window does not slide as the evaluation date changes; it is fixed
+once the anchoring record's expiry is known. Leave `anchor` off (or write
+`evaluation_date` explicitly) for the ordinary case.
+
+## Conditions
+
+Narrow *which flights* count (`aircraft_match`, `capacity`, `instructor_aboard`) or *which part*
+of a qualifying flight counts (`day_night`, `landing_type`). Optional; omit `conditions`
+entirely for "every flight of the right event type, unnarrowed."
+
+| `kind` | Field | Values | What it does |
+|---|---|---|---|
+| `aircraft_match` | `level` | `same_type`, `same_class`, `same_type_or_class`, `class_or_type_if_required` | Gates the flight against the aircraft the recency question is being asked about. `class_or_type_if_required` is `§61.57(a)`'s own wording — same class ordinarily, same *type* when the reference aircraft is itself type-rated. |
+| `day_night` | `value` | `day`, `night` | Narrows a landings/takeoffs count to one half of `CircuitCounts`. |
+| `landing_type` | `value` | `full_stop`, `touch_and_go` | As above, the other axis of `CircuitCounts`. |
+| `capacity` | `value` | `command_authority` | Gates on a fact from `PilotCapacity` — currently only whether the pilot held command authority. |
+| `instructor_aboard` | — | — | Gates on `PilotCapacity.instructor` being present, in any capacity. No value field: it is a pure presence check. |
+
+A rule needing a new condition kind or a new `aircraft_match`/`capacity` value is a schema
+change (`lib/domain/currency/flight_condition.dart`, the YAML parser, and the JSON Schema, in
+that order), not something to approximate with an existing one.
+
+## Worked example: citation to YAML
+
+Starting point, `FCL.060(b)(1)`:
+
+> A pilot shall not act as PIC or co-pilot of an aeroplane carrying passengers unless that pilot
+> has carried out, in the preceding 90 days, at least 3 take-offs, approaches and landings, in
+> an aeroplane of the same type or class.
+
+Steps, in the order you'd actually do them:
+
+1. **Pick the `id`.** `easa.fcl060.b1_passenger_recency` — jurisdiction, citation stub, plain
+   English. Stable forever once chosen.
+2. **Pick the `event`.** The regulation names three things (take-offs, approaches, landings),
+   but `docs/entry-form.md` §5 is explicit this is a *recency condition*, not a logging
+   requirement, and a landing implies the approach and take-off that produced it — so `landings`
+   alone is the right event, not three separate counts. (Contrast `§61.57(a)`, which genuinely
+   needs take-offs and landings counted independently, because a pilot who took over in flight
+   has zero take-offs and one landing.) This judgement call is worth a comment in the file, not
+   just in this doc — see the real file for the one actually written.
+3. **Pick the `window`.** "Preceding 90 days" is `{ kind: rolling_days, days: 90 }` — a day
+   count, not a month count.
+4. **Pick the `conditions`.** "Same type or class" is `aircraft_match` at `same_type_or_class`.
+5. **Assemble:**
+
+```yaml
+id: easa.fcl060.b1_passenger_recency
+jurisdiction: eu.easa.part-fcl
+citation: "FCL.060(b)(1)"
+effective_from: 2011-11-08
+requirement:
+  kind: flight_event_count
+  event: landings
+  count: 3
+  window:
+    kind: rolling_days
+    days: 90
+  conditions:
+    - kind: aircraft_match
+      level: same_type_or_class
+```
+
+6. **Write the comment.** Every rule file in `assets/rules/` opens with a comment explaining any
+   non-obvious modelling choice — why this event and not that one, what was deliberately scoped
+   out, which other rule this one pairs with. The YAML says *what*; the comment says *why*, per
+   CLAUDE.md's "put the reasoning in a comment beside the code it explains."
+7. **Validate.** `dart run tool/check_currency_rules.dart` checks the file against both the
+   schema and the Dart parser.
+8. **Test it.** Every rule needs at least one test exercising it satisfied and one unsatisfied —
+   see `test/domain/currency/golden_logbook_test.dart` (#53) for a shared fixture logbook that
+   most new rules can be evaluated against directly, and any file under
+   `test/domain/pilot_record/*_rules_test.dart` for a rule-specific example when the shared
+   fixture doesn't fit (a rule needing its own held-record shape, for instance).
+
+## When a regulation changes
+
+**Add a new rule file — or a new document in the same file, if your loader path expects one
+document per `id` per file, which this codebase's does not enforce either way — with a new
+`effective_from`. Never edit an existing version's dates, and never delete a superseded
+version.**
+
+`CurrencyRuleLoader` groups every loaded rule by `id`, sorts by `effective_from`, and resolves
+"the version in force on this date" per evaluation — so a flight from 2019 is always evaluated
+against the rule that was actually in force in 2019, no matter how many times the regulation has
+changed since (#41). That guarantee only holds if superseded versions stay loaded forever.
+
+Concretely, when `FCL.060(b)(1)`'s 90-day figure changes to 60 days effective 2027-01-01:
+
+1. Add `expires_on: 2026-12-31` to the *existing* file — it is not deleted, not edited beyond
+   this one field.
+2. Add a **new** file (or a new list entry, if this rule's versions are ever split across
+   physical files — not yet the case for anything in this directory) with the same `id`, the new
+   `effective_from: 2027-01-01`, and the new `days: 60`.
+3. Both versions carry the citation — cite the specific sub-paragraph or amending instrument if
+   the two versions read differently (`ED Decision .../.../R`, an amendment number), so a reader
+   can tell at a glance why two files share an `id`.
+4. Two versions of the same `id` may never share an `effective_from` — `CurrencyRuleLoader`'s
+   constructor throws if they do, since nothing would then say which one governs.
+
+The rule of thumb: a rule file, once it has ever been evaluated against a real flight, is as
+immutable as the flight itself. Editing history out from under a past evaluation is exactly the
+"derived quantity silently wrong with no way to recompute" failure CLAUDE.md rule 1 warns about
+for flights — the same logic applies to the rules that read them.

--- a/lib/domain/pilot_record/qualification_gap.dart
+++ b/lib/domain/pilot_record/qualification_gap.dart
@@ -1,0 +1,108 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../model/aircraft.dart';
+import '../model/calendar_date.dart';
+import 'held_aircraft_qualification.dart';
+import 'held_qualification_records.dart';
+import 'held_rating.dart';
+
+part 'qualification_gap.freezed.dart';
+
+/// One qualification [aircraft] requires under a jurisdiction, that the
+/// pilot did not hold on the evaluation date — [qualificationGaps] (#105).
+///
+/// Flat class with a [kind] discriminator, matching [FlightCondition]'s
+/// style: an [AircraftQualification] and a type-rating designator are
+/// different shapes of "missing", not variants worth a sealed hierarchy.
+@freezed
+abstract class QualificationGap with _$QualificationGap {
+  const factory QualificationGap({
+    required QualificationGapKind kind,
+    AircraftQualification? aircraftQualification,
+    String? typeRatingDesignator,
+  }) = _QualificationGap;
+
+  factory QualificationGap.aircraftQualification(AircraftQualification value) =>
+      QualificationGap(
+        kind: QualificationGapKind.aircraftQualification,
+        aircraftQualification: value,
+      );
+
+  factory QualificationGap.typeRating(String designator) => QualificationGap(
+    kind: QualificationGapKind.typeRating,
+    typeRatingDesignator: designator,
+  );
+}
+
+enum QualificationGapKind { aircraftQualification, typeRating }
+
+/// Qualifications [aircraft] requires under [jurisdictionId] that are not
+/// covered by [heldAircraftQualifications]/[heldRatings] on [asOf] —
+/// `docs/ratings-and-endorsements.md` §8's `required_qualifications` vs
+/// `held_qualifications` comparison.
+///
+/// Two independently-required things get compared:
+///
+/// - [Aircraft.requiredQualifications]'s declared list for [jurisdictionId]
+///   — skipped entirely when the key is absent. #104's absent-vs-empty
+///   distinction: a missing key means the aircraft was never set up for
+///   this authority, which is a "we don't know" the caller must not read
+///   as "requires nothing" — silence, not a warning, is the only honest
+///   response.
+/// - [Aircraft.typeRatingDesignator], checked whenever it is set,
+///   independently of whether the qualification list above has been set
+///   up. It is a plain fact about the airframe rather than a declared
+///   list, so there is no "not set up" state for it to be missing from.
+///
+/// A pure query, never blocking anything itself — the caller (#58's entry
+/// form, once built) surfaces the result as a non-blocking warning, per
+/// §8: "the pilot may be logging a flight flown under a different licence,
+/// on a permit aircraft, or under an exemption the app doesn't model."
+///
+/// Scoped to a single [jurisdictionId] on purpose. §8's night-rating
+/// example — an EASA-primary pilot legally flying at night on an FAA
+/// ticket with no EASA night rating — requires evaluating each held
+/// licence's jurisdiction independently rather than against the primary
+/// jurisdiction only; the caller runs this once per held licence, not this
+/// function fanning out internally, since only the caller knows which
+/// licences the pilot holds.
+List<QualificationGap> qualificationGaps({
+  required Aircraft aircraft,
+  required String jurisdictionId,
+  required List<HeldAircraftQualification> heldAircraftQualifications,
+  required List<HeldRating> heldRatings,
+  required CalendarDate asOf,
+}) {
+  final gaps = <QualificationGap>[];
+
+  final required = aircraft.requiredQualifications[jurisdictionId];
+  if (required != null) {
+    for (final qualification in required) {
+      final held = heldAircraftQualifications.any(
+        (h) =>
+            h.qualification == qualification &&
+            h.jurisdictionId == jurisdictionId &&
+            heldAircraftQualificationHeldRecord(h).coversDate(asOf),
+      );
+      if (!held) {
+        gaps.add(QualificationGap.aircraftQualification(qualification));
+      }
+    }
+  }
+
+  final typeRating = aircraft.typeRatingDesignator;
+  if (typeRating != null) {
+    final held = heldRatings.any(
+      (h) =>
+          h.kind == HeldRatingKind.typeRating &&
+          h.designator == typeRating &&
+          h.jurisdictionId == jurisdictionId &&
+          heldRatingHeldRecord(h).coversDate(asOf),
+    );
+    if (!held) {
+      gaps.add(QualificationGap.typeRating(typeRating));
+    }
+  }
+
+  return gaps;
+}

--- a/test/domain/currency/golden_logbook_test.dart
+++ b/test/domain/currency/golden_logbook_test.dart
@@ -1,0 +1,582 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_loader.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/currency/rule_result.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/instructor_presence.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_qualification_records.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_rating.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// #53 -- a golden logbook exercising every implemented currency rule against
+// hand-verified expected outcomes, in both satisfied and unsatisfied states.
+//
+// **Methodology, per #53's own instruction not to derive expectations from
+// the implementation.** The logbook is built from a small number of
+// documented, constant-cadence phases (a pattern flight every N days,
+// stated below) rather than a few hundred individually hand-typed flights.
+// Every expectation in this file is checked by window arithmetic against
+// the regulation text -- "the last qualifying flight was 104 days before
+// the evaluation date, which is more than the 90-day window" -- never by
+// running the evaluator and copying its answer down. The cadence is what
+// makes that arithmetic tractable at this volume: knowing flights occur
+// every 4 days makes "is there one in the last 90 days" a one-line
+// computation instead of a scan.
+//
+// Phases (all flights G-CSEP, a Cessna 172, single-engine piston landplane,
+// no type rating -- so `aircraft_match` conditions always pass trivially
+// against [_referenceAircraft], the same aircraft):
+//   A  2023-01-01 .. 2023-06-29, every 4 days, day full-stop landings.
+//   gap 2023-06-30 .. 2023-10-20, no flying -- 113 days, well past every
+//      90-day window this app has.
+//   C  2023-10-21 .. 2024-08-31, every 4 days, day full-stop landings.
+//   D  2024-09-01 .. 2024-12-10, every 4 days, day TOUCH-AND-GO landings --
+//      deliberately not full-stop, to separate FAA Sec.61.57(a) (any
+//      landing type) from Sec.61.57(a)(2) (full-stop only) at the same
+//      evaluation date.
+//   E  2024-12-11 .. 2024-12-29, every 4 days, day full-stop landings.
+// Plus three landmark flights: a night circuit (2023-02-01), an instrument
+// flight (2023-01-10), and a dual training flight with an instructor
+// aboard (2024-06-01) -- see their own comments below.
+void main() {
+  final loader = _loadAllRules();
+  const evaluator = CurrencyRuleEvaluator();
+
+  final subject = EvaluationSubject(
+    flights: _flightRecords,
+    referenceAircraft: _referenceAircraft,
+    heldRecords: _heldRecords,
+  );
+
+  RuleResult evaluate(String ruleId, CalendarDate asOf) {
+    final rule = loader.resolve(ruleId, asOf);
+    return evaluator.evaluateRequirement(rule.requirement, subject, asOf);
+  }
+
+  group('every rule file loads and resolves', () {
+    test('all 14 currency rule files are present', () {
+      expect(_ruleIds, hasLength(14));
+      for (final id in _ruleIds) {
+        expect(
+          () => loader.resolve(id, CalendarDate(2024, 1, 1)),
+          returnsNormally,
+          reason: 'rule "$id" failed to resolve',
+        );
+      }
+    });
+  });
+
+  group('FAA Sec.61.57(a) takeoff/landing currency', () {
+    const ruleId = 'us.faa.61_57_a.takeoff_landing_currency';
+
+    test('satisfied during active flying (phase A)', () {
+      final result = evaluate(ruleId, CalendarDate(2023, 2, 20));
+      expect(result.satisfied, isTrue);
+    });
+
+    test('unsatisfied 108 days after the last flight before the gap', () {
+      // Last phase-A flight: 2023-06-29. 2023-10-15 is 108 days later.
+      final result = evaluate(ruleId, CalendarDate(2023, 10, 15));
+      expect(result.satisfied, isFalse);
+      expect(result.components[0].explanation, contains('0 of 3'));
+    });
+
+    test('touch-and-goes count too (phase D)', () {
+      // Phase D (2024-09-01..2024-12-10) is touch-and-go only; this rule
+      // does not filter by landing type, unlike Sec.61.57(a)(2).
+      final result = evaluate(ruleId, CalendarDate(2024, 12, 5));
+      expect(result.satisfied, isTrue);
+    });
+  });
+
+  group('FAA Sec.61.57(a)(2) tailwheel (full-stop only) currency', () {
+    const ruleId = 'us.faa.61_57_a2.tailwheel_takeoff_landing_currency';
+
+    test('satisfied when the recent landings are full-stop (phase A)', () {
+      final result = evaluate(ruleId, CalendarDate(2023, 2, 20));
+      expect(result.satisfied, isTrue);
+    });
+
+    test(
+      'unsatisfied when the preceding 90 days are touch-and-go only (phase D)',
+      () {
+        final result = evaluate(ruleId, CalendarDate(2024, 12, 5));
+        expect(result.satisfied, isFalse);
+        expect(result.explanation, contains('0 of 2 requirements met'));
+      },
+    );
+  });
+
+  group('FAA Sec.61.57(b) night takeoff/landing currency', () {
+    const ruleId = 'us.faa.61_57_b.night_takeoff_landing_currency';
+
+    test('satisfied 19 days after the night circuit (2023-02-01)', () {
+      final result = evaluate(ruleId, CalendarDate(2023, 2, 20));
+      expect(result.satisfied, isTrue);
+    });
+
+    test(
+      'unsatisfied 104 days after the night circuit, though day currency holds',
+      () {
+        final night = evaluate(ruleId, CalendarDate(2023, 5, 15));
+        final day = evaluate(
+          'us.faa.61_57_a.takeoff_landing_currency',
+          CalendarDate(2023, 5, 15),
+        );
+        expect(night.satisfied, isFalse);
+        expect(day.satisfied, isTrue);
+      },
+    );
+  });
+
+  group(
+    'FAA Sec.61.57(c) instrument currency (6-month) and grace (12-month)',
+    () {
+      const currentId = 'us.faa.61_57_c.instrument_currency';
+      const graceId = 'us.faa.61_57_c.instrument_currency_grace_period';
+
+      test(
+        'both satisfied shortly after the instrument flight (2023-01-10)',
+        () {
+          expect(
+            evaluate(currentId, CalendarDate(2023, 3, 1)).satisfied,
+            isTrue,
+          );
+          expect(evaluate(graceId, CalendarDate(2023, 3, 1)).satisfied, isTrue);
+        },
+      );
+
+      test('6-month lapsed but 12-month grace still holds at 203 days out', () {
+        // 2023-01-10 -> 2023-08-01 is 203 days: outside 6 calendar months
+        // (window start 2023-02-01) but inside 12 (window start 2022-08-01).
+        expect(
+          evaluate(currentId, CalendarDate(2023, 8, 1)).satisfied,
+          isFalse,
+        );
+        expect(evaluate(graceId, CalendarDate(2023, 8, 1)).satisfied, isTrue);
+      });
+
+      test(
+        'both lapsed a year past the instrument flight: an IPC is required',
+        () {
+          // 12-month window at 2024-02-01 starts 2023-02-01, after the
+          // instrument flight (2023-01-10) -- excluded from both windows.
+          expect(
+            evaluate(currentId, CalendarDate(2024, 2, 1)).satisfied,
+            isFalse,
+          );
+          expect(
+            evaluate(graceId, CalendarDate(2024, 2, 1)).satisfied,
+            isFalse,
+          );
+        },
+      );
+    },
+  );
+
+  group('FAA Sec.61.56 flight review', () {
+    const ruleId = 'us.faa.61_56.flight_review';
+
+    test('satisfied within 24 months of the review (2023-01-05)', () {
+      final result = evaluate(ruleId, CalendarDate(2023, 6, 1));
+      expect(result.satisfied, isTrue);
+    });
+
+    test('unsatisfied more than 24 calendar months later', () {
+      final result = evaluate(ruleId, CalendarDate(2025, 6, 1));
+      expect(result.satisfied, isFalse);
+    });
+  });
+
+  group('FAA Sec.61.23(d) medical validity, all three classes', () {
+    for (final entry in [
+      (
+        'us.faa.61_23.first_class_medical_validity',
+        CalendarDate(2023, 6, 1),
+        CalendarDate(2024, 6, 1),
+      ),
+      (
+        'us.faa.61_23.second_class_medical_validity',
+        CalendarDate(2023, 6, 1),
+        CalendarDate(2024, 6, 1),
+      ),
+      (
+        'us.faa.61_23.third_class_medical_validity',
+        CalendarDate(2023, 1, 1),
+        CalendarDate(2025, 2, 1),
+      ),
+    ]) {
+      final (ruleId, satisfiedAsOf, unsatisfiedAsOf) = entry;
+      test('$ruleId: satisfied within validity, unsatisfied after', () {
+        expect(evaluate(ruleId, satisfiedAsOf).satisfied, isTrue);
+        expect(evaluate(ruleId, unsatisfiedAsOf).satisfied, isFalse);
+      });
+    }
+  });
+
+  group('EASA FCL.060(b)(1) passenger recency', () {
+    const ruleId = 'easa.fcl060.b1_passenger_recency';
+
+    test('satisfied during active flying (phase A)', () {
+      expect(evaluate(ruleId, CalendarDate(2023, 2, 20)).satisfied, isTrue);
+    });
+
+    test('unsatisfied 108 days after the last flight before the gap', () {
+      final result = evaluate(ruleId, CalendarDate(2023, 10, 15));
+      expect(result.satisfied, isFalse);
+      expect(result.explanation, contains('0 of 3'));
+    });
+  });
+
+  group('EASA FCL.060(b)(3) night passenger recency', () {
+    const ruleId = 'eu.easa.fcl060.b3_night_passenger_recency';
+
+    test('satisfied 19 days after the night circuit', () {
+      expect(evaluate(ruleId, CalendarDate(2023, 2, 20)).satisfied, isTrue);
+    });
+
+    test(
+      'unsatisfied 104 days after the night circuit even though day '
+      'passenger recency (FCL.060(b)(1)) still holds -- no IR held either',
+      () {
+        final result = evaluate(ruleId, CalendarDate(2023, 5, 15));
+        expect(result.satisfied, isFalse);
+        // b(1)'s own 3-landing leg still passes; only the night-or-IR leg
+        // fails -- CLAUDE.md rule 5's "never render a jurisdiction-dependent
+        // number without its qualifier" shows up here as two components,
+        // not one flat boolean.
+        expect(result.components, hasLength(2));
+        expect(result.components[0].satisfied, isTrue);
+        expect(result.components[1].satisfied, isFalse);
+      },
+    );
+  });
+
+  group('EASA FCL.740.A(b)(1) SEP(land) revalidation', () {
+    const ruleId = 'eu.easa.fcl740a.sep_land_revalidation';
+
+    test('satisfied: a year of ordinary flying plus the June dual flight '
+        'covers all five FCL.740.A(b)(1)(i) legs before the rating expires '
+        '2025-01-01', () {
+      final rule = loader.resolve(ruleId, CalendarDate(2024, 12, 15));
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        EvaluationSubject(
+          flights: _flightRecords,
+          referenceAircraft: _referenceAircraft,
+          heldRecords: [_currentSepRatingHeldRecord],
+        ),
+        CalendarDate(2024, 12, 15),
+      );
+      expect(result.satisfied, isTrue);
+    });
+
+    test('unsatisfied: a rating that expired 2022-12-31, before this '
+        'logbook has any flights in its preceding-12-months window', () {
+      final rule = loader.resolve(ruleId, CalendarDate(2023, 1, 1));
+      final result = evaluator.evaluateRequirement(
+        rule.requirement,
+        EvaluationSubject(
+          flights: _flightRecords,
+          referenceAircraft: _referenceAircraft,
+          heldRecords: [_oldSepRatingHeldRecord],
+        ),
+        CalendarDate(2023, 1, 1),
+      );
+      expect(result.satisfied, isFalse);
+      expect(result.explanation, contains('None of 2 alternatives'));
+    });
+  });
+
+  group('EASA MED.A.045 medical validity, both classes', () {
+    for (final entry in [
+      (
+        'eu.easa.med_a045.class1_validity',
+        CalendarDate(2023, 4, 1),
+        CalendarDate(2023, 8, 1),
+      ),
+      (
+        'eu.easa.med_a045.class2_validity',
+        CalendarDate(2024, 1, 1),
+        CalendarDate(2025, 2, 1),
+      ),
+    ]) {
+      final (ruleId, satisfiedAsOf, unsatisfiedAsOf) = entry;
+      test('$ruleId: satisfied within validity, unsatisfied after', () {
+        expect(evaluate(ruleId, satisfiedAsOf).satisfied, isTrue);
+        expect(evaluate(ruleId, unsatisfiedAsOf).satisfied, isFalse);
+      });
+    }
+  });
+}
+
+const List<String> _ruleIds = [
+  'us.faa.61_57_a.takeoff_landing_currency',
+  'us.faa.61_57_a2.tailwheel_takeoff_landing_currency',
+  'us.faa.61_57_b.night_takeoff_landing_currency',
+  'us.faa.61_57_c.instrument_currency',
+  'us.faa.61_57_c.instrument_currency_grace_period',
+  'us.faa.61_56.flight_review',
+  'us.faa.61_23.first_class_medical_validity',
+  'us.faa.61_23.second_class_medical_validity',
+  'us.faa.61_23.third_class_medical_validity',
+  'easa.fcl060.b1_passenger_recency',
+  'eu.easa.fcl060.b3_night_passenger_recency',
+  'eu.easa.fcl740a.sep_land_revalidation',
+  'eu.easa.med_a045.class1_validity',
+  'eu.easa.med_a045.class2_validity',
+];
+
+CurrencyRuleLoader _loadAllRules() {
+  final ruleFiles =
+      Directory('assets/rules')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.yaml'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+  return CurrencyRuleLoader.fromYaml([
+    for (final file in ruleFiles) file.readAsStringSync(),
+  ]);
+}
+
+const _referenceAircraft = Aircraft(
+  registration: 'G-CSEP',
+  manufacturer: 'Cessna',
+  model: '172',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+const _picCapacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _dualWithInstructorCapacity = PilotCapacity(
+  commandAuthority: false,
+  soleManipulator: true,
+  soleOccupant: false,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+  instructor: InstructorPresence(
+    capacity: InstructorCapacity.flightInstructor,
+    influencedFlight: false,
+    name: 'A. Instructor',
+  ),
+);
+
+Flight _patternFlight(
+  CalendarDate date, {
+  required CircuitCounts counts,
+  Duration blockTime = const Duration(minutes: 30),
+  PilotCapacity capacity = _picCapacity,
+  List<Approach> approaches = const [],
+  int holdingProceduresCount = 0,
+  bool trackingPerformed = false,
+  Set<AlternativeComplianceEvent> alternativeComplianceEvents = const {},
+}) {
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
+  return Flight(
+    aircraftRegistration: _referenceAircraft.registration,
+    route: const ['EGXX'],
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(blockTime),
+    capacity: capacity,
+    carryingPassengers: false,
+    takeoffs: counts,
+    landings: counts,
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: approaches,
+    holdingProceduresCount: holdingProceduresCount,
+    trackingPerformed: trackingPerformed,
+    alternativeComplianceEvents: alternativeComplianceEvents,
+    remarks: '',
+  );
+}
+
+/// A run of pattern flights every [stepDays] days from [start] to [end]
+/// inclusive, all with [counts]. The regular cadence is what makes "is
+/// there a qualifying flight in the last N days" a one-line arithmetic
+/// check rather than a per-flight lookup -- see the file dartdoc.
+List<Flight> _cadence({
+  required CalendarDate start,
+  required CalendarDate end,
+  required CircuitCounts counts,
+  int stepDays = 4,
+}) {
+  final flights = <Flight>[];
+  var date = start;
+  while (date <= end) {
+    flights.add(_patternFlight(date, counts: counts));
+    date = date.addDays(stepDays);
+  }
+  return flights;
+}
+
+const _fullStop3 = CircuitCounts(dayFullStop: 3);
+const _touchAndGo3 = CircuitCounts(dayTouchAndGo: 3);
+
+final List<Flight> _allFlights = [
+  // Phase A: 2023-01-01 .. 2023-06-29, day full-stop, every 4 days.
+  ..._cadence(
+    start: CalendarDate(2023, 1, 1),
+    end: CalendarDate(2023, 6, 29),
+    counts: _fullStop3,
+  ),
+  // gap: 2023-06-30 .. 2023-10-20, no flying (113 days).
+  // Phase C: 2023-10-21 .. 2024-08-31, day full-stop, every 4 days.
+  ..._cadence(
+    start: CalendarDate(2023, 10, 21),
+    end: CalendarDate(2024, 8, 31),
+    counts: _fullStop3,
+  ),
+  // Phase D: 2024-09-01 .. 2024-12-10, day TOUCH-AND-GO, every 4 days --
+  // separates Sec.61.57(a) from Sec.61.57(a)(2).
+  ..._cadence(
+    start: CalendarDate(2024, 9, 1),
+    end: CalendarDate(2024, 12, 10),
+    counts: _touchAndGo3,
+  ),
+  // Phase E: 2024-12-11 .. 2024-12-29, day full-stop, every 4 days.
+  ..._cadence(
+    start: CalendarDate(2024, 12, 11),
+    end: CalendarDate(2024, 12, 29),
+    counts: _fullStop3,
+  ),
+
+  // Landmark: a night circuit, the sole source of night landings in this
+  // logbook -- FAA Sec.61.57(b) and EASA FCL.060(b)(3) both key off it.
+  _patternFlight(
+    CalendarDate(2023, 2, 1),
+    counts: const CircuitCounts(nightFullStop: 3),
+  ),
+
+  // Landmark: an instrument flight -- six ILS approaches to one procedure,
+  // one holding pattern, tracking performed. The sole source of instrument
+  // currency in this logbook -- Sec.61.57(c) and its grace-period sibling
+  // key off it.
+  _patternFlight(
+    CalendarDate(2023, 1, 10),
+    counts: const CircuitCounts(),
+    approaches: const [
+      Approach(
+        type: ApproachType.ils,
+        aerodromeIcao: 'EGXX',
+        runway: '27',
+        count: 6,
+      ),
+    ],
+    holdingProceduresCount: 1,
+    trackingPerformed: true,
+  ),
+
+  // Landmark: a training flight with an instructor aboard, satisfying
+  // FCL.740.A(b)(1)(i)'s "1 hour with an instructor" leg. Also carries the
+  // faaFlightReview event on the *cadence* flight of 2023-01-05, below.
+  _patternFlight(
+    CalendarDate(2024, 6, 1),
+    counts: const CircuitCounts(dayFullStop: 1),
+    blockTime: const Duration(hours: 1, minutes: 12),
+    capacity: _dualWithInstructorCapacity,
+  ),
+
+  // Landmark: the FAA Sec.61.56 flight review, recorded on its own date
+  // rather than folded into a cadence flight so it reads clearly here.
+  _patternFlight(
+    CalendarDate(2023, 1, 5),
+    counts: _fullStop3,
+    alternativeComplianceEvents: const {
+      AlternativeComplianceEvent.faaFlightReview,
+    },
+  ),
+];
+
+final List<FlightRecord> _flightRecords = [
+  for (var i = 0; i < _allFlights.length; i++)
+    FlightRecord(
+      id: 'golden-$i',
+      flight: _allFlights[i],
+      aircraft: _referenceAircraft,
+    ),
+];
+
+final HeldRecord _currentSepRatingHeldRecord = heldRatingHeldRecord(
+  HeldRating(
+    kind: HeldRatingKind.classRating,
+    designator: 'SEP(land)',
+    jurisdictionId: 'eu.easa.part-fcl',
+    issueDate: CalendarDate(2023, 1, 1),
+    expiryDate: CalendarDate(2025, 1, 1),
+  ),
+);
+
+final HeldRecord _oldSepRatingHeldRecord = heldRatingHeldRecord(
+  HeldRating(
+    kind: HeldRatingKind.classRating,
+    designator: 'SEP(land)',
+    jurisdictionId: 'eu.easa.part-fcl',
+    issueDate: CalendarDate(2021, 1, 1),
+    expiryDate: CalendarDate(2022, 12, 31),
+  ),
+);
+
+// Medical held records are constructed directly with an explicit validity
+// window rather than run through medicalCertificateHeldRecord's age-band
+// logic -- that logic already has its own dedicated tests
+// (medical_certificate_validity_test.dart). This fixture only needs *some*
+// valid/invalid window to exercise the currency rule that consumes it.
+final List<HeldRecord> _heldRecords = [
+  _currentSepRatingHeldRecord,
+  const HeldRecord(
+    kind: 'medical_certificate.easaClass1',
+    validFrom: CalendarDate(2023, 1, 1),
+    validUntil: CalendarDate(2023, 7, 1),
+  ),
+  const HeldRecord(
+    kind: 'medical_certificate.easaClass2',
+    validFrom: CalendarDate(2023, 1, 1),
+    validUntil: CalendarDate(2025, 1, 1),
+  ),
+  const HeldRecord(
+    kind: 'medical_certificate.faaFirstClass',
+    validFrom: CalendarDate(2023, 1, 1),
+    validUntil: CalendarDate(2024, 1, 1),
+  ),
+  const HeldRecord(
+    kind: 'medical_certificate.faaSecondClass',
+    validFrom: CalendarDate(2023, 1, 1),
+    validUntil: CalendarDate(2024, 1, 1),
+  ),
+  const HeldRecord(
+    kind: 'medical_certificate.faaThirdClass',
+    validFrom: CalendarDate(2020, 1, 1),
+    validUntil: CalendarDate(2025, 1, 1),
+  ),
+];

--- a/test/domain/pilot_record/qualification_gap_test.dart
+++ b/test/domain/pilot_record/qualification_gap_test.dart
@@ -1,0 +1,279 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_aircraft_qualification.dart';
+import 'package:easa_digital_log/domain/pilot_record/held_rating.dart';
+import 'package:easa_digital_log/domain/pilot_record/qualification_gap.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _easa = 'eu.easa.part-fcl';
+const _faa = 'us.faa.part61';
+
+Aircraft _arrow({String? typeRatingDesignator}) => Aircraft(
+  registration: 'G-ARRW',
+  manufacturer: 'Piper',
+  model: 'Arrow',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+  typeRatingDesignator: typeRatingDesignator,
+  requiredQualifications: const {
+    _easa: {
+      AircraftQualification.easaVariablePitchPropeller,
+      AircraftQualification.easaRetractableUndercarriage,
+    },
+    _faa: {AircraftQualification.faaComplex},
+  },
+);
+
+void main() {
+  group('qualificationGaps (#105)', () {
+    test('the pilot holds everything required: no gaps', () {
+      final held = [
+        HeldAircraftQualification(
+          qualification: AircraftQualification.easaVariablePitchPropeller,
+          jurisdictionId: _easa,
+          dateGranted: CalendarDate(2020, 1, 1),
+        ),
+        HeldAircraftQualification(
+          qualification: AircraftQualification.easaRetractableUndercarriage,
+          jurisdictionId: _easa,
+          dateGranted: CalendarDate(2020, 1, 1),
+        ),
+      ];
+
+      final gaps = qualificationGaps(
+        aircraft: _arrow(),
+        jurisdictionId: _easa,
+        heldAircraftQualifications: held,
+        heldRatings: const [],
+        asOf: CalendarDate(2024, 1, 1),
+      );
+
+      expect(gaps, isEmpty);
+    });
+
+    test('a required qualification the pilot does not hold is a gap', () {
+      final held = [
+        HeldAircraftQualification(
+          qualification: AircraftQualification.easaVariablePitchPropeller,
+          jurisdictionId: _easa,
+          dateGranted: CalendarDate(2020, 1, 1),
+        ),
+      ];
+
+      final gaps = qualificationGaps(
+        aircraft: _arrow(),
+        jurisdictionId: _easa,
+        heldAircraftQualifications: held,
+        heldRatings: const [],
+        asOf: CalendarDate(2024, 1, 1),
+      );
+
+      expect(gaps, [
+        QualificationGap.aircraftQualification(
+          AircraftQualification.easaRetractableUndercarriage,
+        ),
+      ]);
+    });
+
+    test(
+      'a set typeRatingDesignator with no matching held rating is a gap',
+      () {
+        final gaps = qualificationGaps(
+          aircraft: _arrow(typeRatingDesignator: 'PA46'),
+          jurisdictionId: _easa,
+          heldAircraftQualifications: const [
+            HeldAircraftQualification(
+              qualification: AircraftQualification.easaVariablePitchPropeller,
+              jurisdictionId: _easa,
+              dateGranted: CalendarDate(2020, 1, 1),
+            ),
+            HeldAircraftQualification(
+              qualification: AircraftQualification.easaRetractableUndercarriage,
+              jurisdictionId: _easa,
+              dateGranted: CalendarDate(2020, 1, 1),
+            ),
+          ],
+          heldRatings: const [],
+          asOf: CalendarDate(2024, 1, 1),
+        );
+
+        expect(gaps, [QualificationGap.typeRating('PA46')]);
+      },
+    );
+
+    test('an expired type rating is a gap, not a pass', () {
+      final gaps = qualificationGaps(
+        aircraft: _arrow(typeRatingDesignator: 'PA46'),
+        jurisdictionId: _easa,
+        heldAircraftQualifications: const [
+          HeldAircraftQualification(
+            qualification: AircraftQualification.easaVariablePitchPropeller,
+            jurisdictionId: _easa,
+            dateGranted: CalendarDate(2020, 1, 1),
+          ),
+          HeldAircraftQualification(
+            qualification: AircraftQualification.easaRetractableUndercarriage,
+            jurisdictionId: _easa,
+            dateGranted: CalendarDate(2020, 1, 1),
+          ),
+        ],
+        heldRatings: [
+          HeldRating(
+            kind: HeldRatingKind.typeRating,
+            designator: 'PA46',
+            jurisdictionId: _easa,
+            issueDate: CalendarDate(2022, 1, 1),
+            expiryDate: CalendarDate(2023, 1, 1),
+          ),
+        ],
+        asOf: CalendarDate(2024, 1, 1),
+      );
+
+      expect(gaps, [QualificationGap.typeRating('PA46')]);
+    });
+
+    test('a currently-valid type rating satisfies the requirement', () {
+      final gaps = qualificationGaps(
+        aircraft: _arrow(typeRatingDesignator: 'PA46'),
+        jurisdictionId: _easa,
+        heldAircraftQualifications: const [
+          HeldAircraftQualification(
+            qualification: AircraftQualification.easaVariablePitchPropeller,
+            jurisdictionId: _easa,
+            dateGranted: CalendarDate(2020, 1, 1),
+          ),
+          HeldAircraftQualification(
+            qualification: AircraftQualification.easaRetractableUndercarriage,
+            jurisdictionId: _easa,
+            dateGranted: CalendarDate(2020, 1, 1),
+          ),
+        ],
+        heldRatings: [
+          HeldRating(
+            kind: HeldRatingKind.typeRating,
+            designator: 'PA46',
+            jurisdictionId: _easa,
+            issueDate: CalendarDate(2023, 1, 1),
+            expiryDate: CalendarDate(2025, 1, 1),
+          ),
+        ],
+        asOf: CalendarDate(2024, 1, 1),
+      );
+
+      expect(gaps, isEmpty);
+    });
+
+    test('an FAA type rating with no stored expiry is held permanently', () {
+      final gaps = qualificationGaps(
+        aircraft: _arrow(typeRatingDesignator: 'PA46'),
+        jurisdictionId: _faa,
+        heldAircraftQualifications: const [
+          HeldAircraftQualification(
+            qualification: AircraftQualification.faaComplex,
+            jurisdictionId: _faa,
+            dateGranted: CalendarDate(2020, 1, 1),
+          ),
+        ],
+        heldRatings: [
+          HeldRating(
+            kind: HeldRatingKind.typeRating,
+            designator: 'PA46',
+            jurisdictionId: _faa,
+            issueDate: CalendarDate(2010, 1, 1),
+          ),
+        ],
+        asOf: CalendarDate(2040, 1, 1),
+      );
+
+      expect(gaps, isEmpty);
+    });
+
+    test(
+      'an aircraft never set up for a jurisdiction (absent key) produces no warning',
+      () {
+        const aircraft = Aircraft(
+          registration: 'G-NEW',
+          manufacturer: 'Cessna',
+          model: '172',
+          category: AircraftCategory.aeroplane,
+          engineType: EngineType.piston,
+          engineCount: 1,
+          operatingSurface: OperatingSurface.land,
+          requiresMultiCrew: false,
+        );
+
+        final gaps = qualificationGaps(
+          aircraft: aircraft,
+          jurisdictionId: _easa,
+          heldAircraftQualifications: const [],
+          heldRatings: const [],
+          asOf: CalendarDate(2024, 1, 1),
+        );
+
+        expect(gaps, isEmpty);
+      },
+    );
+
+    test(
+      'an aircraft set up with an empty required set produces no warning',
+      () {
+        const aircraft = Aircraft(
+          registration: 'G-NEW',
+          manufacturer: 'Cessna',
+          model: '172',
+          category: AircraftCategory.aeroplane,
+          engineType: EngineType.piston,
+          engineCount: 1,
+          operatingSurface: OperatingSurface.land,
+          requiresMultiCrew: false,
+          requiredQualifications: {_easa: {}},
+        );
+
+        final gaps = qualificationGaps(
+          aircraft: aircraft,
+          jurisdictionId: _easa,
+          heldAircraftQualifications: const [],
+          heldRatings: const [],
+          asOf: CalendarDate(2024, 1, 1),
+        );
+
+        expect(gaps, isEmpty);
+      },
+    );
+
+    test(
+      'runs per licence: a gap under one jurisdiction is not a gap under another',
+      () {
+        final held = [
+          HeldAircraftQualification(
+            qualification: AircraftQualification.faaComplex,
+            jurisdictionId: _faa,
+            dateGranted: CalendarDate(2020, 1, 1),
+          ),
+        ];
+        final aircraft = _arrow();
+
+        final easaGaps = qualificationGaps(
+          aircraft: aircraft,
+          jurisdictionId: _easa,
+          heldAircraftQualifications: held,
+          heldRatings: const [],
+          asOf: CalendarDate(2024, 1, 1),
+        );
+        final faaGaps = qualificationGaps(
+          aircraft: aircraft,
+          jurisdictionId: _faa,
+          heldAircraftQualifications: held,
+          heldRatings: const [],
+          asOf: CalendarDate(2024, 1, 1),
+        );
+
+        expect(easaGaps, isNotEmpty);
+        expect(faaGaps, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

The last three M3 issues, closing out the milestone.

- **#105** — `qualificationGaps()` in `lib/domain/pilot_record/qualification_gap.dart`: a pure comparison of `Aircraft.requiredQualifications` against a pilot's held aircraft qualifications (EASA differences training / FAA `§61.31` endorsements) and held ratings (type ratings, which can expire). Scoped to a single jurisdiction per call, since `docs/ratings-and-endorsements.md` §8's night-rating example requires evaluating each held licence independently rather than against the primary jurisdiction only — the caller (#58's entry form, once built) runs it once per held licence. Respects #104's absent-vs-empty distinction: an aircraft never set up for a jurisdiction produces no warning, not a false negative.
- **#53** — `test/domain/currency/golden_logbook_test.dart`: a fixture logbook of ~160 flights built from a small number of documented, constant-cadence phases (a pattern flight every 4 days, stated in the file), rather than individually hand-typed flights. Every one of the 14 currency rule files is exercised satisfied and unsatisfied at several evaluation dates, with expectations checked by window arithmetic against the regulation text — never derived from running the evaluator, per the issue's own instruction. Also demonstrates the FAA §61.57(a)/(a)(2) full-stop divergence and the §61.57(c) six-month/twelve-month grace-period two-stage state at the same fixture.
- **#54** — `assets/rules/README.md`: field-by-field guide to the rule YAML schema, a worked example carrying `FCL.060(b)(1)` from citation text to finished YAML, and the never-edit/never-delete process for a superseded rule version once `CurrencyRuleLoader` depends on it for historical evaluation.

## Test plan

- [x] TDD: `qualificationGaps` test written and confirmed red before implementation
- [x] `dart format .` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] `check_layering` / `check_domain_types` / `check_currency_rules` (14 files) / `check_schema_snapshot` all clean
- [x] `flutter test` — 552 tests passing
- [x] `check_domain_coverage` — 95.4% (threshold 90%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)