### PR TITLE
Flight Entry Form and Currency dashboard (#58, #129, #62)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,13 @@ analyzer:
   exclude:
     - "**/*.freezed.dart"
     - "**/*.g.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
     strict-inference: true

--- a/assets/rules/easa/fcl060_b1_passenger_recency.yaml
+++ b/assets/rules/easa/fcl060_b1_passenger_recency.yaml
@@ -17,6 +17,7 @@
 id: easa.fcl060.b1_passenger_recency
 jurisdiction: eu.easa.part-fcl
 citation: "FCL.060(b)(1)"
+title: "Passenger recency"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_count

--- a/assets/rules/easa/fcl060_b3_night_passenger_recency.yaml
+++ b/assets/rules/easa/fcl060_b3_night_passenger_recency.yaml
@@ -19,6 +19,7 @@
 id: eu.easa.fcl060.b3_night_passenger_recency
 jurisdiction: eu.easa.part-fcl
 citation: "FCL.060(b)(3)"
+title: "Night passenger recency"
 effective_from: 2011-11-08
 requirement:
   kind: all_of

--- a/assets/rules/easa/fcl740a_sep_land_revalidation.yaml
+++ b/assets/rules/easa/fcl740a_sep_land_revalidation.yaml
@@ -26,6 +26,7 @@
 id: eu.easa.fcl740a.sep_land_revalidation
 jurisdiction: eu.easa.part-fcl
 citation: "FCL.740.A(b)(1)"
+title: "SEP (land) revalidation"
 effective_from: 2011-11-08
 requirement:
   kind: any_of

--- a/assets/rules/easa/med_a045_class1_validity.yaml
+++ b/assets/rules/easa/med_a045_class1_validity.yaml
@@ -9,6 +9,7 @@
 id: eu.easa.med_a045.class1_validity
 jurisdiction: eu.easa.part-fcl
 citation: "MED.A.045"
+title: "Class 1 medical"
 effective_from: 2011-11-08
 requirement:
   kind: held_record_currently_valid

--- a/assets/rules/easa/med_a045_class2_validity.yaml
+++ b/assets/rules/easa/med_a045_class2_validity.yaml
@@ -8,6 +8,7 @@
 id: eu.easa.med_a045.class2_validity
 jurisdiction: eu.easa.part-fcl
 citation: "MED.A.045"
+title: "Class 2 medical"
 effective_from: 2011-11-08
 requirement:
   kind: held_record_currently_valid

--- a/assets/rules/faa/61_23_first_class_medical_validity.yaml
+++ b/assets/rules/faa/61_23_first_class_medical_validity.yaml
@@ -8,6 +8,7 @@
 id: us.faa.61_23.first_class_medical_validity
 jurisdiction: us.faa.part61
 citation: "§61.23(d)"
+title: "First-class medical"
 effective_from: 1997-08-04
 requirement:
   kind: held_record_currently_valid

--- a/assets/rules/faa/61_23_second_class_medical_validity.yaml
+++ b/assets/rules/faa/61_23_second_class_medical_validity.yaml
@@ -4,6 +4,7 @@
 id: us.faa.61_23.second_class_medical_validity
 jurisdiction: us.faa.part61
 citation: "§61.23(d)"
+title: "Second-class medical"
 effective_from: 1997-08-04
 requirement:
   kind: held_record_currently_valid

--- a/assets/rules/faa/61_23_third_class_medical_validity.yaml
+++ b/assets/rules/faa/61_23_third_class_medical_validity.yaml
@@ -4,6 +4,7 @@
 id: us.faa.61_23.third_class_medical_validity
 jurisdiction: us.faa.part61
 citation: "§61.23(d)"
+title: "Third-class medical"
 effective_from: 1997-08-04
 requirement:
   kind: held_record_currently_valid

--- a/assets/rules/faa/61_56_flight_review.yaml
+++ b/assets/rules/faa/61_56_flight_review.yaml
@@ -15,6 +15,7 @@
 id: us.faa.61_56.flight_review
 jurisdiction: us.faa.part61
 citation: "§61.56"
+title: "Flight review"
 effective_from: 1997-08-04
 requirement:
   kind: any_of

--- a/assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml
+++ b/assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml
@@ -11,6 +11,7 @@
 id: us.faa.61_57_a2.tailwheel_takeoff_landing_currency
 jurisdiction: us.faa.part61
 citation: "§61.57(a)(2)"
+title: "Tailwheel take-off & landing currency"
 effective_from: 1997-08-04
 requirement:
   kind: all_of

--- a/assets/rules/faa/61_57_a_takeoff_landing_currency.yaml
+++ b/assets/rules/faa/61_57_a_takeoff_landing_currency.yaml
@@ -16,6 +16,7 @@
 id: us.faa.61_57_a.takeoff_landing_currency
 jurisdiction: us.faa.part61
 citation: "§61.57(a)"
+title: "Take-off & landing currency"
 effective_from: 1997-08-04
 requirement:
   kind: all_of

--- a/assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml
+++ b/assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml
@@ -20,6 +20,7 @@
 id: us.faa.61_57_b.night_takeoff_landing_currency
 jurisdiction: us.faa.part61
 citation: "§61.57(b)"
+title: "Night take-off & landing currency"
 effective_from: 1997-08-04
 requirement:
   kind: all_of

--- a/assets/rules/faa/61_57_c_instrument_currency.yaml
+++ b/assets/rules/faa/61_57_c_instrument_currency.yaml
@@ -30,6 +30,7 @@
 id: us.faa.61_57_c.instrument_currency
 jurisdiction: us.faa.part61
 citation: "§61.57(c)"
+title: "Instrument currency"
 effective_from: 1997-08-04
 requirement:
   kind: any_of

--- a/assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml
+++ b/assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml
@@ -10,6 +10,7 @@
 id: us.faa.61_57_c.instrument_currency_grace_period
 jurisdiction: us.faa.part61
 citation: "§61.57(c)"
+title: "Instrument currency (grace period)"
 effective_from: 1997-08-04
 requirement:
   kind: any_of

--- a/assets/rules/schema/currency-rule.schema.json
+++ b/assets/rules/schema/currency-rule.schema.json
@@ -4,7 +4,7 @@
   "title": "Currency rule",
   "description": "One versioned currency rule under assets/rules/. See assets/rules/README.md (#54) for a field-by-field authoring guide, and lib/domain/currency/currency_rule_yaml.dart for the Dart parser this schema documents -- the parser is the actual enforcement (test/domain/currency/currency_rule_schema_test.dart checks the two agree on required fields).",
   "type": "object",
-  "required": ["id", "jurisdiction", "citation", "effective_from", "requirement"],
+  "required": ["id", "jurisdiction", "citation", "title", "effective_from", "requirement"],
   "additionalProperties": false,
   "properties": {
     "id": {
@@ -21,6 +21,11 @@
       "type": "string",
       "minLength": 1,
       "description": "The regulation this rule implements, e.g. FCL.060(b)(1)."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human display label, e.g. Passenger recency."
     },
     "effective_from": {
       "$ref": "#/$defs/date",

--- a/drift_schemas/drift_schema_v5.json
+++ b/drift_schemas/drift_schema_v5.json
@@ -1,0 +1,1626 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "alternative_compliance_events",
+            "getter_name": "alternativeComplianceEvents",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pilot_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_of_birth",
+            "getter_name": "dateOfBirth",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "primary_jurisdiction_id",
+            "getter_name": "primaryJurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'eu.easa.part-fcl\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "medical_certificates",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "certificate_class",
+            "getter_name": "certificateClass",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_aircraft_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_granted",
+            "getter_name": "dateGranted",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_name",
+            "getter_name": "signatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_credential_number",
+            "getter_name": "signatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_ratings",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "designator",
+            "getter_name": "designator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "expiry_date",
+            "getter_name": "expiryDate",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "language_proficiency_level",
+            "getter_name": "languageProficiencyLevel",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"alternative_compliance_events\" TEXT NOT NULL DEFAULT '', \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pilot_profile",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pilot_profile\" (\"id\" TEXT NOT NULL, \"date_of_birth\" TEXT NOT NULL, \"primary_jurisdiction_id\" TEXT NOT NULL DEFAULT 'eu.easa.part-fcl', PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "medical_certificates",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"medical_certificates\" (\"id\" TEXT NOT NULL, \"certificate_class\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_aircraft_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_aircraft_qualifications\" (\"id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"date_granted\" TEXT NOT NULL, \"signatory_name\" TEXT NULL, \"signatory_credential_number\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_ratings",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_ratings\" (\"id\" TEXT NOT NULL, \"kind\" TEXT NOT NULL, \"designator\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, \"expiry_date\" TEXT NULL, \"language_proficiency_level\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -32,7 +32,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.executor);
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   // SQLite does not enforce foreign keys — including this schema's
   // `onDelete: KeyAction.cascade` on the flight/aircraft child tables —
@@ -66,6 +66,24 @@ class AppDatabase extends _$AppDatabase {
         await m.addColumn(
           flightsTable,
           flightsTable.alternativeComplianceEvents,
+        );
+      }
+      // Adds primaryJurisdictionId to pilot_profile — CLAUDE.md's "primary
+      // jurisdiction must be an explicit settings value". The column's
+      // withDefault backfills the one pre-existing singleton row to EASA;
+      // a real pilot changes it in Settings same as any other preference.
+      //
+      // Guarded to `from >= 2`: a database upgrading from v1 hits the
+      // `from < 2` branch above first, and `createTable` always builds from
+      // *today's* Dart table definition — which already includes this
+      // column — so running `addColumn` again on the same upgrade would
+      // fail with "duplicate column name". Only a database whose
+      // pilot_profile table was created by an *older* build (schema v2-v4,
+      // genuinely missing the column) needs this step.
+      if (from >= 2 && from < 5) {
+        await m.addColumn(
+          pilotProfileTable,
+          pilotProfileTable.primaryJurisdictionId,
         );
       }
     },

--- a/lib/data/mappers/pilot_record_mapper.dart
+++ b/lib/data/mappers/pilot_record_mapper.dart
@@ -7,11 +7,18 @@ PilotProfileRow pilotProfileToRow(
   domain.PilotProfile profile, {
   required String id,
 }) {
-  return PilotProfileRow(id: id, dateOfBirth: profile.dateOfBirth.toString());
+  return PilotProfileRow(
+    id: id,
+    dateOfBirth: profile.dateOfBirth.toString(),
+    primaryJurisdictionId: profile.primaryJurisdictionId,
+  );
 }
 
 domain.PilotProfile pilotProfileFromRow(PilotProfileRow row) {
-  return domain.PilotProfile(dateOfBirth: CalendarDate.parse(row.dateOfBirth));
+  return domain.PilotProfile(
+    dateOfBirth: CalendarDate.parse(row.dateOfBirth),
+    primaryJurisdictionId: row.primaryJurisdictionId,
+  );
 }
 
 MedicalCertificateRow medicalCertificateToRow(

--- a/lib/data/tables/pilot_record_tables.dart
+++ b/lib/data/tables/pilot_record_tables.dart
@@ -11,6 +11,15 @@ class PilotProfileTable extends Table {
   TextColumn get id => text()();
   TextColumn get dateOfBirth => text()();
 
+  /// The [JurisdictionProfile.id] whose figures render everywhere that
+  /// isn't the currency screen (CLAUDE.md: "let the user choose their
+  /// primary jurisdiction must be a settings value, never a code path").
+  /// Defaulted only for the migration backfill of the one pre-existing
+  /// singleton row, never for a newly-created profile — `PilotProfile`'s
+  /// own field is `required`.
+  TextColumn get primaryJurisdictionId =>
+      text().withDefault(const Constant('eu.easa.part-fcl'))();
+
   @override
   Set<Column> get primaryKey => {id};
 }

--- a/lib/domain/currency/currency_dashboard.dart
+++ b/lib/domain/currency/currency_dashboard.dart
@@ -1,0 +1,146 @@
+import '../model/calendar_date.dart';
+import 'currency_expiry_projection.dart';
+import 'currency_rule_evaluator.dart';
+import 'currency_rule_loader.dart';
+import 'evaluation_subject.dart';
+import 'rule_result.dart';
+
+/// One held licence's worth of currency rows to evaluate — the Currency
+/// screen's per-licence grouping (CLAUDE.md: "show all held licences
+/// grouped, always").
+///
+/// [privilegeSummary] and [ruleIds] are supplied by the caller rather than
+/// derived from held ratings: rolling ratings/medicals up into "one row per
+/// issuing authority with a privileges summary", and resolving which
+/// currency rules actually apply to what a pilot holds, are both real
+/// features with no domain representation yet (flagged for the Settings
+/// phase of this redesign) — a real caller hand-picks both today the same
+/// way `sample_currency_data.dart` does.
+class CurrencyLicenceSpec {
+  const CurrencyLicenceSpec({
+    required this.jurisdictionId,
+    required this.label,
+    required this.isPrimary,
+    required this.privilegeSummary,
+    required this.ruleIds,
+  });
+
+  final String jurisdictionId;
+  final String label;
+  final bool isPrimary;
+  final String privilegeSummary;
+
+  /// Which loaded [CurrencyRule] ids apply under this licence, in display
+  /// order.
+  final List<String> ruleIds;
+}
+
+/// One evaluated currency rule, ready to render as a row.
+class CurrencyDashboardRow {
+  const CurrencyDashboardRow({
+    required this.title,
+    required this.evaluation,
+    required this.isAtRisk,
+  });
+
+  final String title;
+  final CurrencyRuleEvaluation evaluation;
+
+  /// Unsatisfied, or satisfied with an [RuleResult.expiresOn] inside the
+  /// hero window — [isNearingExpiry]'s own criteria. This is what decides
+  /// hero-row membership; "not current, with no explanation" (CLAUDE.md)
+  /// applies just as much to an unsatisfied rule with no expiry as to one
+  /// about to lapse, so both count as at-risk here.
+  final bool isAtRisk;
+}
+
+class CurrencyLicenceGroup {
+  const CurrencyLicenceGroup({
+    required this.jurisdictionId,
+    required this.label,
+    required this.isPrimary,
+    required this.privilegeSummary,
+    required this.rows,
+  });
+
+  final String jurisdictionId;
+  final String label;
+  final bool isPrimary;
+  final String privilegeSummary;
+  final List<CurrencyDashboardRow> rows;
+}
+
+/// Every held licence's currency rows, grouped for display — the Currency
+/// screen's whole data model, built fresh from [buildCurrencyDashboard] on
+/// each load rather than cached, since it is cheap and always as-of "now".
+class CurrencyDashboard {
+  const CurrencyDashboard({required this.groups});
+
+  final List<CurrencyLicenceGroup> groups;
+
+  /// Rows worth surfacing in the hero row — across every group, in group
+  /// order. Empty when nothing is expired or due soon, which hides the
+  /// whole hero row (the mockup's own rule: "nothing appears there unless
+  /// it is expired or inside 30 days").
+  List<CurrencyDashboardRow> get atRiskRows => [
+    for (final group in groups)
+      for (final row in group.rows)
+        if (row.isAtRisk) row,
+  ];
+}
+
+/// Resolves, evaluates and groups every rule named by [licences] — the
+/// Currency screen's whole pipeline, kept as one pure function so it can be
+/// unit-tested without a widget tree.
+///
+/// [heroLeadDays] is [isNearingExpiry]'s own `leadDays` parameter, exposed
+/// rather than hard-coded per that function's own dartdoc ("always
+/// caller-supplied, never a fixed default").
+CurrencyDashboard buildCurrencyDashboard({
+  required List<CurrencyLicenceSpec> licences,
+  required CurrencyRuleLoader loader,
+  required EvaluationSubject subject,
+  required CalendarDate asOf,
+  CurrencyRuleEvaluator evaluator = const CurrencyRuleEvaluator(),
+  int heroLeadDays = 30,
+}) {
+  final groups = <CurrencyLicenceGroup>[];
+  for (final licence in licences) {
+    final rows = <CurrencyDashboardRow>[
+      for (final ruleId in licence.ruleIds)
+        _evaluateRow(ruleId, loader, evaluator, subject, asOf, heroLeadDays),
+    ];
+    groups.add(
+      CurrencyLicenceGroup(
+        jurisdictionId: licence.jurisdictionId,
+        label: licence.label,
+        isPrimary: licence.isPrimary,
+        privilegeSummary: licence.privilegeSummary,
+        rows: rows,
+      ),
+    );
+  }
+  return CurrencyDashboard(groups: groups);
+}
+
+CurrencyDashboardRow _evaluateRow(
+  String ruleId,
+  CurrencyRuleLoader loader,
+  CurrencyRuleEvaluator evaluator,
+  EvaluationSubject subject,
+  CalendarDate asOf,
+  int heroLeadDays,
+) {
+  final rule = loader.resolve(ruleId, asOf);
+  final evaluation = evaluator.evaluateRule(rule, subject, asOf);
+  final expiresOn = evaluation.result.expiresOn;
+  final isAtRisk =
+      !evaluation.result.satisfied ||
+      (expiresOn != null &&
+          isNearingExpiry(expiresOn, asOf, leadDays: heroLeadDays));
+  return CurrencyDashboardRow(
+    title: rule.title,
+    evaluation: evaluation,
+    isAtRisk: isAtRisk,
+  );
+}

--- a/lib/domain/currency/currency_rule.dart
+++ b/lib/domain/currency/currency_rule.dart
@@ -29,6 +29,12 @@ abstract class CurrencyRule with _$CurrencyRule {
     /// per #40 — every [RuleResult] carries it through for display.
     required String citation,
 
+    /// Human display label, e.g. "Passenger recency" — [id] is a dotted
+    /// machine string never meant for a screen. Lives here, next to
+    /// [citation], rather than as a UI-side `id -> title` lookup table,
+    /// which would silently drift the moment a rule file changes.
+    required String title,
+
     /// The date this version takes effect. #41 selects, for a given
     /// evaluation date, the latest version with `effectiveFrom <=` that date.
     required CalendarDate effectiveFrom,

--- a/lib/domain/currency/currency_rule_evaluator.dart
+++ b/lib/domain/currency/currency_rule_evaluator.dart
@@ -110,6 +110,10 @@ class CurrencyRuleEvaluator {
                 '${requirement.count! - cumulative} more',
       expiresOn: satisfied ? window.expiryFrom(anchorDate!) : null,
       contributingFlightIds: contributingIds,
+      progress: RuleProgress.count(
+        current: cumulative,
+        required: requirement.count!,
+      ),
     );
   }
 
@@ -178,6 +182,10 @@ class CurrencyRuleEvaluator {
                 'needs ${(requirement.hours! - cumulative).toDecimalHours()} more',
       expiresOn: satisfied ? window.expiryFrom(anchorDate!) : null,
       contributingFlightIds: contributingIds,
+      progress: RuleProgress.hours(
+        current: cumulative,
+        required: requirement.hours!,
+      ),
     );
   }
 
@@ -201,6 +209,12 @@ class CurrencyRuleEvaluator {
           : 'Currently-valid "$kind" held'
                 '${covering.validUntil != null ? ', expires ${covering.validUntil}' : ''}',
       expiresOn: covering?.validUntil,
+      progress: covering == null
+          ? null
+          : RuleProgress.validity(
+              validFrom: covering.validFrom,
+              validUntil: covering.validUntil,
+            ),
     );
   }
 
@@ -236,6 +250,10 @@ class CurrencyRuleEvaluator {
       expiresOn: expiresOn,
       contributingFlightIds: _mergedContributingIds(components),
       components: components,
+      // The tightest component is the one that decides whether the whole
+      // conjunction holds, so it's the one worth putting on a progress bar
+      // — matching [expiresOn] above picking the earliest component lapse.
+      progress: _representativeProgress(components, pickLowest: true),
     );
   }
 
@@ -269,7 +287,56 @@ class CurrencyRuleEvaluator {
       expiresOn: expiresOn,
       contributingFlightIds: _mergedContributingIds(components),
       components: components,
+      // The alternative closest to being satisfied is the one worth a
+      // progress bar — only one branch needs to succeed, so the nearest is
+      // the actionable one, matching [expiresOn] above picking the most
+      // generous satisfied alternative.
+      progress: _representativeProgress(components, pickLowest: false),
     );
+  }
+
+  /// Picks one [components] member's [RuleResult.progress] to represent the
+  /// whole composite — a bar needs one number, and neither [_evaluateAllOf]
+  /// nor [_evaluateAnyOf] has a single natural "the" requirement otherwise,
+  /// since a real currency rule is almost always compound (hours AND
+  /// landings AND a training flight, say). [pickLowest] selects the
+  /// tightest component for a conjunction, the nearest-to-met component for
+  /// a disjunction — see each caller's own comment.
+  ///
+  /// Only compares [RuleProgressKind.count]/[RuleProgressKind.hours]
+  /// components against each other — [RuleProgressKind.validity] has no
+  /// fill-ratio concept to rank against a count or hours sibling, and a
+  /// component with no progress at all (itself an unrepresented composite,
+  /// or a [RequirementKind.heldRecordCurrentlyValid] miss) is skipped
+  /// rather than treated as a zero.
+  RuleProgress? _representativeProgress(
+    List<RuleResult> components, {
+    required bool pickLowest,
+  }) {
+    RuleProgress? best;
+    double? bestRatio;
+    for (final component in components) {
+      final progress = component.progress;
+      final ratio = switch (progress?.kind) {
+        RuleProgressKind.count =>
+          progress!.requiredCount == 0
+              ? 1.0
+              : progress.currentCount! / progress.requiredCount!,
+        RuleProgressKind.hours =>
+          progress!.requiredHours!.inMinutes == 0
+              ? 1.0
+              : progress.currentHours!.inMinutes /
+                    progress.requiredHours!.inMinutes,
+        RuleProgressKind.validity || null => null,
+      };
+      if (ratio == null) continue;
+      if (bestRatio == null ||
+          (pickLowest ? ratio < bestRatio : ratio > bestRatio)) {
+        bestRatio = ratio;
+        best = progress;
+      }
+    }
+    return best;
   }
 
   List<String> _mergedContributingIds(List<RuleResult> components) {

--- a/lib/domain/currency/currency_rule_loader.dart
+++ b/lib/domain/currency/currency_rule_loader.dart
@@ -89,4 +89,11 @@ class CurrencyRuleLoader {
     }
     return inForce;
   }
+
+  /// Every loaded rule id's in-force version as of [evaluationDate] — one
+  /// resolved [CurrencyRule] per id, for a caller building a dashboard
+  /// across every rule rather than asking about one specific id.
+  List<CurrencyRule> allInForce(CalendarDate evaluationDate) => [
+    for (final id in _byId.keys) resolve(id, evaluationDate),
+  ];
 }

--- a/lib/domain/currency/currency_rule_yaml.dart
+++ b/lib/domain/currency/currency_rule_yaml.dart
@@ -25,6 +25,7 @@ CurrencyRule parseCurrencyRuleYaml(String yamlContent) {
   final id = _requiredString(yaml, 'id', 'currency rule');
   final jurisdictionId = _requiredString(yaml, 'jurisdiction', id);
   final citation = _requiredString(yaml, 'citation', id);
+  final title = _requiredString(yaml, 'title', id);
   final effectiveFrom = _requiredDate(yaml, 'effective_from', id);
   final expiresOn = _optionalDate(yaml, 'expires_on', id);
 
@@ -38,6 +39,7 @@ CurrencyRule parseCurrencyRuleYaml(String yamlContent) {
     id: id,
     jurisdictionId: jurisdictionId,
     citation: citation,
+    title: title,
     effectiveFrom: effectiveFrom,
     expiresOn: expiresOn,
     requirement: requirement,

--- a/lib/domain/currency/rule_result.dart
+++ b/lib/domain/currency/rule_result.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../model/calendar_date.dart';
+import '../model/flight_duration.dart';
 
 part 'rule_result.freezed.dart';
 
@@ -36,7 +37,68 @@ abstract class RuleResult with _$RuleResult {
     /// declared. Empty for a leaf requirement (flight-event or held-record
     /// check).
     @Default(<RuleResult>[]) List<RuleResult> components,
+
+    /// The structured numbers behind [explanation] — a progress bar or
+    /// "4 / 6" readout needs the actual current/required values, not a
+    /// regex against prose. Null for a composite (`allOf`/`anyOf`) result,
+    /// where no single number represents the requirement.
+    RuleProgress? progress,
   }) = _RuleResult;
+}
+
+/// The count/hours/validity numbers a leaf [RuleResult] was decided from —
+/// what a progress bar and a "current / required" readout render from,
+/// instead of parsing [RuleResult.explanation]'s prose back into numbers.
+///
+/// A flat class with a [kind] discriminator, not a sealed union — the same
+/// shape [FlightCondition] and [Requirement] already use in this codebase
+/// (see `currency_rule.dart`'s dartdoc for why).
+enum RuleProgressKind { count, hours, validity }
+
+@freezed
+abstract class RuleProgress with _$RuleProgress {
+  const factory RuleProgress({
+    required RuleProgressKind kind,
+
+    // ---- count.
+    int? currentCount,
+    int? requiredCount,
+
+    // ---- hours.
+    FlightDuration? currentHours,
+    FlightDuration? requiredHours,
+
+    // ---- validity. No "current/required" here — a held document either
+    // covers the evaluation date or it doesn't; the progress bar instead
+    // fills by how much of [validFrom]..[validUntil] has elapsed.
+    CalendarDate? validFrom,
+    CalendarDate? validUntil,
+  }) = _RuleProgress;
+
+  factory RuleProgress.count({required int current, required int required}) =>
+      RuleProgress(
+        kind: RuleProgressKind.count,
+        currentCount: current,
+        requiredCount: required,
+      );
+
+  factory RuleProgress.hours({
+    required FlightDuration current,
+    required FlightDuration required,
+  }) => RuleProgress(
+    kind: RuleProgressKind.hours,
+    currentHours: current,
+    requiredHours: required,
+  );
+
+  factory RuleProgress.validity({
+    required CalendarDate validFrom,
+    CalendarDate? validUntil,
+  }) => RuleProgress(
+    kind: RuleProgressKind.validity,
+    validFrom: validFrom,
+    validUntil: validUntil,
+  );
 }
 
 /// A [RuleResult] labelled with the rule it came from — what

--- a/lib/domain/model/calendar_date.dart
+++ b/lib/domain/model/calendar_date.dart
@@ -50,6 +50,13 @@ class CalendarDate implements Comparable<CalendarDate> {
     return _fromJulianDayNumber(jdn);
   }
 
+  /// Number of days from [other] to this date — positive when this date is
+  /// later, negative when earlier. The inverse of [addDays]:
+  /// `other.addDays(this.differenceInDays(other)) == this`.
+  int differenceInDays(CalendarDate other) =>
+      _toJulianDayNumber(year, month, day) -
+      _toJulianDayNumber(other.year, other.month, other.day);
+
   static int _toJulianDayNumber(int y, int m, int d) {
     final a = (14 - m) ~/ 12;
     final y2 = y + 4800 - a;

--- a/lib/domain/pilot_record/pilot_profile.dart
+++ b/lib/domain/pilot_record/pilot_profile.dart
@@ -15,6 +15,13 @@ part 'pilot_profile.freezed.dart';
 /// would ever vary.
 @freezed
 abstract class PilotProfile with _$PilotProfile {
-  const factory PilotProfile({required CalendarDate dateOfBirth}) =
-      _PilotProfile;
+  const factory PilotProfile({
+    required CalendarDate dateOfBirth,
+
+    /// The `JurisdictionProfile.id` whose figures the logbook, currency and
+    /// totals screens render — "let the user choose their primary
+    /// jurisdiction" must be this explicit settings value, never inferred
+    /// from which licence happens to come first (CLAUDE.md).
+    required String primaryJurisdictionId,
+  }) = _PilotProfile;
 }

--- a/lib/ui/currency/currency_screen.dart
+++ b/lib/ui/currency/currency_screen.dart
@@ -1,26 +1,410 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
-import '../widgets/large_title_scaffold.dart';
+import '../../domain/currency/currency_dashboard.dart';
+import '../../domain/currency/currency_rule_loader.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/repository/flight_read_repository.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
+import 'sample_currency_data.dart';
+import 'widgets/currency_hero_card.dart';
+import 'widgets/currency_rule_row.dart';
 
-/// Placeholder for #62 (currency dashboard with explanations).
-class CurrencyScreen extends StatelessWidget {
+/// Every rule file the Currency screen loads at start-up — see
+/// `assets/rules/README.md`. Loading the full set rather than only the ids
+/// [sampleCurrencyLicences] happens to reference keeps this list from
+/// needing to track the sample fixture's own choices, which are themselves
+/// a stand-in for a real per-licence rule resolver (see that file's
+/// dartdoc).
+const _ruleAssetPaths = [
+  'assets/rules/easa/fcl060_b1_passenger_recency.yaml',
+  'assets/rules/easa/fcl060_b3_night_passenger_recency.yaml',
+  'assets/rules/easa/fcl740a_sep_land_revalidation.yaml',
+  'assets/rules/easa/med_a045_class1_validity.yaml',
+  'assets/rules/easa/med_a045_class2_validity.yaml',
+  'assets/rules/faa/61_23_first_class_medical_validity.yaml',
+  'assets/rules/faa/61_23_second_class_medical_validity.yaml',
+  'assets/rules/faa/61_23_third_class_medical_validity.yaml',
+  'assets/rules/faa/61_56_flight_review.yaml',
+  'assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml',
+  'assets/rules/faa/61_57_a_takeoff_landing_currency.yaml',
+  'assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml',
+  'assets/rules/faa/61_57_c_instrument_currency.yaml',
+  'assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml',
+];
+
+/// #62: the currency dashboard — every held licence, grouped, with a reason
+/// for each pill. Runs the real `CurrencyRuleEvaluator`/`CurrencyRuleLoader`
+/// engine against `sample_currency_data.dart`'s fixture, the same
+/// real-engine-over-sample-data convention `NewFlightScreen` and
+/// `LogbookScreen` already use pending #56's live repository wiring.
+class CurrencyScreen extends StatefulWidget {
   const CurrencyScreen({super.key});
 
   @override
+  State<CurrencyScreen> createState() => _CurrencyScreenState();
+}
+
+class _CurrencyScreenState extends State<CurrencyScreen> {
+  CurrencyDashboard? _dashboard;
+  List<FlightRecord> _flights = const [];
+  late final CalendarDate _today;
+
+  @override
+  void initState() {
+    super.initState();
+    _today = CalendarDate.fromUtcInstant(
+      UtcInstant.fromDateTime(DateTime.now().toUtc()),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    // `cache: false` — see `NewFlightScreen._loadJurisdictions`'s own note:
+    // `rootBundle`'s process-wide cache otherwise returns a permanently-
+    // pending `Future` to a later widget-test run that reopens this screen.
+    final yamlContents = await Future.wait([
+      for (final path in _ruleAssetPaths)
+        rootBundle.loadString(path, cache: false),
+    ]);
+    final loader = CurrencyRuleLoader.fromYaml(yamlContents);
+    final flights = sampleCurrencyFlights(_today);
+    final dashboard = buildCurrencyDashboard(
+      licences: sampleCurrencyLicences,
+      loader: loader,
+      subject: sampleEvaluationSubject(_today),
+      asOf: _today,
+    );
+    if (!mounted) return;
+    setState(() {
+      _flights = flights;
+      _dashboard = dashboard;
+    });
+  }
+
+  void _showContributingFlights(List<String> flightIds) {
+    final matching = [
+      for (final record in _flights)
+        if (flightIds.contains(record.id)) record,
+    ]..sort((a, b) => b.flight.offBlocks.compareTo(a.flight.offBlocks));
+
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => _ContributingFlightsSheet(flights: matching),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return LargeTitleScaffold(
-      title: 'Currency',
-      slivers: [
-        SliverFillRemaining(
-          hasScrollBody: false,
-          child: EmptyStateMessage(
-            icon: Icons.verified_outlined,
-            headline: 'Currency rules land next',
-            caption:
-                'Every held licence, grouped, with a reason for each pill.',
+    final dashboard = _dashboard;
+    if (dashboard == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    final theme = Theme.of(context);
+    final heroRows = dashboard.atRiskRows;
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          // One continuous tinted band for the title and the hero
+          // scroller — the mockup's status-bar-to-hero-row area shares a
+          // background a shade off the page, distinct from the plain
+          // white list below.
+          SliverSafeArea(
+            bottom: false,
+            sliver: SliverToBoxAdapter(
+              child: ColoredBox(
+                color: theme.colorScheme.surfaceContainerLowest,
+                child: Column(
+                  children: [
+                    _Header(asOf: _today),
+                    if (heroRows.isNotEmpty) ...[
+                      // A `ListView` needs a bounded cross-axis height from
+                      // its parent — it can't ask a horizontally-scrolling
+                      // child to report its own intrinsic height the way a
+                      // plain `Row` can (`IntrinsicHeight` around the list
+                      // itself throws: the viewport passes its *own*
+                      // unbounded incoming height straight through rather
+                      // than computing one from its child). 185 is sized to
+                      // the card's own content (padding + every internal
+                      // row + a two-line footer, the tallest case), not the
+                      // much larger fixed box this used before.
+                      SizedBox(
+                        height: 185,
+                        child: ListView.separated(
+                          scrollDirection: Axis.horizontal,
+                          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                          itemCount: heroRows.length,
+                          separatorBuilder: (_, _) => const SizedBox(width: 12),
+                          itemBuilder: (context, index) => CurrencyHeroCard(
+                            row: heroRows[index],
+                            asOf: _today,
+                            onShowContributingFlights: _showContributingFlights,
+                          ),
+                        ),
+                      ),
+                      _HeroPageDots(count: heroRows.length),
+                      const SizedBox(height: 11),
+                    ] else
+                      const SizedBox(height: 12),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Container(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                border: Border(
+                  top: BorderSide(color: theme.colorScheme.outlineVariant),
+                ),
+              ),
+              child: Column(
+                children: [
+                  for (final group in dashboard.groups)
+                    _LicenceGroupSection(
+                      group: group,
+                      asOf: _today,
+                      onShowContributingFlights: _showContributingFlights,
+                    ),
+                ],
+              ),
+            ),
+          ),
+          const SliverPadding(padding: EdgeInsets.only(bottom: 96)),
+        ],
+      ),
+    );
+  }
+}
+
+/// The mockup's own pagination hint below the hero scroller — decorative,
+/// always showing the first dot "active" rather than tracking real scroll
+/// position, since the row is short enough to skim without a live indicator
+/// mattering.
+class _HeroPageDots extends StatelessWidget {
+  const _HeroPageDots({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final ink = context.inkTiers;
+    if (count <= 1) return const SizedBox.shrink();
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          width: 15,
+          height: 4,
+          decoration: BoxDecoration(
+            color: ink.medium,
+            borderRadius: BorderRadius.circular(2),
           ),
         ),
+        const SizedBox(width: 5),
+        for (var i = 1; i < count; i++) ...[
+          if (i > 1) const SizedBox(width: 5),
+          Container(
+            width: 4,
+            height: 4,
+            decoration: BoxDecoration(
+              color: ink.faint,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+        ],
       ],
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.asOf});
+
+  final CalendarDate asOf;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            'Currency',
+            style: theme.textTheme.displaySmall?.copyWith(fontSize: 27),
+          ),
+          Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: 'as at ',
+                  style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+                ),
+                TextSpan(text: '$asOf', style: AppMonoText.value(ink.medium)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One held licence's currency rules, flowing directly into the continuous
+/// white list alongside every other licence — the mockup keeps the whole
+/// group list as one panel, section headers doing the separating rather
+/// than each licence getting its own boxed card with a gap around it.
+class _LicenceGroupSection extends StatelessWidget {
+  const _LicenceGroupSection({
+    required this.group,
+    required this.asOf,
+    required this.onShowContributingFlights,
+  });
+
+  final CurrencyLicenceGroup group;
+  final CalendarDate asOf;
+  final ValueChanged<List<String>> onShowContributingFlights;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final scheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 9),
+          decoration: BoxDecoration(
+            color: scheme.surfaceContainerLowest,
+            border: Border(
+              top: BorderSide(color: scheme.outlineVariant),
+              bottom: BorderSide(color: scheme.outlineVariant),
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    group.label.toUpperCase(),
+                    style: AppMonoText.tag(
+                      ink.muted,
+                    ).copyWith(letterSpacing: 1.1),
+                  ),
+                  const SizedBox(width: 8),
+                  if (group.isPrimary)
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: scheme.primary.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Text(
+                        'PRIMARY',
+                        style: AppMonoText.tag(
+                          context.semanticColors.overriddenText,
+                        ).copyWith(letterSpacing: 0.7),
+                      ),
+                    )
+                  else
+                    Text(
+                      group.privilegeSummary,
+                      style: AppMonoText.value(ink.faint, size: 10.5),
+                    ),
+                ],
+              ),
+              // "Edit" has nowhere to go yet — a licence editor is
+              // Settings-phase work — so this is a harmless no-op,
+              // matching LogbookScreen's own not-yet-built taps.
+              InkWell(
+                onTap: () {},
+                child: Text(
+                  'Edit',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: scheme.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        for (var i = 0; i < group.rows.length; i++) ...[
+          if (i > 0) Divider(height: 1, color: scheme.outlineVariant),
+          CurrencyRuleRow(
+            row: group.rows[i],
+            asOf: asOf,
+            onShowContributingFlights: onShowContributingFlights,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ContributingFlightsSheet extends StatelessWidget {
+  const _ContributingFlightsSheet({required this.flights});
+
+  final List<FlightRecord> flights;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Which flights counted', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 12),
+            for (final record in flights)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 6),
+                child: Row(
+                  children: [
+                    Text(
+                      CalendarDate.fromUtcInstant(
+                        record.flight.offBlocks,
+                      ).toString(),
+                      style: AppMonoText.value(ink.medium),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        record.flight.route.join(' → '),
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                    Text(
+                      record.aircraft.registration,
+                      style: AppMonoText.value(ink.muted, size: 12.5),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/currency/currency_status_colors.dart
+++ b/lib/ui/currency/currency_status_colors.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+
+/// The three-state colour system the Currency screen's own mockup defines
+/// (Claude Design project 513e7fc3-e41a-40ea-b3a5-f16f086d15f8, "Currency
+/// Totals Settings.dc.html", sections 2a/2a-dark) — red for expired, amber
+/// for due soon, green for healthy. Deliberately separate from
+/// [AppSemanticColors]'s `currencyWarning`/`error`: those are the app's
+/// general-purpose attention/error tones (draft badges, form validation),
+/// tuned for a different job, while this screen's mockup specifies its own
+/// tighter red/amber/green with several distinct shades per state (a bright
+/// "accent" for dots/labels/links, a darker "text" for titles and body
+/// copy, and a separate bar-fill shade) — collapsing them into the generic
+/// tokens would lose that.
+///
+/// Every value here is a direct conversion of the mockup's own OKLCH
+/// swatches to sRGB via the standard OKLab matrices, not a hand-picked
+/// approximation. Dark values come from the mockup's own "2a-dark" variant
+/// (independently re-tuned there, not an inverted copy of light — see that
+/// section's own note in the design doc).
+@immutable
+class CurrencyStatusColors {
+  const CurrencyStatusColors({
+    required this.accent,
+    required this.text,
+    required this.fill,
+    required this.cardBackground,
+    required this.cardBorder,
+  });
+
+  /// Status dot, the "EXPIRED"/"DUE SOON" label, and the "Which flights
+  /// counted" link — the brightest, most saturated shade of the state.
+  final Color accent;
+
+  /// Title, numeric line, and footer/context copy inside a hero card or a
+  /// flagged list row — darker than [accent] so extended text stays
+  /// readable rather than glaring.
+  final Color text;
+
+  /// Progress bar fill — its own shade, distinct from both [accent] and
+  /// [text] in the source mockup.
+  final Color fill;
+
+  final Color cardBackground;
+  final Color cardBorder;
+}
+
+class CurrencyPalette {
+  const CurrencyPalette._();
+
+  static const _expiredLight = CurrencyStatusColors(
+    accent: Color(0xFFBE222A),
+    text: Color(0xFF861118),
+    fill: Color(0xFFC92F33),
+    cardBackground: Color(0xFFFFE9E6),
+    cardBorder: Color(0xFFFFCCC7),
+  );
+
+  static const _expiredDark = CurrencyStatusColors(
+    accent: Color(0xFFF97770),
+    text: Color(0xFFFFC6C0),
+    fill: Color(0xFFF66D67),
+    cardBackground: Color(0xFF421C19),
+    cardBorder: Color(0xFF6C3531),
+  );
+
+  static const _dueSoonLight = CurrencyStatusColors(
+    accent: Color(0xFFB86B00),
+    text: Color(0xFF5B2D00),
+    fill: Color(0xFFCC8730),
+    cardBackground: Color(0xFFFFEFD5),
+    cardBorder: Color(0xFFEFD3AC),
+  );
+
+  static const _dueSoonDark = CurrencyStatusColors(
+    accent: Color(0xFFE7A04C),
+    text: Color(0xFFF1D2AD),
+    fill: Color(0xFFEAA85D),
+    cardBackground: Color(0xFF382409),
+    cardBorder: Color(0xFF573C1C),
+  );
+
+  /// The "DUE SOON" mono label itself uses a third amber shade in the
+  /// source mockup — distinct from both [_dueSoonLight]'s accent (the dot)
+  /// and text (the title) colours. Nothing else needs this one, so it
+  /// isn't a [CurrencyStatusColors] field of its own.
+  static const dueSoonLabelLight = Color(0xFF854F15);
+  static const dueSoonLabelDark = Color(0xFFDFB585);
+
+  static const _healthyFillLight = Color(0xFF008053);
+  static const _healthyFillDark = Color(0xFF57BC8A);
+
+  static CurrencyStatusColors expired(Brightness brightness) =>
+      brightness == Brightness.dark ? _expiredDark : _expiredLight;
+
+  static CurrencyStatusColors dueSoon(Brightness brightness) =>
+      brightness == Brightness.dark ? _dueSoonDark : _dueSoonLight;
+
+  static Color dueSoonLabel(Brightness brightness) =>
+      brightness == Brightness.dark ? dueSoonLabelDark : dueSoonLabelLight;
+
+  static Color healthyFill(Brightness brightness) =>
+      brightness == Brightness.dark ? _healthyFillDark : _healthyFillLight;
+}

--- a/lib/ui/currency/sample_currency_data.dart
+++ b/lib/ui/currency/sample_currency_data.dart
@@ -1,0 +1,245 @@
+import '../../domain/currency/currency_dashboard.dart';
+import '../../domain/currency/evaluation_subject.dart';
+import '../../domain/currency/held_record.dart';
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/flight.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/pilot_capacity.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/pilot_record/held_qualification_records.dart';
+import '../../domain/pilot_record/held_rating.dart';
+import '../../domain/pilot_record/medical_certificate.dart';
+import '../../domain/pilot_record/medical_certificate_validity.dart';
+import '../../domain/pilot_record/pilot_profile.dart';
+import '../../domain/repository/flight_read_repository.dart';
+
+/// Sample data for the Currency screen, standing in for real repository
+/// wiring — the same convention `sample_logbook_data.dart` and
+/// `sample_fleet_data.dart` already established, pending #56's live data
+/// wiring. Every date below is computed relative to [CalendarDate today]
+/// rather than hard-coded, so the deliberately-crafted spread of currency
+/// states (satisfied, due soon, expired, in grace) stays correct no matter
+/// when the app happens to run.
+///
+/// **Which rules apply to which licence is fixture-picked, not resolved
+/// from held ratings.** No domain concept of "which currency rules apply to
+/// what a pilot holds" exists yet (a pilot without a tailwheel endorsement,
+/// for instance, should never see tailwheel currency at all) — this hand
+/// picks a subset consistent with the sample pilot's own held ratings,
+/// standing in for a real resolver that's Settings-phase work.
+const samplePilotProfile = PilotProfile(
+  dateOfBirth: CalendarDate(1985, 6, 15),
+  primaryJurisdictionId: 'eu.easa.part-fcl',
+);
+
+const sampleAircraft = Aircraft(
+  registration: 'G-ABCD',
+  manufacturer: 'Cessna',
+  model: '172S',
+  icaoTypeDesignator: 'C172',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+const _picCapacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+/// EASA and FAA licence descriptors — see this file's own dartdoc for why
+/// [CurrencyLicenceSpec.privilegeSummary] and `ruleIds` are hand-written
+/// rather than derived.
+const sampleCurrencyLicences = [
+  CurrencyLicenceSpec(
+    jurisdictionId: 'eu.easa.part-fcl',
+    label: 'EASA',
+    isPrimary: true,
+    privilegeSummary: 'PPL(A) · SEP (land)',
+    ruleIds: [
+      'easa.fcl060.b1_passenger_recency',
+      'eu.easa.fcl740a.sep_land_revalidation',
+      'eu.easa.med_a045.class2_validity',
+    ],
+  ),
+  CurrencyLicenceSpec(
+    jurisdictionId: 'us.faa.part61',
+    label: 'FAA',
+    isPrimary: false,
+    privilegeSummary: 'PPL ASEL',
+    ruleIds: [
+      'us.faa.61_57_a.takeoff_landing_currency',
+      'us.faa.61_57_c.instrument_currency',
+      'us.faa.61_57_c.instrument_currency_grace_period',
+      'us.faa.61_56.flight_review',
+      'us.faa.61_23.third_class_medical_validity',
+    ],
+  ),
+];
+
+Flight _sampleFlight({
+  required CalendarDate date,
+  CircuitCounts? landings,
+  CircuitCounts? takeoffs,
+  List<Approach> approaches = const [],
+  int holdingProceduresCount = 0,
+  bool trackingPerformed = false,
+  Set<AlternativeComplianceEvent> alternativeComplianceEvents = const {},
+}) {
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
+  return Flight(
+    aircraftRegistration: sampleAircraft.registration,
+    route: const ['EGKA', 'EGKA'],
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(const Duration(hours: 1)),
+    capacity: _picCapacity,
+    carryingPassengers: false,
+    takeoffs: takeoffs ?? const CircuitCounts(),
+    landings: landings ?? const CircuitCounts(),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: approaches,
+    holdingProceduresCount: holdingProceduresCount,
+    trackingPerformed: trackingPerformed,
+    alternativeComplianceEvents: alternativeComplianceEvents,
+    remarks: '',
+  );
+}
+
+/// This pilot's flights, deliberately chosen to exercise a spread of
+/// currency states rather than an all-green dashboard:
+/// - 10 days ago: 12 landings + 4 takeoffs, deliberately overshooting both
+///   rules that read it, at two different margins: EASA passenger recency
+///   (landings only, needs 3) shows the big "12 / 3" overshoot; FAA
+///   take-off/landing currency (an `allOf` of both counts, represented by
+///   whichever leaf has the *tighter* ratio) is instead capped by its
+///   takeoffs leaf at "4 / 3" — the mockup's own "4 of 3" example — since
+///   4/3 (1.33×) is a tighter margin than landings' 12/3 (4×). One flight,
+///   two different overshoot magnitudes, each genuinely computed rather
+///   than hand-set per row.
+/// - 60 days ago: an EASA class-rating proficiency check — satisfies SEP
+///   (land) revalidation via `FCL.740.A(b)(1)(ii)`'s alternative branch,
+///   comfortably (`RuleWindow.expiryFrom` projects a fresh ~12-month
+///   currency window forward from *this occurrence's own date*, not from
+///   the rating's stated expiry — see [sampleHeldRatings]'s own note).
+/// - ~8 months ago: 6 approaches, a holding procedure and course tracking —
+///   inside FAA instrument currency's 12-month grace window but outside its
+///   ordinary 6-month one, so the two rows land in different states.
+/// - exactly 730 days ago (the earliest date the rule's own 24-month
+///   window still counts): an FAA flight review — lands its `expiryFrom`
+///   projection inside the hero row's 30-day window, the screen's "DUE
+///   SOON" example (see the flight's own comment below for the exact
+///   mechanics).
+List<FlightRecord> sampleCurrencyFlights(CalendarDate today) => [
+  FlightRecord(
+    id: 'sample-currency-1',
+    flight: _sampleFlight(
+      date: today.addDays(-10),
+      takeoffs: const CircuitCounts(dayFullStop: 4),
+      landings: const CircuitCounts(dayFullStop: 12),
+    ),
+    aircraft: sampleAircraft,
+  ),
+  FlightRecord(
+    id: 'sample-currency-2',
+    flight: _sampleFlight(
+      date: today.addDays(-60),
+      alternativeComplianceEvents: const {
+        AlternativeComplianceEvent.easaClassRatingProficiencyCheck,
+      },
+    ),
+    aircraft: sampleAircraft,
+  ),
+  FlightRecord(
+    id: 'sample-currency-3',
+    flight: _sampleFlight(
+      date: today.addDays(-240),
+      approaches: const [
+        Approach(
+          type: ApproachType.ils,
+          aerodromeIcao: 'EGKA',
+          runway: '02',
+          count: 6,
+        ),
+      ],
+      holdingProceduresCount: 1,
+      trackingPerformed: true,
+    ),
+    aircraft: sampleAircraft,
+  ),
+  FlightRecord(
+    id: 'sample-currency-4',
+    // `RuleWindow.expiryFrom` projects forward from the *occurrence's own*
+    // date by the window's month count (24), not from today — a flight
+    // review flown exactly 730 days ago (the earliest date that still
+    // counts inside the rule's own 24-calendar-month window) keeps this
+    // rule current only through the last day of the same calendar month
+    // two years on, which lands inside the hero row's 30-day window
+    // relative to `today`. This is the screen's "DUE SOON" example, next
+    // to instrument currency's "EXPIRED" one.
+    flight: _sampleFlight(
+      date: today.addDays(-730),
+      alternativeComplianceEvents: const {
+        AlternativeComplianceEvent.faaFlightReview,
+      },
+    ),
+    aircraft: sampleAircraft,
+  ),
+];
+
+/// The SEP(land) class rating — stated to expire 25 days from [today],
+/// though the revalidation rule itself doesn't land near that date; see the
+/// proficiency-check flight's own comment above for why.
+List<HeldRating> sampleHeldRatings(CalendarDate today) => [
+  HeldRating(
+    kind: HeldRatingKind.classRating,
+    designator: 'SEP(land)',
+    jurisdictionId: 'eu.easa.part-fcl',
+    issueDate: today.addDays(-700),
+    expiryDate: today.addDays(25),
+  ),
+];
+
+List<MedicalCertificate> sampleMedicalCertificates(CalendarDate today) => [
+  MedicalCertificate(
+    certificateClass: MedicalCertificateClass.easaClass2,
+    jurisdictionId: 'eu.easa.part-fcl',
+    issueDate: today.addDays(-300),
+  ),
+  MedicalCertificate(
+    certificateClass: MedicalCertificateClass.faaThirdClass,
+    jurisdictionId: 'us.faa.part61',
+    issueDate: today.addDays(-200),
+  ),
+];
+
+/// One [EvaluationSubject], shared by both licences: a flight's raw facts
+/// don't change depending on which jurisdiction is asking about them, and
+/// [sampleAircraft] is the one aircraft both licences' rules reference —
+/// see `currency_dashboard.dart`'s own note on why a dashboard-wide view
+/// evaluates against a single representative aircraft rather than one per
+/// rule.
+EvaluationSubject sampleEvaluationSubject(CalendarDate today) {
+  final heldRecords = <HeldRecord>[
+    for (final rating in sampleHeldRatings(today)) heldRatingHeldRecord(rating),
+    for (final certificate in sampleMedicalCertificates(today))
+      medicalCertificateHeldRecord(certificate, samplePilotProfile.dateOfBirth),
+  ];
+  return EvaluationSubject(
+    flights: sampleCurrencyFlights(today),
+    referenceAircraft: sampleAircraft,
+    heldRecords: heldRecords,
+  );
+}

--- a/lib/ui/currency/widgets/currency_hero_card.dart
+++ b/lib/ui/currency/widgets/currency_hero_card.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/currency/currency_dashboard.dart';
+import '../../../domain/model/calendar_date.dart';
+import '../../theme/app_typography.dart';
+import '../currency_status_colors.dart';
+import 'currency_progress_bar.dart';
+import 'currency_rule_row.dart';
+
+/// One at-risk rule, called out in the horizontal-scrolling hero row —
+/// [CurrencyDashboard.atRiskRows] only, so every card here is either
+/// unsatisfied or expiring inside the hero window (never a healthy row).
+///
+/// Colour follows the mockup's hero-card convention (Currency Totals
+/// Settings.dc.html, 2a), which is louder and more uniform than a list
+/// row's: the status dot, the EXPIRED/DUE SOON label and the "Which
+/// flights counted" link all use the state's brightest `accent` shade;
+/// the title, numeric line, tick and footer note all share a single
+/// darker `text` shade; the bar fill gets its own third shade. Unlike a
+/// list row, nothing here stays neutral.
+class CurrencyHeroCard extends StatelessWidget {
+  const CurrencyHeroCard({
+    super.key,
+    required this.row,
+    required this.asOf,
+    required this.onShowContributingFlights,
+  });
+
+  final CurrencyDashboardRow row;
+  final CalendarDate asOf;
+  final ValueChanged<List<String>>? onShowContributingFlights;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final result = row.evaluation.result;
+    final progress = result.progress;
+    final expired = !result.satisfied;
+    final palette = expired
+        ? CurrencyPalette.expired(theme.brightness)
+        : CurrencyPalette.dueSoon(theme.brightness);
+    final labelColor = expired
+        ? palette.accent
+        : CurrencyPalette.dueSoonLabel(theme.brightness);
+    final expiresOn = result.expiresOn;
+    final contributingFlightIds = result.contributingFlightIds;
+
+    return Container(
+      width: 330,
+      padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 13),
+      decoration: BoxDecoration(
+        color: palette.cardBackground,
+        border: Border.all(color: palette.cardBorder),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: palette.accent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 7),
+              Text(
+                expired ? 'EXPIRED' : 'DUE SOON',
+                style: AppMonoText.tag(labelColor).copyWith(letterSpacing: 1.2),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            row.title,
+            style: theme.textTheme.titleMedium?.copyWith(color: palette.text),
+          ),
+          if (progress != null) ...[
+            const SizedBox(height: 12),
+            Builder(
+              builder: (context) {
+                final fillAndTick = currencyProgressFillAndTick(progress, asOf);
+                return CurrencyProgressBar(
+                  fill: fillAndTick.fill,
+                  tick: fillAndTick.tick,
+                  fillColor: palette.fill,
+                  tickColor: palette.text,
+                );
+              },
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  currencyNumericLine(progress, asOf),
+                  style: AppMonoText.value(palette.text, size: 11.5),
+                ),
+                if (expiresOn != null)
+                  Text(
+                    'expires $expiresOn',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: palette.text,
+                    ),
+                  ),
+              ],
+            ),
+          ],
+          const SizedBox(height: 11),
+          Container(height: 1, color: palette.cardBorder),
+          const SizedBox(height: 10),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  result.explanation,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: palette.text,
+                  ),
+                ),
+              ),
+              if (contributingFlightIds.isNotEmpty &&
+                  onShowContributingFlights != null) ...[
+                const SizedBox(width: 8),
+                InkWell(
+                  onTap: () =>
+                      onShowContributingFlights!(contributingFlightIds),
+                  child: Text(
+                    'Which flights counted →',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: palette.accent,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/currency/widgets/currency_progress_bar.dart
+++ b/lib/ui/currency/widgets/currency_progress_bar.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/currency/rule_result.dart';
+import '../../../domain/model/calendar_date.dart';
+import '../../theme/app_colors.dart';
+
+/// Fill fraction and tick position for [progress], per the design's own
+/// caption: fill is what you have, the tick is what the rule wants.
+///
+/// [RuleProgressKind.count]/[RuleProgressKind.hours] normalize against
+/// `max(current, required, 1)` rather than clamping the fill at 1.0 — an
+/// overshoot (4 of 3 landings) still fits on the bar this way, with the
+/// tick sitting short of the fill's full width, instead of losing the
+/// overshoot entirely.
+///
+/// [RuleProgressKind.validity] has no threshold to tick — it fills by how
+/// much of its own validity span has elapsed as of [asOf]; never expiring
+/// (`validUntil == null`) reads as a full bar.
+({double fill, double? tick}) currencyProgressFillAndTick(
+  RuleProgress progress,
+  CalendarDate asOf,
+) {
+  switch (progress.kind) {
+    case RuleProgressKind.count:
+      final current = progress.currentCount!;
+      final required = progress.requiredCount!;
+      final scale = [current, required, 1].reduce((a, b) => a > b ? a : b);
+      return (fill: current / scale, tick: required / scale);
+
+    case RuleProgressKind.hours:
+      final current = progress.currentHours!.inMinutes;
+      final required = progress.requiredHours!.inMinutes;
+      final scale = [current, required, 1].reduce((a, b) => a > b ? a : b);
+      return (fill: current / scale, tick: required / scale);
+
+    case RuleProgressKind.validity:
+      final validFrom = progress.validFrom!;
+      final validUntil = progress.validUntil;
+      if (validUntil == null) return (fill: 1, tick: null);
+      final totalDays = validUntil.differenceInDays(validFrom);
+      if (totalDays <= 0) return (fill: 1, tick: null);
+      final elapsedDays = asOf.differenceInDays(validFrom);
+      return (fill: (elapsedDays / totalDays).clamp(0, 1), tick: null);
+  }
+}
+
+/// The horizontal fill-and-tick bar every currency row and hero card
+/// shows — see [currencyProgressFillAndTick] for what [fill]/[tick] mean.
+///
+/// [tickColor] defaults to the neutral ink the mockup's *list rows* use for
+/// every tick regardless of state (a flagged row's bar fill is coloured,
+/// its tick never is) — hero cards pass their state's own `text` shade
+/// instead, since the mockup ticks those to match the surrounding copy.
+class CurrencyProgressBar extends StatelessWidget {
+  const CurrencyProgressBar({
+    super.key,
+    required this.fill,
+    this.tick,
+    required this.fillColor,
+    this.tickColor,
+  });
+
+  final double fill;
+  final double? tick;
+  final Color fillColor;
+  final Color? tickColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final track = Theme.of(context).colorScheme.outlineVariant;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return SizedBox(
+          height: 9,
+          width: width,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: track,
+                  borderRadius: BorderRadius.circular(5),
+                ),
+              ),
+              FractionallySizedBox(
+                widthFactor: fill.clamp(0, 1).toDouble(),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: fillColor,
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                ),
+              ),
+              if (tick != null)
+                Positioned(
+                  left: (width * tick!.clamp(0, 1)) - 1,
+                  top: -2,
+                  bottom: -2,
+                  child: Container(
+                    width: 2,
+                    decoration: BoxDecoration(
+                      color: tickColor ?? context.inkTiers.medium,
+                      borderRadius: BorderRadius.circular(1),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/currency/widgets/currency_rule_row.dart
+++ b/lib/ui/currency/widgets/currency_rule_row.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/currency/currency_dashboard.dart';
+import '../../../domain/currency/rule_result.dart';
+import '../../../domain/model/calendar_date.dart';
+import '../../theme/app_colors.dart';
+import '../../theme/app_typography.dart';
+import '../currency_status_colors.dart';
+import 'currency_progress_bar.dart';
+
+/// The "current / required" (or "days remaining") readout next to a
+/// progress bar — [RuleProgressKind.validity] has no threshold, so it falls
+/// back to a bare day count instead of a fraction.
+String currencyNumericLine(RuleProgress progress, CalendarDate asOf) {
+  switch (progress.kind) {
+    case RuleProgressKind.count:
+      return '${progress.currentCount} / ${progress.requiredCount}';
+    case RuleProgressKind.hours:
+      return '${progress.currentHours!.toHoursMinutes()} / '
+          '${progress.requiredHours!.toHoursMinutes()} hours';
+    case RuleProgressKind.validity:
+      final until = progress.validUntil;
+      if (until == null) return 'no expiry';
+      final days = until.differenceInDays(asOf);
+      return '$days days remaining';
+  }
+}
+
+/// One evaluated currency rule, as a row inside its licence's card —
+/// title + expiry date/day-count, the fill/tick progress bar when
+/// [RuleResult.progress] has one, and a value/context-note line below.
+///
+/// Structure and colour follow the mockup's own list-row convention
+/// (Currency Totals Settings.dc.html, 2a) precisely: the title and the
+/// numeric value stay neutral ink *even on a flagged row* — only the
+/// left accent bar, the row's faint tint, the bar's fill, and the trailing
+/// context note pick up the state colour. A row is tappable (revealing
+/// which flights counted, via [onShowContributingFlights]) rather than
+/// carrying a visible link, since the mockup's rows have no such link —
+/// only its hero cards do.
+class CurrencyRuleRow extends StatelessWidget {
+  const CurrencyRuleRow({
+    super.key,
+    required this.row,
+    required this.asOf,
+    required this.onShowContributingFlights,
+  });
+
+  final CurrencyDashboardRow row;
+  final CalendarDate asOf;
+
+  /// Called with [RuleResult.contributingFlightIds] when the pilot taps
+  /// the row — null (or an empty contributing list) leaves the row inert.
+  final ValueChanged<List<String>>? onShowContributingFlights;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final brightness = theme.brightness;
+    final result = row.evaluation.result;
+    final progress = result.progress;
+
+    final Color fillColor;
+    final Color? flagColor;
+    if (!result.satisfied) {
+      final palette = CurrencyPalette.expired(brightness);
+      fillColor = palette.fill;
+      flagColor = palette.accent;
+    } else if (row.isAtRisk) {
+      final palette = CurrencyPalette.dueSoon(brightness);
+      fillColor = palette.fill;
+      flagColor = palette.accent;
+    } else {
+      fillColor = CurrencyPalette.healthyFill(brightness);
+      flagColor = null;
+    }
+
+    final expiresOn = result.expiresOn;
+    final contributingFlightIds = result.contributingFlightIds;
+    final canDrillDown =
+        contributingFlightIds.isNotEmpty && onShowContributingFlights != null;
+
+    final content = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      decoration: flagColor == null
+          ? null
+          : BoxDecoration(
+              color: flagColor.withValues(alpha: 0.05),
+              border: Border(left: BorderSide(color: flagColor, width: 3)),
+            ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(row.title, style: theme.textTheme.titleSmall),
+              ),
+              const SizedBox(width: 10),
+              if (expiresOn != null)
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '$expiresOn ',
+                        style: AppMonoText.value(ink.muted, size: 11.5),
+                      ),
+                      TextSpan(
+                        text: '(${expiresOn.differenceInDays(asOf)})',
+                        style: AppMonoText.value(ink.faint, size: 11.5),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 9),
+          if (progress != null) ...[
+            Builder(
+              builder: (context) {
+                final fillAndTick = currencyProgressFillAndTick(progress, asOf);
+                return CurrencyProgressBar(
+                  fill: fillAndTick.fill,
+                  tick: fillAndTick.tick,
+                  fillColor: fillColor,
+                );
+              },
+            ),
+            const SizedBox(height: 7),
+          ],
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              if (progress != null)
+                Text(
+                  currencyNumericLine(progress, asOf),
+                  style: AppMonoText.value(ink.medium, size: 11.5),
+                ),
+              const SizedBox(width: 10),
+              if (_noteText(progress, result) case final note?)
+                Expanded(
+                  child: Text(
+                    note,
+                    textAlign: TextAlign.right,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: flagColor ?? ink.muted,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    if (!canDrillDown) return content;
+    return InkWell(
+      onTap: () => onShowContributingFlights!(contributingFlightIds),
+      child: content,
+    );
+  }
+
+  /// The trailing context note, or null to omit it entirely.
+  ///
+  /// A satisfied [RuleProgressKind.validity] row's own
+  /// [RuleResult.explanation] is just `Currently-valid "$kind" held...` —
+  /// a raw [HeldRecord.kind] identifier restating the date already shown
+  /// above it, not genuine context. The mockup's own validity-style rows
+  /// (a medical certificate, a rating with no activity requirement) carry
+  /// a short, real note instead ("issued 14 Mar 2025") that this domain
+  /// data doesn't have a source for yet, so omitting the row is more
+  /// honest than showing an internal string in its place.
+  String? _noteText(RuleProgress? progress, RuleResult result) {
+    if (progress?.kind == RuleProgressKind.validity && result.satisfied) {
+      return null;
+    }
+    return result.explanation;
+  }
+}

--- a/lib/ui/entry/entry_form_types.dart
+++ b/lib/ui/entry/entry_form_types.dart
@@ -1,0 +1,86 @@
+/// Small UI-only vocabulary shared across the entry form's crew widgets and
+/// its draft-[Flight] mapper (`flight_draft_mapper.dart`). None of these are
+/// domain types — they're the *questions the form asks*, not the raw facts
+/// those answers resolve to. See `docs/entry-form.md` §4 and
+/// `lib/domain/model/pilot_capacity.dart`'s dartdoc for why the domain model
+/// itself has no such enums.
+library;
+
+/// §4B: "What was the arrangement?" — the EASA dual/SPIC discriminator.
+enum InstructorArrangement {
+  receivingInstruction,
+  inCommandObserving;
+
+  String get label => switch (this) {
+    InstructorArrangement.receivingInstruction => 'I was receiving instruction',
+    InstructorArrangement.inCommandObserving =>
+      'I was in command, instructor observing only',
+  };
+}
+
+/// §4C: "Who was in command?"
+enum CommandChoice {
+  me,
+  otherPilot;
+
+  String get label => switch (this) {
+    CommandChoice.me => 'Me',
+    CommandChoice.otherPilot => 'Other pilot',
+  };
+}
+
+/// §4C: "Who was flying?"
+enum FlyingChoice {
+  me,
+  otherPilot,
+  bothSplit;
+
+  String get label => switch (this) {
+    FlyingChoice.me => 'Me',
+    FlyingChoice.otherPilot => 'Other',
+    FlyingChoice.bothSplit => 'Both — split',
+  };
+}
+
+/// The countersignature block's own choice — always present, never required
+/// to save (§4B/§4C, §8).
+enum SignChoice {
+  now,
+  defer;
+
+  String get label => switch (this) {
+    SignChoice.now => 'Sign now',
+    SignChoice.defer => 'Defer',
+  };
+}
+
+/// §4B purpose-of-flight options, in the order docs/entry-form.md lists them.
+const List<String> flightPurposes = [
+  'Training — general',
+  'Skill test',
+  'Proficiency check',
+  'SEP/TMG revalidation refresher',
+  'FAA flight review (§61.56)',
+  'FAA IPC (§61.57(d))',
+  'Instrument training toward a rating',
+];
+
+/// Purposes that force a remarks entry (§4B), and the note explaining why —
+/// shown under the purpose picker and, when remarks are still empty, as a
+/// warning under the remarks field.
+const Map<String, String> flightPurposeNotes = {
+  'SEP/TMG revalidation refresher':
+      'Instructor name and signature are mandatory in remarks under '
+      'AMC1 FCL.050. This entry also feeds the SEP revalidation rule.',
+  'Skill test': 'Examiner number, result and a remarks entry are required.',
+  'Proficiency check':
+      'Examiner number, result, rating affected and a remarks entry are '
+      'required.',
+  'Instrument training toward a rating':
+      'A remarks entry is mandatory under AMC1 FCL.050.',
+};
+
+/// Purposes administered by an examiner rather than an ordinary instructor —
+/// drives whether the examiner-number/result/rating-affected fields show.
+bool purposeHasExaminer(String? purpose) =>
+    purpose == 'Skill test' || purpose == 'Proficiency check';

--- a/lib/ui/entry/flight_draft_mapper.dart
+++ b/lib/ui/entry/flight_draft_mapper.dart
@@ -1,0 +1,288 @@
+/// Builds a draft [Flight] from the entry form's raw UI state, so the
+/// derivation strip (docs/entry-form.md §7) can run it through the real
+/// [JurisdictionProjection]s instead of re-deriving PIC/dual/SPIC/PICUS
+/// logic in the UI layer — CLAUDE.md's whole point about
+/// `domain/projection/` existing in the first place.
+///
+/// This mapping only ever *reads* form state; it never writes it. Whether
+/// the result is fit to persist (required fields present, block time
+/// non-negative, ...) is a separate, later concern — #56 wires up an actual
+/// save.
+library;
+
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/countersignature.dart';
+import '../../domain/model/flight.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/instructor_presence.dart';
+import '../../domain/model/pilot_capacity.dart';
+import '../../domain/model/utc_instant.dart';
+import 'entry_form_types.dart';
+import 'widgets/crew/crew_selection.dart' show CrewSelection;
+
+/// Everything the mapper needs, gathered from `NewFlightScreen`'s state.
+/// A plain data holder, not a form-state manager — the screen still owns
+/// every field independently; this is just the snapshot passed to
+/// [buildDraftFlight] on each rebuild.
+class DraftFlightInputs {
+  const DraftFlightInputs({
+    required this.aircraft,
+    required this.route,
+    required this.offBlocks,
+    required this.onBlocks,
+    this.takeoff,
+    this.landing,
+    required this.crew,
+    required this.isStudent,
+    required this.soloEndorsementHeld,
+    required this.endorsingInstructorName,
+    required this.arrangement,
+    required this.instructorName,
+    required this.instructorLicence,
+    this.instructorCredentialExpiry,
+    required this.purpose,
+    required this.instructorSoleManipulator,
+    this.instructorManipulationTime,
+    required this.instructorPassengers,
+    required this.command,
+    required this.flying,
+    required this.otherPilotName,
+    required this.otherPilotLicence,
+    required this.multiPilotOperation,
+    this.otherPilotRole,
+    required this.picusClaimed,
+    required this.picInterventionNotRequired,
+    this.otherManipulationTime,
+    required this.otherPilotPassengers,
+    required this.sign,
+    this.signedAt,
+    required this.ifrFlightPlanFiled,
+    required this.actualInstrumentTime,
+    required this.simulatedInstrumentTime,
+    required this.approaches,
+    required this.holdingProceduresCount,
+    required this.trackingPerformed,
+    required this.takeoffs,
+    required this.landings,
+    required this.remarks,
+  });
+
+  final Aircraft aircraft;
+  final List<String> route;
+  final UtcInstant offBlocks;
+  final UtcInstant onBlocks;
+  final UtcInstant? takeoff;
+  final UtcInstant? landing;
+
+  final CrewSelection crew;
+  final bool isStudent;
+  final bool soloEndorsementHeld;
+  final String endorsingInstructorName;
+
+  final InstructorArrangement arrangement;
+  final String instructorName;
+  final String instructorLicence;
+  final CalendarDateInput? instructorCredentialExpiry;
+  final String? purpose;
+  final bool instructorSoleManipulator;
+  final FlightDuration? instructorManipulationTime;
+  final bool instructorPassengers;
+
+  final CommandChoice command;
+  final FlyingChoice flying;
+  final String otherPilotName;
+  final String otherPilotLicence;
+  final bool multiPilotOperation;
+  final OtherPilotRole? otherPilotRole;
+  final bool picusClaimed;
+  final bool picInterventionNotRequired;
+  final FlightDuration? otherManipulationTime;
+  final bool otherPilotPassengers;
+
+  final SignChoice sign;
+  final UtcInstant? signedAt;
+
+  final bool ifrFlightPlanFiled;
+  final FlightDuration actualInstrumentTime;
+  final FlightDuration simulatedInstrumentTime;
+  final List<Approach> approaches;
+  final int holdingProceduresCount;
+  final bool trackingPerformed;
+
+  final CircuitCounts takeoffs;
+  final CircuitCounts landings;
+
+  final String remarks;
+}
+
+/// A calendar-date-shaped input the UI collects as a plain `DateTime` (from
+/// `showDatePicker`) — kept separate from [CalendarDate] itself so this file
+/// doesn't need to import `flutter/material.dart`.
+typedef CalendarDateInput = (int year, int month, int day);
+
+/// Builds the [PilotCapacity] + [Flight] the entry form's answers describe so
+/// far. Returns `null` when there isn't enough to project yet — the
+/// derivation strip then falls back to showing block time alone, exactly as
+/// it did before any crew answer was given.
+Flight? buildDraftFlight(DraftFlightInputs input) {
+  final capacity = _buildCapacity(input);
+  if (capacity == null) return null;
+
+  return Flight(
+    aircraftRegistration: input.aircraft.registration,
+    route: input.route,
+    // No UI for this yet — docs/entry-form.md §4 note: unbackfillable if
+    // omitted, but nothing downstream (this screen's derivation strip) reads
+    // cross-country time, so leaving it false here doesn't silently corrupt
+    // anything a pilot would see today.
+    prePlannedNavigation: false,
+    offBlocks: input.offBlocks,
+    onBlocks: input.onBlocks,
+    takeoff: input.takeoff,
+    landing: input.landing,
+    capacity: capacity,
+    otherPilotName: input.otherPilotName.isEmpty ? null : input.otherPilotName,
+    otherPilotCredentialNumber: input.otherPilotLicence.isEmpty
+        ? null
+        : input.otherPilotLicence,
+    carryingPassengers: switch (input.crew) {
+      CrewSelection.justMe => false,
+      CrewSelection.withInstructor => input.instructorPassengers,
+      CrewSelection.withOtherPilot => input.otherPilotPassengers,
+      CrewSelection.withPassengers => true,
+    },
+    takeoffs: input.takeoffs,
+    landings: input.landings,
+    ifrFlightPlanFiled: input.ifrFlightPlanFiled,
+    actualInstrumentTime: input.actualInstrumentTime,
+    simulatedInstrumentTime: input.simulatedInstrumentTime,
+    approaches: input.approaches,
+    holdingProceduresCount: input.holdingProceduresCount,
+    trackingPerformed: input.trackingPerformed,
+    remarks: input.remarks,
+  );
+}
+
+PilotCapacity? _buildCapacity(DraftFlightInputs input) {
+  switch (input.crew) {
+    case CrewSelection.justMe:
+      return PilotCapacity(
+        commandAuthority: true,
+        soleManipulator: true,
+        soleOccupant: true,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+        soloEndorsementHeld: input.isStudent ? input.soloEndorsementHeld : null,
+        endorsingInstructorName: input.isStudent
+            ? _orNull(input.endorsingInstructorName)
+            : null,
+      );
+
+    case CrewSelection.withInstructor:
+      final receiving =
+          input.arrangement == InstructorArrangement.receivingInstruction;
+      final instructor = InstructorPresence(
+        capacity: purposeHasExaminer(input.purpose)
+            ? InstructorCapacity.flightExaminer
+            : InstructorCapacity.flightInstructor,
+        influencedFlight: receiving,
+        name: _orNull(input.instructorName),
+        credentialNumber: _orNull(input.instructorLicence),
+        credentialExpiry: _calendarDate(input.instructorCredentialExpiry),
+      );
+      return PilotCapacity(
+        commandAuthority: !receiving,
+        soleManipulator: receiving ? input.instructorSoleManipulator : true,
+        soleOccupant: false,
+        multiPilotOperation: input.aircraft.requiresMultiCrew,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+        manipulationTime: receiving && !input.instructorSoleManipulator
+            ? input.instructorManipulationTime
+            : null,
+        instructor: instructor,
+        countersignature: _countersignature(
+          input.sign,
+          input.signedAt,
+          signatoryName: input.instructorName,
+          signatoryCredentialNumber: input.instructorLicence,
+        ),
+      );
+
+    case CrewSelection.withOtherPilot:
+      final commandMe = input.command == CommandChoice.me;
+      final flyingMe = input.flying == FlyingChoice.me;
+      final canClaimPicus =
+          (input.multiPilotOperation || input.aircraft.requiresMultiCrew) &&
+          !commandMe;
+      final picus = canClaimPicus && input.picusClaimed;
+      return PilotCapacity(
+        commandAuthority: commandMe,
+        soleManipulator: flyingMe,
+        soleOccupant: false,
+        multiPilotOperation:
+            input.multiPilotOperation || input.aircraft.requiresMultiCrew,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: picus,
+        picInterventionNotRequired: picus && input.picInterventionNotRequired,
+        manipulationTime: input.flying == FlyingChoice.bothSplit
+            ? input.otherManipulationTime
+            : null,
+        otherPilotRole: input.otherPilotRole,
+        countersignature: picus
+            ? _countersignature(
+                input.sign,
+                input.signedAt,
+                signatoryName: input.otherPilotName,
+                signatoryCredentialNumber: input.otherPilotLicence,
+              )
+            : null,
+      );
+
+    case CrewSelection.withPassengers:
+      return const PilotCapacity(
+        commandAuthority: true,
+        soleManipulator: true,
+        soleOccupant: false,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+      );
+  }
+}
+
+Countersignature _countersignature(
+  SignChoice sign,
+  UtcInstant? signedAt, {
+  required String signatoryName,
+  required String signatoryCredentialNumber,
+}) {
+  return Countersignature(
+    status: sign == SignChoice.now
+        ? CountersignatureStatus.signed
+        : CountersignatureStatus.pending,
+    signatoryName: _orNull(signatoryName),
+    signatoryCredentialNumber: _orNull(signatoryCredentialNumber),
+    signedAt: sign == SignChoice.now ? signedAt : null,
+  );
+}
+
+String? _orNull(String value) => value.isEmpty ? null : value;
+
+CalendarDate? _calendarDate(CalendarDateInput? input) {
+  if (input == null) return null;
+  return CalendarDate(input.$1, input.$2, input.$3);
+}

--- a/lib/ui/entry/new_flight_screen.dart
+++ b/lib/ui/entry/new_flight_screen.dart
@@ -1,17 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
+import '../../domain/jurisdiction/jurisdiction_profile.dart';
+import '../../domain/jurisdiction/jurisdiction_registry.dart';
+import '../../domain/model/aerodrome_directory.dart';
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/flight.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/pilot_capacity.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/primitives/default_primitives.dart';
+import '../../domain/projection/jurisdiction_projection.dart';
+import '../../domain/projection/projection_result.dart';
+import 'entry_form_types.dart';
+import 'flight_draft_mapper.dart';
+import 'sample_fleet_data.dart';
 import 'widgets/aircraft_section.dart';
+import 'widgets/conditions_section.dart';
+import 'widgets/counters_section.dart';
+import 'widgets/crew/crew_form_data.dart';
 import 'widgets/crew/crew_section.dart';
+import 'widgets/crew/crew_selection.dart';
 import 'widgets/date_route_section.dart';
 import 'widgets/entry_footer.dart';
 import 'widgets/entry_top_bar.dart';
+import 'widgets/remarks_section.dart';
 import 'widgets/times_section.dart';
 
-/// #58, direction 2a from the mockups: one literal scroll, sections in the
-/// exact order docs/entry-form.md §1 lists them, derivation strip pinned
-/// above the save controls. This pass covers §1 Aircraft, §1.2 Date &
-/// route, §2 Times and §4 Crew — take-offs/landings (§5), conditions (§6)
-/// and remarks (§7 onward) land in a later pass.
+/// #58/#129, direction 2a from the mockups (Flight Entry Form.dc.html): one
+/// literal scroll, sections in the exact order docs/entry-form.md §1 lists
+/// them, derivation strip pinned above the save controls. Every UI section
+/// through §7 is built; §8 (overrides) and §9 (FSTD, a different form
+/// entirely) are not — see the dartdoc on `flight_draft_mapper.dart` and
+/// `conditions_section.dart` for exactly which pieces are stubbed and why.
 class NewFlightScreen extends StatefulWidget {
   const NewFlightScreen({super.key});
 
@@ -20,26 +41,255 @@ class NewFlightScreen extends StatefulWidget {
 }
 
 class _NewFlightScreenState extends State<NewFlightScreen> {
+  // ---- §1 Aircraft.
   final _registrationController = TextEditingController();
+  final _fleetSearchController = TextEditingController();
+  bool _fleetOpen = false;
+
+  // ---- §1.2 Date & route.
   DateTime _date = DateTime.now();
   final List<TextEditingController> _legControllers = [
     TextEditingController(),
     TextEditingController(),
   ];
+  final List<FocusNode> _legFocusNodes = [FocusNode(), FocusNode()];
 
+  // ---- §2 Times.
   TimeOfDay? _offBlocks;
   TimeOfDay? _onBlocks;
   TimeOfDay? _takeoff;
   TimeOfDay? _landing;
+  String? _blockOverride;
+
+  // ---- §4 Crew.
+  CrewSelection? _crew;
+
+  // 4A.
+  bool _soloEndorsementHeld = true;
+  final _endorsingInstructorController = TextEditingController();
+
+  // 4B.
+  InstructorArrangement _arrangement =
+      InstructorArrangement.receivingInstruction;
+  final _instructorNameController = TextEditingController();
+  final _instructorLicenceController = TextEditingController();
+  DateTime? _instructorCertExpiry;
+  String? _purpose;
+  final _examinerNoController = TextEditingController();
+  String? _result;
+  final _ratingAffectedController = TextEditingController();
+  bool _instructorSoleManipulator = true;
+  final _instructorManipHoursController = TextEditingController();
+  final _instructorManipMinutesController = TextEditingController();
+  bool _instructorPassengers = false;
+
+  // 4C.
+  CommandChoice _command = CommandChoice.me;
+  FlyingChoice _flying = FlyingChoice.me;
+  final _otherPilotNameController = TextEditingController();
+  final _otherPilotLicenceController = TextEditingController();
+  bool _multiPilotOperation = false;
+  final _otherManipHoursController = TextEditingController();
+  final _otherManipMinutesController = TextEditingController();
+  OtherPilotRole? _otherPilotRole;
+  bool _picusClaimed = false;
+  bool _picInterventionNotRequired = false;
+  bool _otherPilotPassengers = false;
+
+  // Countersignature (§4B/§4C, shown from the remarks section).
+  SignChoice _sign = SignChoice.defer;
+  DateTime? _signedAt;
+
+  // ---- §5 Take-offs and landings.
+  int _takeoffsDay = 0;
+  int _takeoffsNight = 0;
+  int _landingsDay = 0;
+  int _landingsNight = 0;
+  int _fullStop = 0;
+
+  // ---- §6 Conditions.
+  final _nightHoursController = TextEditingController();
+  final _nightMinutesController = TextEditingController();
+  bool _ifrFlightPlanFiled = false;
+  final _actualInstHoursController = TextEditingController();
+  final _actualInstMinutesController = TextEditingController();
+  final _simInstHoursController = TextEditingController();
+  final _simInstMinutesController = TextEditingController();
+  final List<Approach> _approaches = [];
+  final List<TextEditingController> _approachIcaoControllers = [];
+  final List<TextEditingController> _approachRunwayControllers = [];
+  int _holdingProceduresCount = 0;
+  bool _trackingPerformed = false;
+
+  // ---- §7 Remarks.
+  final _remarksController = TextEditingController();
+
+  // ---- Held licences. Stubbed until a real pilot-profile/held-ratings
+  // source is read by this screen — see #56/#61, and the equivalent notes
+  // already on `aircraft_section.dart` and `crew_with_instructor.dart`
+  // before this pass. Both true by default (docs' "EASA and FAA" default).
+  final bool _hasEasaLicence = true;
+  final bool _hasFaaLicence = true;
+  final bool _isStudent = false;
+
+  // ---- Jurisdiction projection, loaded once from assets/jurisdictions/.
+  JurisdictionProjection? _easaProjection;
+  JurisdictionProjection? _faaProjection;
+
+  @override
+  void initState() {
+    super.initState();
+    // Every text field below feeds either the draft `Flight` (the
+    // derivation strip, `flight_draft_mapper.dart`) or a conditionally-
+    // rendered field elsewhere on the screen (aircraft resolution, the
+    // safety-pilot toggle gated on simulated instrument time, the remarks-
+    // required note). All of those are read via getters at *build* time —
+    // a `TextEditingController` changing does not, on its own, rebuild the
+    // ancestor `State` that reads it, so every one of these needs a
+    // listener that requests a rebuild. Leg and approach-field controllers
+    // are the exception: their callers already `setState` explicitly
+    // (`_addStop`/`_removeStop`, the `onApproach*Changed` callbacks), so
+    // adding a listener there would only double the rebuild, not fix
+    // anything.
+    for (final c in [
+      _registrationController,
+      _fleetSearchController,
+      _endorsingInstructorController,
+      _instructorNameController,
+      _instructorLicenceController,
+      _examinerNoController,
+      _ratingAffectedController,
+      _instructorManipHoursController,
+      _instructorManipMinutesController,
+      _otherPilotNameController,
+      _otherPilotLicenceController,
+      _otherManipHoursController,
+      _otherManipMinutesController,
+      _nightHoursController,
+      _nightMinutesController,
+      _actualInstHoursController,
+      _actualInstMinutesController,
+      _simInstHoursController,
+      _simInstMinutesController,
+      _remarksController,
+    ]) {
+      c.addListener(_rebuild);
+    }
+    _loadJurisdictions();
+  }
+
+  void _rebuild() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _loadJurisdictions() async {
+    // `cache: false` — `rootBundle` is a process-wide singleton whose
+    // default cache keys a `Future<String>` by asset path. In a widget-test
+    // run that opens this screen more than once, a `Future` first created
+    // in one test's zone never resolves once that test tears down its
+    // message channel, and every later test that asks for the same asset
+    // gets hits that permanently-pending cached `Future` back instead of a
+    // fresh load. Loading is cheap and happens once per screen open either
+    // way, so skipping the cache costs nothing in the real app.
+    final easaYaml = await rootBundle.loadString(
+      'assets/jurisdictions/eu.easa.part-fcl.yaml',
+      cache: false,
+    );
+    final faaYaml = await rootBundle.loadString(
+      'assets/jurisdictions/us.faa.part61.yaml',
+      cache: false,
+    );
+    final registry = JurisdictionRegistry([
+      parseJurisdictionProfileYaml(easaYaml),
+      parseJurisdictionProfileYaml(faaYaml),
+    ]);
+    // No aerodrome data source wired into this screen yet — night/cross-
+    // country quantities will read back as "could not be resolved" rather
+    // than a real figure, which is fine: the derivation strip only shows
+    // pilot-function-time quantities (pic/dual/spic/... and
+    // actingPic/loggedPic/...), none of which touch aerodromes.
+    final aerodromes = AerodromeDirectory(const []);
+    if (!mounted) return;
+    setState(() {
+      _easaProjection = JurisdictionProjection(
+        registry: registry,
+        primitives: defaultPrimitives,
+        aerodromes: aerodromes,
+        jurisdictionId: 'eu.easa.part-fcl',
+      );
+      _faaProjection = JurisdictionProjection(
+        registry: registry,
+        primitives: defaultPrimitives,
+        aerodromes: aerodromes,
+        jurisdictionId: 'us.faa.part61',
+      );
+    });
+  }
 
   @override
   void dispose() {
     _registrationController.dispose();
+    _fleetSearchController.dispose();
     for (final c in _legControllers) {
       c.dispose();
     }
+    for (final f in _legFocusNodes) {
+      f.dispose();
+    }
+    _endorsingInstructorController.dispose();
+    _instructorNameController.dispose();
+    _instructorLicenceController.dispose();
+    _examinerNoController.dispose();
+    _ratingAffectedController.dispose();
+    _instructorManipHoursController.dispose();
+    _instructorManipMinutesController.dispose();
+    _otherPilotNameController.dispose();
+    _otherPilotLicenceController.dispose();
+    _otherManipHoursController.dispose();
+    _otherManipMinutesController.dispose();
+    _nightHoursController.dispose();
+    _nightMinutesController.dispose();
+    _actualInstHoursController.dispose();
+    _actualInstMinutesController.dispose();
+    _simInstHoursController.dispose();
+    _simInstMinutesController.dispose();
+    for (final c in _approachIcaoControllers) {
+      c.dispose();
+    }
+    for (final c in _approachRunwayControllers) {
+      c.dispose();
+    }
+    _remarksController.dispose();
     super.dispose();
   }
+
+  // ---- Derived helpers.
+
+  SampleFleetAircraft? get _resolvedAircraft =>
+      findFleetAircraft(_registrationController.text);
+
+  /// Used for the derivation strip when no registration has resolved yet.
+  /// A generic single-pilot, non-multi-crew aeroplane — the common case,
+  /// and safe because [DraftFlightInputs] only reads
+  /// `Aircraft.requiresMultiCrew` (the 4B/4C multi-pilot pre-fill), which
+  /// this deliberately leaves off rather than on. Requiring a resolved
+  /// registration before showing *any* breakdown was too strict: crew and
+  /// times alone are enough to project PIC/dual/SPIC for the "Just me" and
+  /// "With passengers" paths, which never read the aircraft at all (see
+  /// `flight_draft_mapper.dart`'s `_buildCapacity`).
+  static const _fallbackAircraft = Aircraft(
+    registration: '',
+    manufacturer: '',
+    model: '',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 1,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+  );
+
+  Aircraft get _effectiveAircraft =>
+      _resolvedAircraft?.aircraft ?? _fallbackAircraft;
 
   Duration? get _blockTime {
     final off = _offBlocks;
@@ -50,6 +300,142 @@ class _NewFlightScreenState extends State<NewFlightScreen> {
     if (onMinutes < offMinutes) onMinutes += 24 * 60; // past midnight
     return Duration(minutes: onMinutes - offMinutes);
   }
+
+  String get _blockTimeText {
+    if (_blockOverride?.isNotEmpty == true) return _blockOverride!;
+    final block = _blockTime;
+    if (block == null) return '—:—';
+    return '${block.inHours}:${block.inMinutes.remainder(60).abs().toString().padLeft(2, '0')}';
+  }
+
+  String get _startLabel => switch (_resolvedAircraft?.aircraft.category) {
+    AircraftCategory.helicopter => 'Rotors start',
+    AircraftCategory.airship => 'Released from mast',
+    _ => 'Off blocks',
+  };
+
+  String get _endLabel => switch (_resolvedAircraft?.aircraft.category) {
+    AircraftCategory.helicopter => 'Rotors stop',
+    AircraftCategory.airship => 'Secured on mast',
+    _ => 'On blocks',
+  };
+
+  List<String> get _route => [
+    for (final c in _legControllers) c.text.trim().toUpperCase(),
+  ].where((s) => s.isNotEmpty).toList();
+
+  UtcInstant? _utcOf(TimeOfDay? t) {
+    if (t == null) return null;
+    return UtcInstant.utc(_date.year, _date.month, _date.day, t.hour, t.minute);
+  }
+
+  FlightDuration _durationOf(
+    TextEditingController hours,
+    TextEditingController minutes,
+  ) {
+    final h = int.tryParse(hours.text) ?? 0;
+    final m = int.tryParse(minutes.text) ?? 0;
+    return FlightDuration(h * 60 + m);
+  }
+
+  Flight? get _draftFlight {
+    final off = _utcOf(_offBlocks);
+    final on = _utcOf(_onBlocks);
+    final crew = _crew;
+    if (off == null || on == null || crew == null) {
+      return null;
+    }
+    return buildDraftFlight(
+      DraftFlightInputs(
+        aircraft: _effectiveAircraft,
+        route: _route,
+        offBlocks: off,
+        onBlocks: on,
+        takeoff: _utcOf(_takeoff),
+        landing: _utcOf(_landing),
+        crew: crew,
+        isStudent: _isStudent,
+        soloEndorsementHeld: _soloEndorsementHeld,
+        endorsingInstructorName: _endorsingInstructorController.text,
+        arrangement: _arrangement,
+        instructorName: _instructorNameController.text,
+        instructorLicence: _instructorLicenceController.text,
+        instructorCredentialExpiry: _instructorCertExpiry == null
+            ? null
+            : (
+                _instructorCertExpiry!.year,
+                _instructorCertExpiry!.month,
+                _instructorCertExpiry!.day,
+              ),
+        purpose: _purpose,
+        instructorSoleManipulator: _instructorSoleManipulator,
+        instructorManipulationTime: _durationOf(
+          _instructorManipHoursController,
+          _instructorManipMinutesController,
+        ),
+        instructorPassengers: _instructorPassengers,
+        command: _command,
+        flying: _flying,
+        otherPilotName: _otherPilotNameController.text,
+        otherPilotLicence: _otherPilotLicenceController.text,
+        multiPilotOperation: _multiPilotOperation,
+        otherPilotRole: _otherPilotRole,
+        picusClaimed: _picusClaimed,
+        picInterventionNotRequired: _picInterventionNotRequired,
+        otherManipulationTime: _durationOf(
+          _otherManipHoursController,
+          _otherManipMinutesController,
+        ),
+        otherPilotPassengers: _otherPilotPassengers,
+        sign: _sign,
+        signedAt: _signedAt == null
+            ? null
+            : UtcInstant.fromDateTime(_signedAt!.toUtc()),
+        ifrFlightPlanFiled: _ifrFlightPlanFiled,
+        actualInstrumentTime: _durationOf(
+          _actualInstHoursController,
+          _actualInstMinutesController,
+        ),
+        simulatedInstrumentTime: _durationOf(
+          _simInstHoursController,
+          _simInstMinutesController,
+        ),
+        approaches: List.of(_approaches),
+        holdingProceduresCount: _holdingProceduresCount,
+        trackingPerformed: _trackingPerformed,
+        takeoffs: CircuitCounts(
+          dayFullStop: _takeoffsDay,
+          nightFullStop: _takeoffsNight,
+        ),
+        landings: CircuitCounts(
+          dayFullStop: _landingsDay,
+          nightFullStop: _landingsNight,
+        ),
+        remarks: _remarksController.text,
+      ),
+    );
+  }
+
+  ProjectionResult? get _easaResult {
+    final flight = _draftFlight;
+    if (flight == null || _easaProjection == null) return null;
+    return _easaProjection!.project(flight, _effectiveAircraft);
+  }
+
+  ProjectionResult? get _faaResult {
+    final flight = _draftFlight;
+    if (flight == null || _faaProjection == null) return null;
+    return _faaProjection!.project(flight, _effectiveAircraft);
+  }
+
+  bool get _simulatedInstrumentPresent =>
+      _durationOf(
+        _simInstHoursController,
+        _simInstMinutesController,
+      ).inMinutes >
+      0;
+
+  // ---- Callbacks.
 
   Future<void> _pickDate() async {
     final picked = await showDatePicker(
@@ -63,71 +449,303 @@ class _NewFlightScreenState extends State<NewFlightScreen> {
 
   Future<void> _pickTime(
     ValueChanged<TimeOfDay> onPicked,
-    TimeOfDay? initial,
-  ) async {
+    TimeOfDay? initial, {
+    required String helpText,
+  }) async {
     final picked = await showTimePicker(
       context: context,
       initialTime: initial ?? TimeOfDay.now(),
+      helpText: helpText,
+      // Entry is Zulu, not local (see times_section.dart's dartdoc) — a
+      // 12-hour AM/PM picker would invite exactly the local/UTC confusion
+      // this screen exists to avoid, and aviation time is conventionally
+      // written 24-hour regardless.
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
+        child: child!,
+      ),
     );
     if (picked != null) setState(() => onPicked(picked));
   }
 
+  Future<void> _pickInstructorCertExpiry() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _instructorCertExpiry ?? DateTime.now(),
+      firstDate: DateTime.now(),
+      lastDate: DateTime(DateTime.now().year + 20),
+    );
+    if (picked != null) setState(() => _instructorCertExpiry = picked);
+  }
+
   void _addStop() {
     setState(() {
-      _legControllers.insert(
-        _legControllers.length - 1,
-        TextEditingController(),
-      );
+      final insertAt = _legControllers.length - 1;
+      _legControllers.insert(insertAt, TextEditingController());
+      _legFocusNodes.insert(insertAt, FocusNode());
     });
   }
 
   void _removeStop(int index) {
     setState(() {
       _legControllers.removeAt(index).dispose();
+      _legFocusNodes.removeAt(index).dispose();
+    });
+  }
+
+  void _pickAircraft(SampleFleetAircraft entry) {
+    setState(() {
+      _registrationController.text = entry.registration;
+      _fleetOpen = false;
+      _fleetSearchController.clear();
+      // The multi-pilot toggle pre-fills from the aircraft record and stays
+      // independently overridable — docs/entry-form.md §4C.
+      _multiPilotOperation = entry.aircraft.requiresMultiCrew;
+    });
+  }
+
+  void _addApproach() {
+    setState(() {
+      final prefillIcao = _route.isNotEmpty ? _route.last : '';
+      _approaches.add(
+        Approach(
+          type: ApproachType.rnav,
+          aerodromeIcao: prefillIcao,
+          runway: '',
+          count: 1,
+        ),
+      );
+      _approachIcaoControllers.add(TextEditingController(text: prefillIcao));
+      _approachRunwayControllers.add(TextEditingController());
+    });
+  }
+
+  void _removeApproach(int index) {
+    setState(() {
+      _approaches.removeAt(index);
+      _approachIcaoControllers.removeAt(index).dispose();
+      _approachRunwayControllers.removeAt(index).dispose();
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    final crewData = CrewFormData(
+      crew: _crew,
+      onSelectCrew: (v) => setState(() => _crew = v),
+      isStudent: _isStudent,
+      soloEndorsementHeld: _soloEndorsementHeld,
+      onToggleSoloEndorsement: () =>
+          setState(() => _soloEndorsementHeld = !_soloEndorsementHeld),
+      endorsingInstructorController: _endorsingInstructorController,
+      arrangement: _arrangement,
+      onArrangementChanged: (v) => setState(() => _arrangement = v),
+      spicOffered: true,
+      instructorNameController: _instructorNameController,
+      instructorLicenceController: _instructorLicenceController,
+      hasFaaLicence: _hasFaaLicence,
+      instructorCertExpiry: _instructorCertExpiry,
+      onPickInstructorCertExpiry: _pickInstructorCertExpiry,
+      purpose: _purpose,
+      onPurposeChanged: (v) => setState(() => _purpose = v),
+      examinerNoController: _examinerNoController,
+      result: _result,
+      onResultChanged: (v) => setState(() => _result = v),
+      ratingAffectedController: _ratingAffectedController,
+      instructorSoleManipulator: _instructorSoleManipulator,
+      onToggleInstructorSoleManipulator: () => setState(
+        () => _instructorSoleManipulator = !_instructorSoleManipulator,
+      ),
+      instructorManipHoursController: _instructorManipHoursController,
+      instructorManipMinutesController: _instructorManipMinutesController,
+      instructorPassengers: _instructorPassengers,
+      onToggleInstructorPassengers: () =>
+          setState(() => _instructorPassengers = !_instructorPassengers),
+      command: _command,
+      onCommandChanged: (v) => setState(() => _command = v),
+      flying: _flying,
+      onFlyingChanged: (v) => setState(() => _flying = v),
+      otherPilotNameController: _otherPilotNameController,
+      otherPilotLicenceController: _otherPilotLicenceController,
+      multiPilotOperation: _multiPilotOperation,
+      aircraftRequiresMultiCrew:
+          _resolvedAircraft?.aircraft.requiresMultiCrew ?? false,
+      onToggleMultiPilot: () =>
+          setState(() => _multiPilotOperation = !_multiPilotOperation),
+      otherManipHoursController: _otherManipHoursController,
+      otherManipMinutesController: _otherManipMinutesController,
+      otherPilotRole: _otherPilotRole,
+      onOtherPilotRoleChanged: (v) => setState(() => _otherPilotRole = v),
+      picusClaimed: _picusClaimed,
+      onTogglePicus: () => setState(() => _picusClaimed = !_picusClaimed),
+      picInterventionNotRequired: _picInterventionNotRequired,
+      onTogglePicInterventionNotRequired: () => setState(
+        () => _picInterventionNotRequired = !_picInterventionNotRequired,
+      ),
+      simulatedInstrumentPresent: _simulatedInstrumentPresent,
+      otherPilotPassengers: _otherPilotPassengers,
+      onToggleOtherPilotPassengers: () =>
+          setState(() => _otherPilotPassengers = !_otherPilotPassengers),
+    );
+
+    final showCountersignature =
+        _crew == CrewSelection.withInstructor ||
+        (_crew == CrewSelection.withOtherPilot && _picusClaimed);
+    final signatoryName = _crew == CrewSelection.withInstructor
+        ? _instructorNameController.text
+        : _otherPilotNameController.text;
+    final needsRemarks =
+        _crew == CrewSelection.withInstructor &&
+        (flightPurposeNotes[_purpose] != null);
+
     return Scaffold(
       body: Column(
         children: [
           EntryTopBar(title: 'New flight', onSaveDraft: () {}),
           Expanded(
+            // `padding: zero` — a primary vertical `ListView` otherwise
+            // insets itself by the ambient `MediaQuery.padding` (status bar
+            // height) automatically, on top of what `EntryTopBar`'s own
+            // `SafeArea` already consumed above it. The two together
+            // produced the large blank gap between the top bar and
+            // "Aircraft" reported after the first real-device run.
             child: ListView(
+              padding: EdgeInsets.zero,
               children: [
                 AircraftSection(
                   controller: _registrationController,
-                  resolvedType: null,
+                  resolved: _resolvedAircraft,
+                  fleetOpen: _fleetOpen,
+                  onToggleFleet: () => setState(() {
+                    _fleetOpen = !_fleetOpen;
+                    if (!_fleetOpen) _fleetSearchController.clear();
+                  }),
+                  onFocusRegistration: () => setState(() => _fleetOpen = true),
+                  onPickAircraft: _pickAircraft,
+                  searchController: _fleetSearchController,
                 ),
                 DateRouteSection(
                   date: _date,
                   onTapDate: _pickDate,
                   legControllers: _legControllers,
+                  legFocusNodes: _legFocusNodes,
                   onAddStop: _addStop,
                   onRemoveStop: _removeStop,
                 ),
                 TimesSection(
                   offBlocks: _offBlocks,
                   onBlocks: _onBlocks,
-                  onTapOffBlocks: () =>
-                      _pickTime((t) => _offBlocks = t, _offBlocks),
-                  onTapOnBlocks: () =>
-                      _pickTime((t) => _onBlocks = t, _onBlocks),
+                  onTapOffBlocks: () => _pickTime(
+                    (t) => _offBlocks = t,
+                    _offBlocks,
+                    helpText: '${_startLabel.toUpperCase()} (ZULU)',
+                  ),
+                  onTapOnBlocks: () => _pickTime(
+                    (t) => _onBlocks = t,
+                    _onBlocks,
+                    helpText: '${_endLabel.toUpperCase()} (ZULU)',
+                  ),
                   blockTime: _blockTime,
+                  blockOverrideText: _blockOverride,
+                  onBlockOverrideChanged: (v) =>
+                      setState(() => _blockOverride = v),
+                  startLabel: _startLabel,
+                  endLabel: _endLabel,
                   takeoff: _takeoff,
                   landing: _landing,
-                  onTapTakeoff: () => _pickTime((t) => _takeoff = t, _takeoff),
-                  onTapLanding: () => _pickTime((t) => _landing = t, _landing),
+                  onTapTakeoff: () => _pickTime(
+                    (t) => _takeoff = t,
+                    _takeoff,
+                    helpText: 'TAKE-OFF (ZULU)',
+                  ),
+                  onTapLanding: () => _pickTime(
+                    (t) => _landing = t,
+                    _landing,
+                    helpText: 'LANDING (ZULU)',
+                  ),
                 ),
-                const CrewSection(),
-                // Landings, conditions and remarks land in the next pass —
-                // see the class dartdoc.
+                CrewSection(data: crewData),
+                CountersSection(
+                  takeoffsDay: _takeoffsDay,
+                  takeoffsNight: _takeoffsNight,
+                  landingsDay: _landingsDay,
+                  landingsNight: _landingsNight,
+                  onChangeTakeoffsDay: (v) => setState(() => _takeoffsDay = v),
+                  onChangeTakeoffsNight: (v) =>
+                      setState(() => _takeoffsNight = v),
+                  onChangeLandingsDay: (v) => setState(() => _landingsDay = v),
+                  onChangeLandingsNight: (v) =>
+                      setState(() => _landingsNight = v),
+                  showFullStop: _hasFaaLicence && _landingsNight > 0,
+                  fullStop: _fullStop,
+                  onChangeFullStop: (v) => setState(() => _fullStop = v),
+                ),
+                ConditionsSection(
+                  blockTime: _blockTime,
+                  nightHoursController: _nightHoursController,
+                  nightMinutesController: _nightMinutesController,
+                  hasEasaLicence: _hasEasaLicence,
+                  ifrFlightPlanFiled: _ifrFlightPlanFiled,
+                  onToggleIfrFlightPlanFiled: () => setState(
+                    () => _ifrFlightPlanFiled = !_ifrFlightPlanFiled,
+                  ),
+                  hasFaaLicence: _hasFaaLicence,
+                  actualInstHoursController: _actualInstHoursController,
+                  actualInstMinutesController: _actualInstMinutesController,
+                  simInstHoursController: _simInstHoursController,
+                  simInstMinutesController: _simInstMinutesController,
+                  approaches: _approaches,
+                  approachIcaoControllers: _approachIcaoControllers,
+                  approachRunwayControllers: _approachRunwayControllers,
+                  onApproachTypeChanged: (i, t) => setState(
+                    () => _approaches[i] = _approaches[i].copyWith(type: t),
+                  ),
+                  onApproachIcaoChanged: (i, v) => setState(
+                    () => _approaches[i] = _approaches[i].copyWith(
+                      aerodromeIcao: v,
+                    ),
+                  ),
+                  onApproachRunwayChanged: (i, v) => setState(
+                    () => _approaches[i] = _approaches[i].copyWith(runway: v),
+                  ),
+                  onApproachCountChanged: (i, c) => setState(
+                    () => _approaches[i] = _approaches[i].copyWith(count: c),
+                  ),
+                  onApproachRemoved: _removeApproach,
+                  onApproachAdded: _addApproach,
+                  holdingProceduresCount: _holdingProceduresCount,
+                  onHoldingProceduresChanged: (v) =>
+                      setState(() => _holdingProceduresCount = v),
+                  trackingPerformed: _trackingPerformed,
+                  onToggleTracking: () =>
+                      setState(() => _trackingPerformed = !_trackingPerformed),
+                ),
+                RemarksSection(
+                  controller: _remarksController,
+                  remarksRequiredNote: needsRemarks
+                      ? flightPurposeNotes[_purpose]
+                      : null,
+                  showCountersignature: showCountersignature,
+                  sign: _sign,
+                  onSignChanged: (v) => setState(() {
+                    _sign = v;
+                    if (v == SignChoice.now) _signedAt = DateTime.now();
+                  }),
+                  signedAt: _signedAt,
+                  signatoryName: signatoryName,
+                ),
                 const SizedBox(height: 24),
               ],
             ),
           ),
-          EntryFooter(blockTime: _blockTime, onSaveDraft: () {}, onSave: () {}),
+          EntryFooter(
+            blockTimeText: _blockTimeText,
+            easaResult: _easaResult,
+            faaResult: _faaResult,
+            hasFaaLicence: _hasFaaLicence,
+            onSaveDraft: () {},
+            onSave: () {},
+          ),
         ],
       ),
     );

--- a/lib/ui/entry/sample_fleet_data.dart
+++ b/lib/ui/entry/sample_fleet_data.dart
@@ -1,0 +1,128 @@
+import '../../domain/model/aircraft.dart';
+
+/// A pilot's own fleet — the aircraft they've flown before, offered first
+/// when picking a registration (docs/entry-form.md §10: "recent aircraft
+/// ... pinned to the top"). Static sample data, matching the convention
+/// `lib/ui/logbook/sample_logbook_data.dart` already established: real data
+/// is `AircraftRepository`, which has no `findAll`/search method yet (#56).
+///
+/// [displayChips] are short type-rating/class-rating tags shown next to the
+/// registration — display sugar, not a domain field; the underlying
+/// qualification facts live on [Aircraft.requiredQualifications].
+class SampleFleetAircraft {
+  const SampleFleetAircraft({
+    required this.aircraft,
+    required this.displayChips,
+    required this.pushbackOperations,
+  });
+
+  final Aircraft aircraft;
+
+  /// e.g. `['P28A', 'SEP land', 'SP']`.
+  final List<String> displayChips;
+
+  /// Whether this type routinely operates with a pushback/tow start —
+  /// surfaces the EASA-first-movement-vs-FAA-own-power note
+  /// (docs/entry-form.md §2). True only for the multi-pilot jet in this
+  /// sample set.
+  final bool pushbackOperations;
+
+  String get registration => aircraft.registration;
+
+  String get typeLabel => '${aircraft.manufacturer} ${aircraft.model}'.trim();
+}
+
+final List<SampleFleetAircraft> sampleFleet = [
+  SampleFleetAircraft(
+    aircraft: const Aircraft(
+      registration: 'G-ARRW',
+      manufacturer: 'Piper',
+      model: 'PA-28-161 Warrior',
+      icaoTypeDesignator: 'P28A',
+      category: AircraftCategory.aeroplane,
+      engineType: EngineType.piston,
+      engineCount: 1,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: false,
+    ),
+    displayChips: const ['P28A', 'SEP land', 'SP'],
+    pushbackOperations: false,
+  ),
+  SampleFleetAircraft(
+    aircraft: const Aircraft(
+      registration: 'G-ABCD',
+      manufacturer: 'Cessna',
+      model: '152',
+      icaoTypeDesignator: 'C152',
+      category: AircraftCategory.aeroplane,
+      engineType: EngineType.piston,
+      engineCount: 1,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: false,
+    ),
+    displayChips: const ['C152', 'SEP land', 'SP'],
+    pushbackOperations: false,
+  ),
+  SampleFleetAircraft(
+    aircraft: const Aircraft(
+      registration: 'N456BD',
+      manufacturer: 'Cirrus',
+      model: 'SR22',
+      icaoTypeDesignator: 'SR22',
+      category: AircraftCategory.aeroplane,
+      engineType: EngineType.piston,
+      engineCount: 1,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: false,
+      requiredQualifications: {
+        'us.faa.part61': {AircraftQualification.faaHighPerformance},
+      },
+    ),
+    displayChips: const ['SR22', 'SEP land', 'SP', 'high-performance'],
+    pushbackOperations: false,
+  ),
+  SampleFleetAircraft(
+    aircraft: const Aircraft(
+      registration: 'G-VMPS',
+      manufacturer: 'Airbus',
+      model: 'A320-214',
+      icaoTypeDesignator: 'A320',
+      category: AircraftCategory.aeroplane,
+      engineType: EngineType.turbofan,
+      engineCount: 2,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: true,
+      typeRatingDesignator: 'A320',
+    ),
+    displayChips: const ['A320', 'MET', 'MP', 'pushback ops'],
+    pushbackOperations: true,
+  ),
+  SampleFleetAircraft(
+    aircraft: const Aircraft(
+      registration: 'G-HELI',
+      manufacturer: 'Airbus',
+      model: 'EC135 T2+',
+      icaoTypeDesignator: 'EC35',
+      category: AircraftCategory.helicopter,
+      engineType: EngineType.turboprop,
+      engineCount: 2,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: false,
+    ),
+    displayChips: const ['EC35', 'SE helicopter', 'SP'],
+    pushbackOperations: false,
+  ),
+];
+
+/// Looks up a fleet entry by registration, case-insensitively. `null` when
+/// [registration] doesn't match anything in [sampleFleet] — an unresolved
+/// aircraft, never guessed (CLAUDE.md: "never guess a missing
+/// discriminator").
+SampleFleetAircraft? findFleetAircraft(String registration) {
+  final needle = registration.trim().toUpperCase();
+  if (needle.isEmpty) return null;
+  for (final entry in sampleFleet) {
+    if (entry.registration.toUpperCase() == needle) return entry;
+  }
+  return null;
+}

--- a/lib/ui/entry/widgets/aircraft_section.dart
+++ b/lib/ui/entry/widgets/aircraft_section.dart
@@ -1,31 +1,69 @@
 import 'package:flutter/material.dart';
 
 import '../../theme/app_colors.dart';
+import '../sample_fleet_data.dart';
 import 'entry_card.dart';
 import 'entry_section_label.dart';
 
 /// §1 of docs/entry-form.md: aircraft first, registration only — it
-/// determines the shape of everything below. Real resolution (type, ICAO
-/// designator, class, SP/MP, category, FAA complex/high-performance/
-/// tailwheel flags) comes from the aircraft repository once #56/#61 wire
-/// it up; for now this just captures the registration.
+/// determines the shape of everything below. Entering a registration that
+/// matches [sampleFleet] resolves type, chips and the pushback note; one
+/// that doesn't match resolves nothing, rather than guessing (CLAUDE.md:
+/// "never guess a missing discriminator"). Real resolution against
+/// `AircraftRepository` lands with #56/#61 — [sampleFleet] is the same kind
+/// of stand-in `lib/ui/logbook/sample_logbook_data.dart` already uses.
+/// Fleet list rows shown before a search narrows them down, and the most a
+/// search can ever bring back — a defensive cap for when a real fleet
+/// (post-#56/#61) is far larger than this screen's five-entry sample data,
+/// so the picker never tries to render an unbounded list.
+const int _maxFleetResults = 20;
+
 class AircraftSection extends StatelessWidget {
   const AircraftSection({
     super.key,
     required this.controller,
-    required this.resolvedType,
+    required this.resolved,
+    required this.fleetOpen,
+    required this.onToggleFleet,
+    required this.onFocusRegistration,
+    required this.onPickAircraft,
+    required this.searchController,
   });
 
   final TextEditingController controller;
 
-  /// Null until a registration is typed — stands in for real aircraft-record
-  /// resolution. Once #56 lands this becomes a real lookup against
-  /// [AircraftRepository] instead of a guess made here in the UI.
-  final String? resolvedType;
+  /// Null until the typed registration matches a fleet entry.
+  final SampleFleetAircraft? resolved;
+
+  final bool fleetOpen;
+  final VoidCallback onToggleFleet;
+  final VoidCallback onFocusRegistration;
+  final ValueChanged<SampleFleetAircraft> onPickAircraft;
+
+  /// Filters the fleet list by registration or type — docs/entry-form.md
+  /// §10: recent/matching aircraft should be quick to find, not a long
+  /// scroll. Owned by the parent screen like every other text field here,
+  /// so its listener-driven rebuild (see `NewFlightScreen.initState`)
+  /// re-filters as the pilot types.
+  final TextEditingController searchController;
+
+  List<SampleFleetAircraft> get _fleetMatches {
+    final query = searchController.text.trim().toLowerCase();
+    final matches = query.isEmpty
+        ? sampleFleet
+        : sampleFleet.where(
+            (entry) =>
+                entry.registration.toLowerCase().contains(query) ||
+                entry.typeLabel.toLowerCase().contains(query),
+          );
+    return matches.take(_maxFleetResults).toList();
+  }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final ink = context.inkTiers;
+
     return EntrySection(
       label: 'Aircraft',
       child: EntryCard(
@@ -34,34 +72,203 @@ class AircraftSection extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            TextField(
-              controller: controller,
-              textCapitalization: TextCapitalization.characters,
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: controller,
+                    textCapitalization: TextCapitalization.characters,
+                    onTap: onFocusRegistration,
+                    style: const TextStyle(
+                      fontFamily: 'IBM Plex Mono',
+                      fontWeight: FontWeight.w600,
+                      fontSize: 19,
+                    ),
+                    decoration: const InputDecoration(
+                      border: InputBorder.none,
+                      enabledBorder: InputBorder.none,
+                      focusedBorder: InputBorder.none,
+                      filled: false,
+                      isDense: true,
+                      contentPadding: EdgeInsets.symmetric(vertical: 4),
+                      hintText: 'Registration, e.g. G-EZTK',
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: onToggleFleet,
+                  child: Text(fleetOpen ? 'Close' : 'Change aircraft'),
+                ),
+              ],
+            ),
+            if (resolved != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                '${resolved!.typeLabel} · '
+                '${resolved!.aircraft.category.name == 'helicopter' ? 'helicopter' : 'aeroplane'}',
+                style: theme.textTheme.bodyMedium?.copyWith(color: ink.muted),
+              ),
+              const SizedBox(height: 9),
+              Wrap(
+                spacing: 5,
+                runSpacing: 5,
+                children: [
+                  for (final chip in resolved!.displayChips) _Chip(label: chip),
+                ],
+              ),
+            ],
+            if (fleetOpen) ...[
+              const SizedBox(height: 11),
+              TextField(
+                controller: searchController,
+                textCapitalization: TextCapitalization.characters,
+                style: const TextStyle(fontSize: 13.5),
+                decoration: InputDecoration(
+                  isDense: true,
+                  prefixIcon: const Icon(Icons.search, size: 18),
+                  hintText: 'Search registration or type',
+                  contentPadding: const EdgeInsets.symmetric(vertical: 10),
+                ),
+              ),
+              const SizedBox(height: 9),
+              if (_fleetMatches.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  child: Text(
+                    'No aircraft match "${searchController.text.trim()}"',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                )
+              else
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: theme.colorScheme.outlineVariant),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(10),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (final entry in _fleetMatches)
+                          _FleetRow(
+                            entry: entry,
+                            selected:
+                                entry.registration.toUpperCase() ==
+                                controller.text.trim().toUpperCase(),
+                            onTap: () => onPickAircraft(entry),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+            if (resolved != null && resolved!.pushbackOperations) ...[
+              const SizedBox(height: 11),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 11,
+                  vertical: 9,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerLow,
+                  border: Border.all(color: theme.colorScheme.outlineVariant),
+                  borderRadius: BorderRadius.circular(9),
+                ),
+                child: Text(
+                  'Pushback operations: EASA counts from first movement, '
+                  'the FAA from movement under own power. Block start is '
+                  'recorded per profile.',
+                  style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+                ),
+              ),
+            ],
+            const SizedBox(height: 2),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final ink = context.inkTiers;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLow,
+        border: Border.all(color: scheme.outlineVariant),
+        borderRadius: BorderRadius.circular(5),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontFamily: 'IBM Plex Mono',
+          fontWeight: FontWeight.w500,
+          fontSize: 10.5,
+          color: ink.medium,
+        ),
+      ),
+    );
+  }
+}
+
+class _FleetRow extends StatelessWidget {
+  const _FleetRow({
+    required this.entry,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final SampleFleetAircraft entry;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+        decoration: BoxDecoration(
+          color: selected
+              ? theme.colorScheme.primary.withValues(alpha: 0.08)
+              : theme.colorScheme.surface,
+          border: Border(
+            bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+          ),
+        ),
+        child: Row(
+          children: [
+            Text(
+              entry.registration,
               style: const TextStyle(
                 fontFamily: 'IBM Plex Mono',
                 fontWeight: FontWeight.w600,
-                fontSize: 19,
-              ),
-              decoration: const InputDecoration(
-                border: InputBorder.none,
-                enabledBorder: InputBorder.none,
-                focusedBorder: InputBorder.none,
-                filled: false,
-                isDense: true,
-                contentPadding: EdgeInsets.symmetric(vertical: 4),
-                hintText: 'Registration, e.g. G-EZTK',
+                fontSize: 13,
               ),
             ),
-            if (resolvedType != null) ...[
-              const SizedBox(height: 4),
-              Text(
-                resolvedType!,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(color: ink.muted),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                entry.typeLabel,
+                textAlign: TextAlign.right,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
               ),
-              const SizedBox(height: 4),
-            ],
+            ),
           ],
         ),
       ),

--- a/lib/ui/entry/widgets/approach_row.dart
+++ b/lib/ui/entry/widgets/approach_row.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/model/flight.dart';
+import '../../theme/app_colors.dart';
+import 'counter_stepper.dart';
+
+const _approachTypeLabels = {
+  ApproachType.ils: 'ILS',
+  ApproachType.rnav: 'RNAV',
+  ApproachType.gps: 'GPS',
+  ApproachType.vor: 'VOR',
+  ApproachType.loc: 'LOC',
+  ApproachType.ndb: 'NDB',
+  ApproachType.backCourse: 'Back course',
+  ApproachType.lda: 'LDA',
+  ApproachType.sdf: 'SDF',
+  ApproachType.tacan: 'TACAN',
+  ApproachType.par: 'PAR',
+  ApproachType.asr: 'ASR',
+  ApproachType.mls: 'MLS',
+};
+
+/// One row of the IR Currency and Proficiency group (§6): a distinct
+/// instrument approach procedure, and how many times it was flown. One
+/// [Approach] per distinct procedure, not per approach flown —
+/// `Flight.approaches`'s own dartdoc.
+class ApproachRow extends StatelessWidget {
+  const ApproachRow({
+    super.key,
+    required this.approach,
+    required this.icaoController,
+    required this.runwayController,
+    required this.onTypeChanged,
+    required this.onIcaoChanged,
+    required this.onRunwayChanged,
+    required this.onCountChanged,
+    required this.onRemove,
+  });
+
+  final Approach approach;
+
+  /// Owned and disposed by the parent screen, alongside `_approaches` itself
+  /// — mirrors `DateRouteSection`'s leg-controller list, since both are a
+  /// dynamic list of rows each carrying its own free-text field.
+  final TextEditingController icaoController;
+  final TextEditingController runwayController;
+  final ValueChanged<ApproachType> onTypeChanged;
+  final ValueChanged<String> onIcaoChanged;
+  final ValueChanged<String> onRunwayChanged;
+  final ValueChanged<int> onCountChanged;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLow,
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<ApproachType>(
+                  initialValue: approach.type,
+                  isDense: true,
+                  isExpanded: true,
+                  // Matches the ICAO/runway fields' own override below —
+                  // without it this box uses the theme default (14/12)
+                  // instead of their tightened padding, and the two end up
+                  // visibly different heights side by side.
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    contentPadding: EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                  ),
+                  style: const TextStyle(
+                    fontFamily: 'IBM Plex Mono',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12.5,
+                  ),
+                  items: [
+                    for (final t in ApproachType.values)
+                      DropdownMenuItem(
+                        value: t,
+                        child: Text(_approachTypeLabels[t]!),
+                      ),
+                  ],
+                  onChanged: (v) {
+                    if (v != null) onTypeChanged(v);
+                  },
+                ),
+              ),
+              const SizedBox(width: 6),
+              SizedBox(
+                // The app's default InputDecorationTheme pads every field
+                // 14px each side for a normal-width field — left as-is,
+                // that alone eats more than half of a box this narrow and
+                // clips whatever's typed. Both fields override it directly
+                // rather than widening indefinitely to outrun the default.
+                width: 72,
+                child: TextField(
+                  controller: icaoController,
+                  textAlign: TextAlign.center,
+                  textCapitalization: TextCapitalization.characters,
+                  maxLength: 4,
+                  style: const TextStyle(
+                    fontFamily: 'IBM Plex Mono',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12.5,
+                  ),
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    counterText: '',
+                    hintText: 'ICAO',
+                    contentPadding: EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 10,
+                    ),
+                  ),
+                  onChanged: (v) => onIcaoChanged(v.toUpperCase()),
+                ),
+              ),
+              const SizedBox(width: 6),
+              SizedBox(
+                width: 60,
+                child: TextField(
+                  controller: runwayController,
+                  textAlign: TextAlign.center,
+                  textCapitalization: TextCapitalization.characters,
+                  maxLength: 3,
+                  style: const TextStyle(
+                    fontFamily: 'IBM Plex Mono',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12.5,
+                  ),
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    counterText: '',
+                    hintText: 'RWY',
+                    contentPadding: EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 10,
+                    ),
+                  ),
+                  onChanged: (v) => onRunwayChanged(v.toUpperCase()),
+                ),
+              ),
+              IconButton(
+                onPressed: onRemove,
+                icon: const Icon(Icons.close, size: 16),
+                visualDensity: VisualDensity.compact,
+                color: ink.faint,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Flown',
+                style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+              ),
+              CounterStepper(
+                width: 120,
+                compact: true,
+                value: approach.count,
+                onIncrement: () => onCountChanged(approach.count + 1),
+                onDecrement: approach.count > 1
+                    ? () => onCountChanged(approach.count - 1)
+                    : null,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/entry/widgets/conditions_section.dart
+++ b/lib/ui/entry/widgets/conditions_section.dart
@@ -1,0 +1,307 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/model/flight.dart';
+import '../../theme/app_colors.dart';
+import 'approach_row.dart';
+import 'counter_stepper.dart';
+import 'duration_field.dart';
+import 'entry_card.dart';
+import 'entry_section_label.dart';
+import 'entry_toggle_row.dart';
+
+/// §6 of docs/entry-form.md.
+///
+/// One deliberate departure from the visual mockup: the mockup's "IFR time"
+/// field is a free duration, but `Flight.ifrFlightPlanFiled` — the only
+/// domain fact `easaInstrumentTime` reads — is a boolean (AMC1 FCL.050
+/// column 9 counts the *whole* block time once a flight plan is filed, not
+/// a sub-duration of it; see `easa_instrument_time.dart`). A free-text IFR
+/// duration has no computational meaning in this codebase, so this section
+/// asks the yes/no operational question the projection engine actually
+/// uses instead of inventing an unbacked raw fact (CLAUDE.md rule 1).
+///
+/// "Night time" has the same problem in reverse: it's genuinely a duration,
+/// but it's *entirely derived* (no raw `Flight.nightTime` field exists —
+/// see `easa_night_time.dart`/`faa_night_time.dart`), and this app has no
+/// override-with-reason mechanism yet (§8) to let a pilot's manual entry
+/// coexist with the computed figure. It's kept here as a plain UI value,
+/// not fed into the draft `Flight` at all, until #8's override plumbing
+/// lands.
+class ConditionsSection extends StatelessWidget {
+  const ConditionsSection({
+    super.key,
+    required this.blockTime,
+    required this.nightHoursController,
+    required this.nightMinutesController,
+    required this.hasEasaLicence,
+    required this.ifrFlightPlanFiled,
+    required this.onToggleIfrFlightPlanFiled,
+    required this.hasFaaLicence,
+    required this.actualInstHoursController,
+    required this.actualInstMinutesController,
+    required this.simInstHoursController,
+    required this.simInstMinutesController,
+    required this.approaches,
+    required this.approachIcaoControllers,
+    required this.approachRunwayControllers,
+    required this.onApproachTypeChanged,
+    required this.onApproachIcaoChanged,
+    required this.onApproachRunwayChanged,
+    required this.onApproachCountChanged,
+    required this.onApproachRemoved,
+    required this.onApproachAdded,
+    required this.holdingProceduresCount,
+    required this.onHoldingProceduresChanged,
+    required this.trackingPerformed,
+    required this.onToggleTracking,
+  });
+
+  /// Feeds each field's "fill from block time" shortcut — see
+  /// `duration_field.dart`. Null (times not yet entered) simply hides the
+  /// shortcut everywhere in this section.
+  final Duration? blockTime;
+
+  final TextEditingController nightHoursController;
+  final TextEditingController nightMinutesController;
+
+  final bool hasEasaLicence;
+  final bool ifrFlightPlanFiled;
+  final VoidCallback onToggleIfrFlightPlanFiled;
+
+  final bool hasFaaLicence;
+  final TextEditingController actualInstHoursController;
+  final TextEditingController actualInstMinutesController;
+  final TextEditingController simInstHoursController;
+  final TextEditingController simInstMinutesController;
+
+  final List<Approach> approaches;
+  final List<TextEditingController> approachIcaoControllers;
+  final List<TextEditingController> approachRunwayControllers;
+  final void Function(int index, ApproachType type) onApproachTypeChanged;
+  final void Function(int index, String icao) onApproachIcaoChanged;
+  final void Function(int index, String runway) onApproachRunwayChanged;
+  final void Function(int index, int count) onApproachCountChanged;
+  final ValueChanged<int> onApproachRemoved;
+  final VoidCallback onApproachAdded;
+
+  final int holdingProceduresCount;
+  final ValueChanged<int> onHoldingProceduresChanged;
+  final bool trackingPerformed;
+  final VoidCallback onToggleTracking;
+
+  String? get _blockTimeText {
+    final block = blockTime;
+    if (block == null) return null;
+    final hours = block.inHours;
+    final minutes = block.inMinutes.remainder(60).abs();
+    return '$hours:${minutes.toString().padLeft(2, '0')}';
+  }
+
+  /// Sets both controllers directly rather than routing through a
+  /// parent-owned callback — `NewFlightScreen` already attaches a rebuild
+  /// listener to every duration controller in this section (see its
+  /// `initState`), so writing `.text` here is enough to keep the
+  /// derivation strip in sync, the same way a pilot typing into the field
+  /// by hand would.
+  void _fillFromBlock(
+    TextEditingController hours,
+    TextEditingController minutes,
+  ) {
+    final block = blockTime;
+    if (block == null) return;
+    hours.text = block.inHours.toString();
+    minutes.text = block.inMinutes
+        .remainder(60)
+        .abs()
+        .toString()
+        .padLeft(2, '0');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      children: [
+        EntrySection(
+          label: 'Conditions',
+          child: EntryCard(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
+            child: Column(
+              children: [
+                _ConditionRow(
+                  label: 'Night time',
+                  hint: 'not yet auto-computed — enter directly',
+                  child: DurationField(
+                    label: '',
+                    hoursController: nightHoursController,
+                    minutesController: nightMinutesController,
+                    blockTimeText: _blockTimeText,
+                    onFillFromBlock: blockTime == null
+                        ? null
+                        : () => _fillFromBlock(
+                            nightHoursController,
+                            nightMinutesController,
+                          ),
+                  ),
+                ),
+                if (hasEasaLicence) ...[
+                  const EntryCardDivider(),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: EntryToggleRow(
+                      label: 'IFR flight plan filed',
+                      subtitle:
+                          'Operational condition, independent of actual met '
+                          'conditions',
+                      value: ifrFlightPlanFiled,
+                      onChanged: (_) => onToggleIfrFlightPlanFiled(),
+                    ),
+                  ),
+                ],
+                if (hasFaaLicence) ...[
+                  const EntryCardDivider(),
+                  _ConditionRow(
+                    label: 'Actual instrument',
+                    hint: '§61.51(g)(1) — solely by reference to instruments',
+                    child: DurationField(
+                      label: '',
+                      hoursController: actualInstHoursController,
+                      minutesController: actualInstMinutesController,
+                      blockTimeText: _blockTimeText,
+                      onFillFromBlock: blockTime == null
+                          ? null
+                          : () => _fillFromBlock(
+                              actualInstHoursController,
+                              actualInstMinutesController,
+                            ),
+                    ),
+                  ),
+                  const EntryCardDivider(),
+                  _ConditionRow(
+                    label: 'Simulated instrument',
+                    hint: 'under a view-limiting device',
+                    child: DurationField(
+                      label: '',
+                      hoursController: simInstHoursController,
+                      minutesController: simInstMinutesController,
+                      blockTimeText: _blockTimeText,
+                      onFillFromBlock: blockTime == null
+                          ? null
+                          : () => _fillFromBlock(
+                              simInstHoursController,
+                              simInstMinutesController,
+                            ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        if (hasFaaLicence)
+          EntrySection(
+            label: 'IR currency and proficiency',
+            trailing: Text(
+              'FAA §61.57(c)',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: context.inkTiers.faint,
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (var i = 0; i < approaches.length; i++) ...[
+                  ApproachRow(
+                    approach: approaches[i],
+                    icaoController: approachIcaoControllers[i],
+                    runwayController: approachRunwayControllers[i],
+                    onTypeChanged: (t) => onApproachTypeChanged(i, t),
+                    onIcaoChanged: (v) => onApproachIcaoChanged(i, v),
+                    onRunwayChanged: (v) => onApproachRunwayChanged(i, v),
+                    onCountChanged: (c) => onApproachCountChanged(i, c),
+                    onRemove: () => onApproachRemoved(i),
+                  ),
+                  const SizedBox(height: 8),
+                ],
+                OutlinedButton(
+                  onPressed: onApproachAdded,
+                  child: const Text('+ Add approach'),
+                ),
+                const SizedBox(height: 13),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Holding procedures',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                    CounterStepper(
+                      width: 128,
+                      value: holdingProceduresCount,
+                      onIncrement: () => onHoldingProceduresChanged(
+                        holdingProceduresCount + 1,
+                      ),
+                      onDecrement: holdingProceduresCount > 0
+                          ? () => onHoldingProceduresChanged(
+                              holdingProceduresCount - 1,
+                            )
+                          : null,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                EntryToggleRow(
+                  label: 'Intercepted and tracked a course',
+                  value: trackingPerformed,
+                  onChanged: (_) => onToggleTracking(),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ConditionRow extends StatelessWidget {
+  const _ConditionRow({
+    required this.label,
+    required this.hint,
+    required this.child,
+  });
+
+  final String label;
+  final String hint;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: theme.textTheme.bodyMedium),
+                const SizedBox(height: 2),
+                Text(
+                  hint,
+                  style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+                ),
+              ],
+            ),
+          ),
+          child,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/entry/widgets/counter_stepper.dart
+++ b/lib/ui/entry/widgets/counter_stepper.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+
+/// The "− n +" counter used throughout §5 (take-offs/landings) and §6 (IR
+/// currency: approach repeat count, holding-procedure count). Pre-filled
+/// values are immediately editable with no confirmation gate
+/// (docs/entry-form.md §5) — this widget is the primary interface, not an
+/// override hidden behind a disclosure triangle.
+class CounterStepper extends StatelessWidget {
+  const CounterStepper({
+    super.key,
+    required this.value,
+    required this.onIncrement,
+    required this.onDecrement,
+    this.width,
+    this.compact = false,
+  });
+
+  final int value;
+  final VoidCallback onIncrement;
+  final VoidCallback? onDecrement;
+  final double? width;
+
+  /// Slightly smaller box, used inline in the approach row where three
+  /// other controls share the line.
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final ink = context.inkTiers;
+    final height = compact ? 40.0 : 44.0;
+    final buttonSize = compact ? 34.0 : 38.0;
+
+    return Container(
+      width: width,
+      height: height,
+      padding: const EdgeInsets.symmetric(horizontal: 2),
+      decoration: BoxDecoration(
+        color: compact ? scheme.surface : scheme.surfaceContainerLow,
+        border: Border.all(color: scheme.outlineVariant),
+        borderRadius: BorderRadius.circular(compact ? 8 : 9),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          _StepButton(
+            icon: Icons.remove,
+            size: buttonSize,
+            onTap: onDecrement,
+            color: onDecrement == null ? ink.faint : scheme.primary,
+          ),
+          Text(
+            '$value',
+            style: TextStyle(
+              fontFamily: 'IBM Plex Mono',
+              fontWeight: FontWeight.w600,
+              fontSize: compact ? 14 : 15,
+              color: scheme.onSurface,
+            ),
+          ),
+          _StepButton(
+            icon: Icons.add,
+            size: buttonSize,
+            onTap: onIncrement,
+            color: scheme.primary,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepButton extends StatelessWidget {
+  const _StepButton({
+    required this.icon,
+    required this.size,
+    required this.onTap,
+    required this.color,
+  });
+
+  final IconData icon;
+  final double size;
+  final VoidCallback? onTap;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: Icon(icon, size: 17, color: color),
+      ),
+    );
+  }
+}

--- a/lib/ui/entry/widgets/counters_section.dart
+++ b/lib/ui/entry/widgets/counters_section.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+import 'counter_stepper.dart';
+import 'entry_card.dart';
+import 'entry_section_label.dart';
+
+/// §5 of docs/entry-form.md: take-offs and landings are four independent
+/// counts (day/night × take-off/landing), never one derived from another —
+/// a pilot who took over in flight has zero take-offs and one landing.
+/// Values start at zero for a new entry; the docs' "pre-filled from the
+/// twilight computation" behaviour needs a route/time-driven twilight
+/// engine this screen doesn't have yet, so for now the pilot enters them
+/// directly — still immediately editable with no confirmation gate, which
+/// is the requirement that actually matters here.
+class CountersSection extends StatelessWidget {
+  const CountersSection({
+    super.key,
+    required this.takeoffsDay,
+    required this.takeoffsNight,
+    required this.landingsDay,
+    required this.landingsNight,
+    required this.onChangeTakeoffsDay,
+    required this.onChangeTakeoffsNight,
+    required this.onChangeLandingsDay,
+    required this.onChangeLandingsNight,
+    required this.showFullStop,
+    required this.fullStop,
+    required this.onChangeFullStop,
+  });
+
+  final int takeoffsDay;
+  final int takeoffsNight;
+  final int landingsDay;
+  final int landingsNight;
+  final ValueChanged<int> onChangeTakeoffsDay;
+  final ValueChanged<int> onChangeTakeoffsNight;
+  final ValueChanged<int> onChangeLandingsDay;
+  final ValueChanged<int> onChangeLandingsNight;
+
+  /// FAA night currency (§61.57(b)) requires full-stop landings
+  /// specifically — shown when an FAA licence is held and night landings
+  /// are greater than zero.
+  final bool showFullStop;
+  final int fullStop;
+  final ValueChanged<int> onChangeFullStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return EntrySection(
+      label: 'Your take-offs and landings',
+      child: EntryCard(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Expanded(flex: 3, child: SizedBox()),
+                Expanded(
+                  flex: 5,
+                  child: Text(
+                    'DAY',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.faint,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  flex: 5,
+                  child: Text(
+                    'NIGHT',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.faint,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            _CounterRow(
+              label: 'Take-offs',
+              dayValue: takeoffsDay,
+              nightValue: takeoffsNight,
+              onDayChanged: onChangeTakeoffsDay,
+              onNightChanged: onChangeTakeoffsNight,
+            ),
+            const SizedBox(height: 8),
+            _CounterRow(
+              label: 'Landings',
+              dayValue: landingsDay,
+              nightValue: landingsNight,
+              onDayChanged: onChangeLandingsDay,
+              onNightChanged: onChangeLandingsNight,
+            ),
+            if (showFullStop) ...[
+              const SizedBox(height: 10),
+              const EntryCardDivider(),
+              const SizedBox(height: 10),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text.rich(
+                      TextSpan(
+                        children: [
+                          const TextSpan(text: 'of which full-stop '),
+                          TextSpan(
+                            text: 'FAA night',
+                            style: TextStyle(color: ink.faint),
+                          ),
+                        ],
+                      ),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: ink.medium,
+                      ),
+                    ),
+                  ),
+                  CounterStepper(
+                    width: 128,
+                    value: fullStop,
+                    onIncrement: () => onChangeFullStop(fullStop + 1),
+                    onDecrement: fullStop > 0
+                        ? () => onChangeFullStop(fullStop - 1)
+                        : null,
+                  ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 9),
+            Text(
+              'Counted as landings you flew, not landings the aircraft '
+              'made.',
+              style: theme.textTheme.bodySmall?.copyWith(color: ink.faint),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CounterRow extends StatelessWidget {
+  const _CounterRow({
+    required this.label,
+    required this.dayValue,
+    required this.nightValue,
+    required this.onDayChanged,
+    required this.onNightChanged,
+  });
+
+  final String label;
+  final int dayValue;
+  final int nightValue;
+  final ValueChanged<int> onDayChanged;
+  final ValueChanged<int> onNightChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Text(label, style: theme.textTheme.bodyMedium),
+        ),
+        Expanded(
+          flex: 5,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: CounterStepper(
+              value: dayValue,
+              onIncrement: () => onDayChanged(dayValue + 1),
+              onDecrement: dayValue > 0
+                  ? () => onDayChanged(dayValue - 1)
+                  : null,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 5,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: CounterStepper(
+              value: nightValue,
+              onIncrement: () => onNightChanged(nightValue + 1),
+              onDecrement: nightValue > 0
+                  ? () => onNightChanged(nightValue - 1)
+                  : null,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/entry/widgets/countersignature_block.dart
+++ b/lib/ui/entry/widgets/countersignature_block.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+import '../entry_form_types.dart';
+import 'entry_segmented_choice.dart';
+
+/// Always present when shown, never required to save (docs/entry-form.md
+/// §4B/§4C, §8). Covers both the §4B instructor-received/SPIC case and the
+/// §4C PICUS case — `NewFlightScreen` decides when to show it
+/// (`crew == instructor || (crew == otherPilot && picus)`) and which name
+/// to sign against; this widget only renders the sign-now/defer choice and
+/// the resulting state.
+///
+/// Uncountersigned SPIC/PICUS time is not creditable — see
+/// `flight_draft_mapper.dart`'s `_countersignature`, which returns
+/// [CountersignatureStatus.pending] rather than silently treating a
+/// deferred signature as valid.
+class CountersignatureBlock extends StatelessWidget {
+  const CountersignatureBlock({
+    super.key,
+    required this.sign,
+    required this.onSignChanged,
+    required this.signedAt,
+    required this.signatoryName,
+  });
+
+  final SignChoice sign;
+  final ValueChanged<SignChoice> onSignChanged;
+  final DateTime? signedAt;
+
+  /// The name that will appear against the signature — the instructor's or
+  /// the other pilot's, whichever path triggered this block.
+  final String signatoryName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLow,
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Countersignature',
+                  style: theme.textTheme.titleSmall,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'never required to save',
+                  textAlign: TextAlign.right,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          EntrySegmentedChoice<SignChoice>(
+            options: [for (final s in SignChoice.values) (s, s.label)],
+            selected: sign,
+            onChanged: onSignChanged,
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Text('Signed at', style: theme.textTheme.bodySmall),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  sign == SignChoice.now && signedAt != null
+                      ? _formatSignedAt(signedAt!)
+                      : 'not signed',
+                  textAlign: TextAlign.right,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'IBM Plex Mono',
+                    fontWeight: FontWeight.w500,
+                    fontSize: 12,
+                    color: sign == SignChoice.now ? null : ink.faint,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (sign == SignChoice.defer) ...[
+            const SizedBox(height: 10),
+            Text(
+              'Queued under "awaiting countersignature". Uncountersigned '
+              'SPIC or PICUS time projects as not creditable, with reason — '
+              'never silently as zero.',
+              style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+String _formatSignedAt(DateTime t) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  final hh = t.hour.toString().padLeft(2, '0');
+  final mm = t.minute.toString().padLeft(2, '0');
+  return '${t.day} ${months[t.month - 1]} ${t.year} $hh:${mm}Z';
+}

--- a/lib/ui/entry/widgets/crew/crew_form_data.dart
+++ b/lib/ui/entry/widgets/crew/crew_form_data.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+import '../../../../domain/model/pilot_capacity.dart';
+import '../../entry_form_types.dart';
+import 'crew_selection.dart';
+
+/// The mutable pieces of entry-form state the four crew paths (§4A-§4D)
+/// read and write, gathered into one bag rather than threaded through as
+/// thirty-odd individual constructor parameters on every crew widget. Owned
+/// and mutated by `NewFlightScreen` via [onSelectCrew] and friends; every
+/// other field here is read-only from a crew widget's point of view.
+///
+/// Mirrors the shape of the flat `state` object in the Flight Entry Form
+/// mockup's own logic class — one state, every section reads the slice it
+/// needs.
+class CrewFormData {
+  const CrewFormData({
+    required this.crew,
+    required this.onSelectCrew,
+    // §4A — just me.
+    required this.isStudent,
+    required this.soloEndorsementHeld,
+    required this.onToggleSoloEndorsement,
+    required this.endorsingInstructorController,
+    // §4B — with an instructor.
+    required this.arrangement,
+    required this.onArrangementChanged,
+    required this.spicOffered,
+    required this.instructorNameController,
+    required this.instructorLicenceController,
+    required this.hasFaaLicence,
+    required this.instructorCertExpiry,
+    required this.onPickInstructorCertExpiry,
+    required this.purpose,
+    required this.onPurposeChanged,
+    required this.examinerNoController,
+    required this.result,
+    required this.onResultChanged,
+    required this.ratingAffectedController,
+    required this.instructorSoleManipulator,
+    required this.onToggleInstructorSoleManipulator,
+    required this.instructorManipHoursController,
+    required this.instructorManipMinutesController,
+    required this.instructorPassengers,
+    required this.onToggleInstructorPassengers,
+    // §4C — with another pilot.
+    required this.command,
+    required this.onCommandChanged,
+    required this.flying,
+    required this.onFlyingChanged,
+    required this.otherPilotNameController,
+    required this.otherPilotLicenceController,
+    required this.multiPilotOperation,
+    required this.aircraftRequiresMultiCrew,
+    required this.onToggleMultiPilot,
+    required this.otherManipHoursController,
+    required this.otherManipMinutesController,
+    required this.otherPilotRole,
+    required this.onOtherPilotRoleChanged,
+    required this.picusClaimed,
+    required this.onTogglePicus,
+    required this.picInterventionNotRequired,
+    required this.onTogglePicInterventionNotRequired,
+    required this.simulatedInstrumentPresent,
+    required this.otherPilotPassengers,
+    required this.onToggleOtherPilotPassengers,
+  });
+
+  final CrewSelection? crew;
+  final ValueChanged<CrewSelection> onSelectCrew;
+
+  final bool isStudent;
+  final bool soloEndorsementHeld;
+  final VoidCallback onToggleSoloEndorsement;
+  final TextEditingController endorsingInstructorController;
+
+  final InstructorArrangement arrangement;
+  final ValueChanged<InstructorArrangement> onArrangementChanged;
+
+  /// Whether "I was in command, instructor observing only" (SPIC) is
+  /// offered — FCL.020 restricts it to student pilots. Stubbed `true` by
+  /// the caller until a real licence-profile source exists.
+  final bool spicOffered;
+  final TextEditingController instructorNameController;
+  final TextEditingController instructorLicenceController;
+  final bool hasFaaLicence;
+  final DateTime? instructorCertExpiry;
+  final VoidCallback onPickInstructorCertExpiry;
+  final String? purpose;
+  final ValueChanged<String?> onPurposeChanged;
+  final TextEditingController examinerNoController;
+  final String? result;
+  final ValueChanged<String> onResultChanged;
+  final TextEditingController ratingAffectedController;
+  final bool instructorSoleManipulator;
+  final VoidCallback onToggleInstructorSoleManipulator;
+  final TextEditingController instructorManipHoursController;
+  final TextEditingController instructorManipMinutesController;
+  final bool instructorPassengers;
+  final VoidCallback onToggleInstructorPassengers;
+
+  final CommandChoice command;
+  final ValueChanged<CommandChoice> onCommandChanged;
+  final FlyingChoice flying;
+  final ValueChanged<FlyingChoice> onFlyingChanged;
+  final TextEditingController otherPilotNameController;
+  final TextEditingController otherPilotLicenceController;
+  final bool multiPilotOperation;
+
+  /// Pre-fill hint from the resolved aircraft record — display only; the
+  /// toggle itself is [multiPilotOperation], independently overridable
+  /// (docs/entry-form.md §4C: "overridable for ops that require two pilots
+  /// by regulation rather than by type certificate").
+  final bool aircraftRequiresMultiCrew;
+  final VoidCallback onToggleMultiPilot;
+  final TextEditingController otherManipHoursController;
+  final TextEditingController otherManipMinutesController;
+  final OtherPilotRole? otherPilotRole;
+  final ValueChanged<OtherPilotRole?> onOtherPilotRoleChanged;
+  final bool picusClaimed;
+  final VoidCallback onTogglePicus;
+  final bool picInterventionNotRequired;
+  final VoidCallback onTogglePicInterventionNotRequired;
+
+  /// Whether §6 Conditions' simulated-instrument field is greater than
+  /// zero — gates the safety-pilot toggle (§4C).
+  final bool simulatedInstrumentPresent;
+  final bool otherPilotPassengers;
+  final VoidCallback onToggleOtherPilotPassengers;
+}

--- a/lib/ui/entry/widgets/crew/crew_just_me.dart
+++ b/lib/ui/entry/widgets/crew/crew_just_me.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
 
 import '../../../theme/app_colors.dart';
+import '../entry_toggle_row.dart';
+import 'crew_form_data.dart';
 
 /// §4A. The simplest path — resolves sole occupancy, sole manipulator and
-/// command in one tap, no fields in the base case.
-///
-/// Not built here: the student-pilot solo-endorsement fields §4A adds when
-/// the pilot's licence profile indicates student status. That needs a real
-/// pilot profile/licence source, which this screen doesn't read yet.
+/// command in one tap. When the pilot's licence profile indicates student
+/// status, §61.51(e)(4) needs a §61.87 solo endorsement before PIC can be
+/// logged, so those two fields appear; [CrewFormData.isStudent] is a stub
+/// (always `false`) until a real pilot-profile source exists.
 class CrewJustMe extends StatelessWidget {
-  const CrewJustMe({super.key});
+  const CrewJustMe({super.key, required this.data});
+
+  final CrewFormData data;
 
   @override
   Widget build(BuildContext context) {
@@ -17,16 +20,39 @@ class CrewJustMe extends StatelessWidget {
     final ink = context.inkTiers;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.check_circle_outline, size: 18, color: ink.muted),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              'Sole occupant. PIC time computed automatically.',
-              style: theme.textTheme.bodyMedium?.copyWith(color: ink.muted),
-            ),
+          Row(
+            children: [
+              Icon(Icons.check_circle_outline, size: 18, color: ink.muted),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Sole occupant, sole manipulator and command all follow '
+                  'from this answer. Nothing further to enter.',
+                  style: theme.textTheme.bodyMedium?.copyWith(color: ink.muted),
+                ),
+              ),
+            ],
           ),
+          if (data.isStudent) ...[
+            const SizedBox(height: 11),
+            const Divider(height: 1),
+            const SizedBox(height: 11),
+            EntryToggleRow(
+              label: 'Solo endorsement held',
+              value: data.soloEndorsementHeld,
+              onChanged: (_) => data.onToggleSoloEndorsement(),
+            ),
+            const SizedBox(height: 6),
+            TextField(
+              controller: data.endorsingInstructorController,
+              decoration: const InputDecoration(
+                labelText: 'Endorsing instructor',
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/ui/entry/widgets/crew/crew_section.dart
+++ b/lib/ui/entry/widgets/crew/crew_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../theme/app_colors.dart';
 import '../entry_card.dart';
 import '../entry_section_label.dart';
+import 'crew_form_data.dart';
 import 'crew_just_me.dart';
 import 'crew_selection.dart';
 import 'crew_with_instructor.dart';
@@ -10,18 +11,14 @@ import 'crew_with_other_pilot.dart';
 import 'crew_with_passengers.dart';
 
 /// §4: one question — "who else was on board?" — with the answer expanding
-/// inline into one of four field sets. Each path keeps its own fields'
-/// state internally; nothing downstream reads them yet, since there's no
-/// real Flight submission to feed until #56 wires up the repository.
-class CrewSection extends StatefulWidget {
-  const CrewSection({super.key});
+/// inline into one of four field sets. Fully controlled from
+/// `NewFlightScreen` via [data], so the derivation strip and the remarks
+/// section's countersignature block can read what the pilot has entered
+/// here.
+class CrewSection extends StatelessWidget {
+  const CrewSection({super.key, required this.data});
 
-  @override
-  State<CrewSection> createState() => _CrewSectionState();
-}
-
-class _CrewSectionState extends State<CrewSection> {
-  CrewSelection? _selection;
+  final CrewFormData data;
 
   static const _options = [
     (CrewSelection.justMe, 'Just me'),
@@ -40,19 +37,11 @@ class _CrewSectionState extends State<CrewSection> {
           Row(
             children: [
               Expanded(
-                child: _OptionCard(
-                  option: _options[0],
-                  selection: _selection,
-                  onSelect: _select,
-                ),
+                child: _OptionCard(option: _options[0], data: data),
               ),
               const SizedBox(width: 8),
               Expanded(
-                child: _OptionCard(
-                  option: _options[1],
-                  selection: _selection,
-                  onSelect: _select,
-                ),
+                child: _OptionCard(option: _options[1], data: data),
               ),
             ],
           ),
@@ -60,30 +49,22 @@ class _CrewSectionState extends State<CrewSection> {
           Row(
             children: [
               Expanded(
-                child: _OptionCard(
-                  option: _options[2],
-                  selection: _selection,
-                  onSelect: _select,
-                ),
+                child: _OptionCard(option: _options[2], data: data),
               ),
               const SizedBox(width: 8),
               Expanded(
-                child: _OptionCard(
-                  option: _options[3],
-                  selection: _selection,
-                  onSelect: _select,
-                ),
+                child: _OptionCard(option: _options[3], data: data),
               ),
             ],
           ),
-          if (_selection != null) ...[
+          if (data.crew != null) ...[
             const SizedBox(height: 12),
             EntryCard(
               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-              child: switch (_selection!) {
-                CrewSelection.justMe => const CrewJustMe(),
-                CrewSelection.withInstructor => const CrewWithInstructor(),
-                CrewSelection.withOtherPilot => const CrewWithOtherPilot(),
+              child: switch (data.crew!) {
+                CrewSelection.justMe => CrewJustMe(data: data),
+                CrewSelection.withInstructor => CrewWithInstructor(data: data),
+                CrewSelection.withOtherPilot => CrewWithOtherPilot(data: data),
                 CrewSelection.withPassengers => const CrewWithPassengers(),
               },
             ),
@@ -92,30 +73,23 @@ class _CrewSectionState extends State<CrewSection> {
       ),
     );
   }
-
-  void _select(CrewSelection s) => setState(() => _selection = s);
 }
 
 class _OptionCard extends StatelessWidget {
-  const _OptionCard({
-    required this.option,
-    required this.selection,
-    required this.onSelect,
-  });
+  const _OptionCard({required this.option, required this.data});
 
   final (CrewSelection, String) option;
-  final CrewSelection? selection;
-  final ValueChanged<CrewSelection> onSelect;
+  final CrewFormData data;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final ink = context.inkTiers;
-    final selected = option.$1 == selection;
+    final selected = option.$1 == data.crew;
 
     return InkWell(
-      onTap: () => onSelect(option.$1),
+      onTap: () => data.onSelectCrew(option.$1),
       borderRadius: BorderRadius.circular(12),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 120),

--- a/lib/ui/entry/widgets/crew/crew_with_instructor.dart
+++ b/lib/ui/entry/widgets/crew/crew_with_instructor.dart
@@ -1,60 +1,27 @@
 import 'package:flutter/material.dart';
 
-import '../../../theme/app_colors.dart';
+import '../../entry_form_types.dart';
 import '../duration_field.dart';
 import '../entry_segmented_choice.dart';
 import '../entry_toggle_row.dart';
-
-enum _Arrangement { receivingInstruction, inCommandObserving }
-
-const _purposes = [
-  'Training — general',
-  'Skill test',
-  'Proficiency check',
-  'SEP/TMG revalidation refresher',
-  'FAA flight review',
-  'FAA IPC',
-  'Instrument training',
-];
+import 'crew_form_data.dart';
 
 /// §4B. Both arrangements share the same field set; only the arrangement
-/// choice itself changes what gets derived (Dual vs SPIC under EASA).
-///
-/// Not built here: certificate-expiry (FAA-only, needs licence-held
-/// detection), and the second arrangement option is shown unconditionally
-/// rather than gated to student pilots under a licence profile — both need
-/// a real pilot-profile source this screen doesn't have yet.
-class CrewWithInstructor extends StatefulWidget {
-  const CrewWithInstructor({super.key});
+/// choice itself changes what gets derived (Dual vs SPIC under EASA — see
+/// `flight_draft_mapper.dart`). The countersignature block itself lives in
+/// the remarks section (§7), not here — docs/entry-form.md places it
+/// alongside §4C's PICUS countersignature under one "always present, never
+/// required to save" block, gated on `crew == instructor || picus`.
+class CrewWithInstructor extends StatelessWidget {
+  const CrewWithInstructor({super.key, required this.data});
 
-  @override
-  State<CrewWithInstructor> createState() => _CrewWithInstructorState();
-}
-
-class _CrewWithInstructorState extends State<CrewWithInstructor> {
-  _Arrangement _arrangement = _Arrangement.receivingInstruction;
-  final _instructorName = TextEditingController();
-  final _instructorLicence = TextEditingController();
-  String? _purpose;
-  bool _soleManipulator = true;
-  final _manipHours = TextEditingController();
-  final _manipMinutes = TextEditingController();
-  bool _passengersOnBoard = false;
-  bool _signed = false;
-  DateTime? _signedAt;
-
-  @override
-  void dispose() {
-    _instructorName.dispose();
-    _instructorLicence.dispose();
-    _manipHours.dispose();
-    _manipMinutes.dispose();
-    super.dispose();
-  }
+  final CrewFormData data;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final receiving =
+        data.arrangement == InstructorArrangement.receivingInstruction;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
@@ -63,68 +30,119 @@ class _CrewWithInstructorState extends State<CrewWithInstructor> {
         children: [
           Text('What was the arrangement?', style: theme.textTheme.bodyMedium),
           const SizedBox(height: 8),
-          EntrySegmentedChoice<_Arrangement>(
-            options: const [
+          EntrySegmentedChoice<InstructorArrangement>(
+            options: [
               (
-                _Arrangement.receivingInstruction,
-                'I was receiving instruction',
+                InstructorArrangement.receivingInstruction,
+                InstructorArrangement.receivingInstruction.label,
               ),
-              (
-                _Arrangement.inCommandObserving,
-                'I was in command, instructor observing',
-              ),
+              if (data.spicOffered)
+                (
+                  InstructorArrangement.inCommandObserving,
+                  InstructorArrangement.inCommandObserving.label,
+                ),
             ],
-            selected: _arrangement,
-            onChanged: (v) => setState(() => _arrangement = v),
+            selected: data.arrangement,
+            onChanged: data.onArrangementChanged,
           ),
           const SizedBox(height: 18),
           TextField(
-            controller: _instructorName,
+            controller: data.instructorNameController,
             decoration: const InputDecoration(labelText: 'Instructor name'),
           ),
           const SizedBox(height: 12),
           TextField(
-            controller: _instructorLicence,
+            controller: data.instructorLicenceController,
             decoration: const InputDecoration(
               labelText: 'Instructor licence / certificate number',
             ),
           ),
+          if (data.hasFaaLicence) ...[
+            const SizedBox(height: 12),
+            InkWell(
+              onTap: data.onPickInstructorCertExpiry,
+              child: InputDecorator(
+                decoration: const InputDecoration(
+                  labelText: 'Certificate expiry',
+                ),
+                child: Text(
+                  data.instructorCertExpiry != null
+                      ? _formatDate(data.instructorCertExpiry!)
+                      : '—',
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 12),
           DropdownButtonFormField<String>(
-            initialValue: _purpose,
+            initialValue: data.purpose,
+            isExpanded: true,
             decoration: const InputDecoration(labelText: 'Purpose of flight'),
             items: [
-              for (final p in _purposes)
-                DropdownMenuItem(value: p, child: Text(p)),
+              for (final p in flightPurposes)
+                DropdownMenuItem(
+                  value: p,
+                  child: Text(p, overflow: TextOverflow.ellipsis),
+                ),
             ],
-            onChanged: (v) => setState(() => _purpose = v),
+            onChanged: data.onPurposeChanged,
           ),
+          if (flightPurposeNotes[data.purpose] != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              flightPurposeNotes[data.purpose]!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.secondary,
+              ),
+            ),
+          ],
+          if (purposeHasExaminer(data.purpose)) ...[
+            const SizedBox(height: 12),
+            TextField(
+              controller: data.examinerNoController,
+              decoration: const InputDecoration(
+                labelText: 'Examiner no.',
+                hintText: 'e.g. UK.FE.1284',
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text('Result', style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 8),
+            EntrySegmentedChoice<String>(
+              options: const [
+                ('Pass', 'Pass'),
+                ('Partial', 'Partial'),
+                ('Fail', 'Fail'),
+              ],
+              selected: data.result,
+              onChanged: data.onResultChanged,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: data.ratingAffectedController,
+              decoration: const InputDecoration(
+                labelText: 'Rating affected',
+                hintText: 'e.g. SEP (land)',
+              ),
+            ),
+          ],
           EntryToggleRow(
             label: 'I was sole manipulator',
-            value: _soleManipulator,
-            onChanged: (v) => setState(() => _soleManipulator = v),
+            value: data.instructorSoleManipulator,
+            onChanged: (_) => data.onToggleInstructorSoleManipulator(),
           ),
-          if (!_soleManipulator) ...[
+          if (!data.instructorSoleManipulator && receiving) ...[
             const SizedBox(height: 6),
             DurationField(
-              label: 'Manipulation time',
-              hoursController: _manipHours,
-              minutesController: _manipMinutes,
+              label: 'My manipulation time',
+              hoursController: data.instructorManipHoursController,
+              minutesController: data.instructorManipMinutesController,
             ),
           ],
           EntryToggleRow(
             label: 'Passengers on board',
-            value: _passengersOnBoard,
-            onChanged: (v) => setState(() => _passengersOnBoard = v),
-          ),
-          const SizedBox(height: 8),
-          _CountersignatureBlock(
-            signed: _signed,
-            signedAt: _signedAt,
-            onSign: () => setState(() {
-              _signed = true;
-              _signedAt = DateTime.now();
-            }),
+            value: data.instructorPassengers,
+            onChanged: (_) => data.onToggleInstructorPassengers(),
           ),
         ],
       ),
@@ -132,63 +150,5 @@ class _CrewWithInstructorState extends State<CrewWithInstructor> {
   }
 }
 
-/// Always present, never required to save (§4B). Uncountersigned SPIC/PICUS
-/// time is not creditable, so this stays visible whether the flight is
-/// saved as a draft or not — it just marks the entry as awaiting signature.
-class _CountersignatureBlock extends StatelessWidget {
-  const _CountersignatureBlock({
-    required this.signed,
-    required this.signedAt,
-    required this.onSign,
-  });
-
-  final bool signed;
-  final DateTime? signedAt;
-  final VoidCallback onSign;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final ink = context.inkTiers;
-    final semantic = context.semanticColors;
-
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: signed ? scheme.surface : semantic.currencyWarningSurface,
-        border: Border.all(
-          color: signed
-              ? scheme.outlineVariant
-              : semantic.currencyWarning.withValues(alpha: 0.4),
-        ),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          Icon(
-            signed ? Icons.check_circle : Icons.schedule,
-            size: 18,
-            color: signed ? ink.muted : semantic.currencyWarning,
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              signed
-                  ? 'Countersigned at ${_formatTime(signedAt!)}'
-                  : 'Awaiting countersignature',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: signed ? ink.medium : semantic.currencyWarning,
-              ),
-            ),
-          ),
-          if (!signed)
-            TextButton(onPressed: onSign, child: const Text('Sign now')),
-        ],
-      ),
-    );
-  }
-}
-
-String _formatTime(DateTime t) =>
-    '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+String _formatDate(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';

--- a/lib/ui/entry/widgets/crew/crew_with_other_pilot.dart
+++ b/lib/ui/entry/widgets/crew/crew_with_other_pilot.dart
@@ -1,64 +1,36 @@
 import 'package:flutter/material.dart';
 
+import '../../../../domain/model/pilot_capacity.dart';
 import '../../../theme/app_colors.dart';
+import '../../entry_form_types.dart';
 import '../duration_field.dart';
 import '../entry_segmented_choice.dart';
 import '../entry_toggle_row.dart';
-
-enum _Command { me, other }
-
-enum _Flying { me, other, bothSplit }
-
-enum _OtherPilotRole { requiredCrew, notRequiredCrew, safetyPilot }
+import 'crew_form_data.dart';
 
 const _roleLabels = {
-  _OtherPilotRole.requiredCrew: 'Required crew',
-  _OtherPilotRole.notRequiredCrew: 'Not required crew',
-  _OtherPilotRole.safetyPilot: 'Safety pilot',
+  OtherPilotRole.requiredCrew: 'Required crew',
+  OtherPilotRole.notRequiredCrew: 'Not required crew',
+  OtherPilotRole.safetyPilot: 'Safety pilot',
 };
 
 /// §4C — the richest path, and the one that carries the FAA/EASA
 /// divergence most sharply. "Who was in command" and "who was flying" are
 /// deliberately two separate questions, not one.
-///
-/// Not built here: the "safety pilot for my simulated instrument" toggle,
-/// which §4C gates on simulated-instrument time being greater than zero —
-/// that field lives in §6 Conditions, which this form doesn't have yet, so
-/// there's nothing to gate on.
-class CrewWithOtherPilot extends StatefulWidget {
-  const CrewWithOtherPilot({super.key});
+class CrewWithOtherPilot extends StatelessWidget {
+  const CrewWithOtherPilot({super.key, required this.data});
 
-  @override
-  State<CrewWithOtherPilot> createState() => _CrewWithOtherPilotState();
-}
-
-class _CrewWithOtherPilotState extends State<CrewWithOtherPilot> {
-  _Command _command = _Command.me;
-  _Flying _flying = _Flying.me;
-  final _otherPilotName = TextEditingController();
-  final _otherPilotLicence = TextEditingController();
-  bool _multiPilot = false;
-  final _myManipHours = TextEditingController();
-  final _myManipMinutes = TextEditingController();
-  _OtherPilotRole? _otherPilotRole;
-  bool _claimPicus = false;
-  bool _interventionNotRequired = false;
-  bool _passengersOnBoard = false;
-
-  @override
-  void dispose() {
-    _otherPilotName.dispose();
-    _otherPilotLicence.dispose();
-    _myManipHours.dispose();
-    _myManipMinutes.dispose();
-    super.dispose();
-  }
+  final CrewFormData data;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final semantic = context.semanticColors;
-    final canClaimPicus = _multiPilot && _command == _Command.other;
+    final multiPilot =
+        data.multiPilotOperation || data.aircraftRequiresMultiCrew;
+    final canClaimPicus =
+        multiPilot && data.command == CommandChoice.otherPilot;
+    final picus = canClaimPicus && data.picusClaimed;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
@@ -67,29 +39,22 @@ class _CrewWithOtherPilotState extends State<CrewWithOtherPilot> {
         children: [
           Text('Who was in command?', style: theme.textTheme.bodyMedium),
           const SizedBox(height: 8),
-          EntrySegmentedChoice<_Command>(
-            options: const [
-              (_Command.me, 'Me'),
-              (_Command.other, 'Other pilot'),
-            ],
-            selected: _command,
-            onChanged: (v) => setState(() => _command = v),
+          EntrySegmentedChoice<CommandChoice>(
+            options: [for (final c in CommandChoice.values) (c, c.label)],
+            selected: data.command,
+            onChanged: data.onCommandChanged,
           ),
           const SizedBox(height: 14),
           Text('Who was flying?', style: theme.textTheme.bodyMedium),
           const SizedBox(height: 8),
-          EntrySegmentedChoice<_Flying>(
-            options: const [
-              (_Flying.me, 'Me'),
-              (_Flying.other, 'Other pilot'),
-              (_Flying.bothSplit, 'Both — split'),
-            ],
-            selected: _flying,
-            onChanged: (v) => setState(() => _flying = v),
+          EntrySegmentedChoice<FlyingChoice>(
+            options: [for (final f in FlyingChoice.values) (f, f.label)],
+            selected: data.flying,
+            onChanged: data.onFlyingChanged,
           ),
-          if (!_multiPilot &&
-              _command == _Command.other &&
-              _flying == _Flying.other) ...[
+          if (!multiPilot &&
+              data.command == CommandChoice.otherPilot &&
+              data.flying == FlyingChoice.otherPilot) ...[
             const SizedBox(height: 12),
             Container(
               padding: const EdgeInsets.all(12),
@@ -125,66 +90,94 @@ class _CrewWithOtherPilotState extends State<CrewWithOtherPilot> {
           ],
           const SizedBox(height: 18),
           TextField(
-            controller: _otherPilotName,
+            controller: data.otherPilotNameController,
             decoration: const InputDecoration(labelText: 'Other pilot name'),
           ),
           const SizedBox(height: 12),
           TextField(
-            controller: _otherPilotLicence,
+            controller: data.otherPilotLicenceController,
             decoration: const InputDecoration(
               labelText: 'Other pilot licence number',
             ),
           ),
           EntryToggleRow(
             label: 'Multi-pilot operation',
-            subtitle: 'Pre-filled from the aircraft record once wired',
-            value: _multiPilot,
-            onChanged: (v) => setState(() => _multiPilot = v),
+            subtitle: data.aircraftRequiresMultiCrew
+                ? 'Pre-filled from the aircraft record'
+                : null,
+            value: multiPilot,
+            onChanged: (_) => data.onToggleMultiPilot(),
           ),
-          if (_flying == _Flying.bothSplit) ...[
+          if (data.flying == FlyingChoice.bothSplit) ...[
             const SizedBox(height: 6),
             DurationField(
               label: 'My manipulation time',
-              hoursController: _myManipHours,
-              minutesController: _myManipMinutes,
+              hoursController: data.otherManipHoursController,
+              minutesController: data.otherManipMinutesController,
             ),
             const SizedBox(height: 12),
           ],
           const SizedBox(height: 12),
-          DropdownButtonFormField<_OtherPilotRole>(
-            initialValue: _otherPilotRole,
+          DropdownButtonFormField<OtherPilotRole>(
+            initialValue: data.otherPilotRole,
+            isExpanded: true,
             decoration: const InputDecoration(labelText: "Other pilot's role"),
             items: [
-              for (final r in _OtherPilotRole.values)
+              for (final r in OtherPilotRole.values)
                 DropdownMenuItem(value: r, child: Text(_roleLabels[r]!)),
             ],
-            onChanged: (v) => setState(() => _otherPilotRole = v),
+            onChanged: data.onOtherPilotRoleChanged,
           ),
           if (canClaimPicus) ...[
             EntryToggleRow(
               label: 'Claim PICUS',
-              value: _claimPicus,
-              onChanged: (v) => setState(() => _claimPicus = v),
+              value: picus,
+              onChanged: (_) => data.onTogglePicus(),
             ),
-            if (_claimPicus)
-              CheckboxListTile(
-                value: _interventionNotRequired,
-                onChanged: (v) =>
-                    setState(() => _interventionNotRequired = v ?? false),
-                controlAffinity: ListTileControlAffinity.leading,
-                contentPadding: EdgeInsets.zero,
-                dense: true,
-                title: Text(
-                  'PIC intervention was not required',
-                  style: theme.textTheme.bodyMedium,
+            if (picus)
+              Container(
+                margin: const EdgeInsets.only(top: 4, bottom: 4),
+                padding: const EdgeInsets.all(11),
+                decoration: BoxDecoration(
+                  border: Border.all(color: theme.colorScheme.outlineVariant),
+                  borderRadius: BorderRadius.circular(9),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Checkbox(
+                      value: data.picInterventionNotRequired,
+                      onChanged: (_) =>
+                          data.onTogglePicInterventionNotRequired(),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 12),
+                        child: Text(
+                          'PIC intervention was not required at any point in '
+                          'the flight.',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
           ],
+          if (data.simulatedInstrumentPresent)
+            EntryToggleRow(
+              label: 'Safety pilot for my simulated instrument',
+              subtitle: 'Records the name per §61.51(b)(1)(v)',
+              value: data.otherPilotRole == OtherPilotRole.safetyPilot,
+              onChanged: (v) => data.onOtherPilotRoleChanged(
+                v ? OtherPilotRole.safetyPilot : null,
+              ),
+            ),
           EntryToggleRow(
             label: 'Passengers on board',
             subtitle: 'Required crew are not passengers',
-            value: _passengersOnBoard,
-            onChanged: (v) => setState(() => _passengersOnBoard = v),
+            value: data.otherPilotPassengers,
+            onChanged: (_) => data.onToggleOtherPilotPassengers(),
           ),
         ],
       ),

--- a/lib/ui/entry/widgets/date_route_section.dart
+++ b/lib/ui/entry/widgets/date_route_section.dart
@@ -14,6 +14,7 @@ class DateRouteSection extends StatelessWidget {
     required this.date,
     required this.onTapDate,
     required this.legControllers,
+    required this.legFocusNodes,
     required this.onAddStop,
     required this.onRemoveStop,
   });
@@ -21,6 +22,12 @@ class DateRouteSection extends StatelessWidget {
   final DateTime date;
   final VoidCallback onTapDate;
   final List<TextEditingController> legControllers;
+
+  /// Parallel to [legControllers], owned and disposed alongside it by the
+  /// parent screen. Lets each `_LegField` hand focus to the *next* leg once
+  /// its four ICAO characters are typed, instead of leaving the pilot to
+  /// tap across every field by hand.
+  final List<FocusNode> legFocusNodes;
   final VoidCallback onAddStop;
   final ValueChanged<int> onRemoveStop;
 
@@ -90,6 +97,10 @@ class DateRouteSection extends StatelessWidget {
                             ),
                           _LegField(
                             controller: legControllers[i],
+                            focusNode: legFocusNodes[i],
+                            nextFocusNode: i + 1 < legFocusNodes.length
+                                ? legFocusNodes[i + 1]
+                                : null,
                             removable: i != 0 && i != legControllers.length - 1,
                             onRemove: () => onRemoveStop(i),
                           ),
@@ -123,11 +134,17 @@ class DateRouteSection extends StatelessWidget {
 class _LegField extends StatelessWidget {
   const _LegField({
     required this.controller,
+    required this.focusNode,
+    required this.nextFocusNode,
     required this.removable,
     required this.onRemove,
   });
 
   final TextEditingController controller;
+  final FocusNode focusNode;
+
+  /// Null for the last leg — nothing to advance to.
+  final FocusNode? nextFocusNode;
   final bool removable;
   final VoidCallback onRemove;
 
@@ -140,6 +157,7 @@ class _LegField extends StatelessWidget {
         IntrinsicWidth(
           child: TextField(
             controller: controller,
+            focusNode: focusNode,
             textAlign: TextAlign.right,
             textCapitalization: TextCapitalization.characters,
             maxLength: 4,
@@ -159,6 +177,16 @@ class _LegField extends StatelessWidget {
               contentPadding: EdgeInsets.zero,
               hintText: 'ICAO',
             ),
+            // A 4-character ICAO code is always complete at 4 characters —
+            // advancing there, rather than waiting for the pilot to tap the
+            // next field by hand, is the whole point of a fixed-length
+            // identifier (docs/entry-form.md never expects a 3-character
+            // code to be topped up later).
+            onChanged: (value) {
+              if (value.length >= 4 && nextFocusNode != null) {
+                FocusScope.of(context).requestFocus(nextFocusNode);
+              }
+            },
           ),
         ),
         if (removable)

--- a/lib/ui/entry/widgets/duration_field.dart
+++ b/lib/ui/entry/widgets/duration_field.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import '../../theme/app_colors.dart';
 
 /// A compact hours/minutes entry, for durations that are typed directly
-/// rather than derived — manipulation time (§4B, §4C), and later the
+/// rather than derived — manipulation time (§4B, §4C), and the
 /// instrument-time fields in §6. Borderless, matching [EntryValueColumn]'s
 /// label-over-value shape, so it reads as part of the surrounding card
 /// rather than a boxed field of its own.
@@ -14,11 +14,25 @@ class DurationField extends StatelessWidget {
     required this.label,
     required this.hoursController,
     required this.minutesController,
+    this.blockTimeText,
+    this.onFillFromBlock,
   });
 
   final String label;
   final TextEditingController hoursController;
   final TextEditingController minutesController;
+
+  /// The current block time, formatted as `H:MM` (e.g. `2:15`) — shown in
+  /// the fill button's tooltip so the pilot can see what one tap will
+  /// enter without having to scroll up to the Times section first.
+  final String? blockTimeText;
+
+  /// Fills [hoursController]/[minutesController] with the flight's block
+  /// time in one tap. Null hides the button — either the caller doesn't
+  /// offer the shortcut for this field (manipulation time is, by
+  /// definition, usually *less* than the whole flight), or block time
+  /// isn't known yet.
+  final VoidCallback? onFillFromBlock;
 
   @override
   Widget build(BuildContext context) {
@@ -79,6 +93,40 @@ class DurationField extends StatelessWidget {
                 style: theme.textTheme.bodyMedium?.copyWith(color: ink.faint),
               ),
             ),
+            if (onFillFromBlock != null) ...[
+              const SizedBox(width: 4),
+              Tooltip(
+                message: blockTimeText != null
+                    ? 'Fill with block time ($blockTimeText)'
+                    : 'Fill with block time',
+                child: InkWell(
+                  onTap: onFillFromBlock,
+                  borderRadius: BorderRadius.circular(6),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: theme.colorScheme.primary.withValues(alpha: 0.4),
+                      ),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(
+                      'BLOCK',
+                      style: TextStyle(
+                        fontFamily: 'IBM Plex Mono',
+                        fontWeight: FontWeight.w600,
+                        fontSize: 9.5,
+                        letterSpacing: 0.4,
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ],

--- a/lib/ui/entry/widgets/entry_footer.dart
+++ b/lib/ui/entry/widgets/entry_footer.dart
@@ -1,27 +1,115 @@
 import 'package:flutter/material.dart';
 
+import '../../../domain/projection/derived_quantity.dart';
+import '../../../domain/projection/projection_result.dart';
 import '../../theme/app_typography.dart';
+
+/// Named-quantity display order + labels per jurisdiction — presentation
+/// concerns only (which of a [ProjectionResult]'s named quantities are
+/// worth a pilot's attention, and what to call them), never a
+/// re-derivation of what value they hold. The values themselves always
+/// come from `JurisdictionProjection` via `flight_draft_mapper.dart`.
+const Map<String, String> _easaLabels = {
+  'pic': 'PIC',
+  'dual': 'Dual',
+  'spic': 'SPIC',
+  'picus': 'PICUS',
+  'copilot': 'Co-pilot',
+  'instructor': 'Instructor',
+  // easa_instrument_time.dart's whole-block-or-nothing 'ifr' quantity —
+  // the only visible effect of §6's "IFR flight plan filed" toggle, so
+  // without this row the toggle looks like it does nothing.
+  'ifr': 'IFR',
+};
+
+const Map<String, String> _faaLabels = {
+  'actingPic': 'Acting PIC',
+  'loggedPic': 'PIC',
+  'dualReceived': 'Dual',
+  'sic': 'SIC',
+  'solo': 'Solo',
+  // faa_instrument_time.dart carries §6's actual/simulated instrument
+  // fields straight through — same reasoning as 'ifr' above.
+  'actualInstrument': 'Actual instrument',
+  'simulatedInstrument': 'Simulated instrument',
+};
+
+class _Line {
+  const _Line(this.label, this.quantity);
+  final String label;
+  final DerivedQuantity quantity;
+}
+
+/// Fixed, theme-invariant accent colours for the two jurisdictions — the
+/// footer card itself is always near-black regardless of the app's own
+/// light/dark theme, so these are picked for contrast against that one
+/// background rather than sourced from `context.semanticColors`, which
+/// flips with the ambient theme. Blue for
+/// EASA and ochre for FAA deliberately echo the app's own primary/secondary
+/// ("night"/"day") accent pairing — CLAUDE.md: "today: EASA primary, FAA
+/// secondary" — so the association reads the same way it does everywhere
+/// else in the app, not a one-off pair invented for this card.
+const Color _easaAccent = Color(0xFF80A3F0);
+const Color _faaAccent = Color(0xFFE3B47D);
+
+List<_Line> _nonZeroLines(
+  ProjectionResult? result,
+  Map<String, String> labels,
+) {
+  if (result == null) return const [];
+  final lines = <_Line>[];
+  for (final entry in labels.entries) {
+    final q = result[entry.key];
+    if (q == null) continue;
+    if (q.value.inMinutes == 0 && q.creditable) continue;
+    lines.add(_Line(entry.value, q));
+  }
+  return lines;
+}
+
+String _summary(List<_Line> lines) {
+  if (lines.isEmpty) return 'no time logged';
+  return lines
+      .map(
+        (l) => l.quantity.creditable
+            ? '${l.label} ${l.quantity.value.toHoursMinutes()}'
+            : '${l.label} ${l.quantity.value.toHoursMinutes()} (pending)',
+      )
+      .join(', ');
+}
 
 /// §7 + §3 of docs/entry-form.md: the derivation strip sits pinned above
 /// the save controls, and "Save draft" is a peer of "Save", never a hidden
-/// option — a flight can always be saved incomplete. Styled as the
-/// mockups' "THIS ENTRY PRODUCES" card: a dark surface distinct from the
-/// page, not another bordered box in the same style as the form above it.
-///
-/// The card only shows block time for now; the per-jurisdiction breakdown
-/// ("EASA: Dual 1:30 · FAA: PIC 1:30") needs the projection engine wired
-/// in, which this screen doesn't have yet.
-class EntryFooter extends StatelessWidget {
+/// option. Tapping the strip expands the full per-jurisdiction breakdown,
+/// each line traceable to the rule that produced it
+/// ([DerivedQuantity.explanation]) — no "Override" affordance yet, since
+/// §8's override-with-reason mechanism doesn't exist in this codebase yet;
+/// rendering a button that doesn't do anything would be worse than not
+/// having one.
+class EntryFooter extends StatefulWidget {
   const EntryFooter({
     super.key,
-    required this.blockTime,
+    required this.blockTimeText,
+    required this.easaResult,
+    required this.faaResult,
+    required this.hasFaaLicence,
     required this.onSaveDraft,
     required this.onSave,
   });
 
-  final Duration? blockTime;
+  final String blockTimeText;
+  final ProjectionResult? easaResult;
+  final ProjectionResult? faaResult;
+  final bool hasFaaLicence;
   final VoidCallback onSaveDraft;
   final VoidCallback onSave;
+
+  @override
+  State<EntryFooter> createState() => _EntryFooterState();
+}
+
+class _EntryFooterState extends State<EntryFooter> {
+  bool _expanded = false;
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +118,23 @@ class EntryFooter extends StatelessWidget {
     final cardBg = isDark ? const Color(0xFF25272C) : const Color(0xFF14161A);
     const onCard = Colors.white;
     final onCardMuted = Colors.white.withValues(alpha: 0.55);
+
+    final easaLines = _nonZeroLines(widget.easaResult, _easaLabels);
+    final faaLines = _nonZeroLines(widget.faaResult, _faaLabels);
+    final hasBreakdown = widget.easaResult != null;
+
+    // A coarse divergence signal, not a re-derivation: does either side
+    // claim command-grade PIC time (creditable and non-zero) while the
+    // other side doesn't? That's the case docs/entry-form.md §7 exists to
+    // surface before saving, not after.
+    final easaPic = widget.easaResult?['pic'];
+    final faaLoggedPic = widget.faaResult?['loggedPic'];
+    final mismatch =
+        widget.hasFaaLicence &&
+        easaPic != null &&
+        faaLoggedPic != null &&
+        (easaPic.creditable && easaPic.value.inMinutes > 0) !=
+            (faaLoggedPic.creditable && faaLoggedPic.value.inMinutes > 0);
 
     return DecoratedBox(
       decoration: BoxDecoration(color: theme.scaffoldBackgroundColor),
@@ -40,68 +145,201 @@ class EntryFooter extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Container(
-                width: double.infinity,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 12,
-                ),
-                decoration: BoxDecoration(
-                  color: cardBg,
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'THIS ENTRY PRODUCES',
-                      style: TextStyle(
-                        fontFamily: 'IBM Plex Mono',
-                        fontSize: 9,
-                        letterSpacing: 1.1,
-                        color: onCardMuted,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text.rich(
-                      TextSpan(
+              InkWell(
+                onTap: hasBreakdown
+                    ? () => setState(() => _expanded = !_expanded)
+                    : null,
+                borderRadius: BorderRadius.circular(12),
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: cardBg,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
                         children: [
-                          TextSpan(
-                            text: blockTime != null
-                                ? _formatDuration(blockTime!)
-                                : '—:—',
-                            style: AppMonoText.value(
-                              onCard,
-                              size: 13,
-                              weight: FontWeight.w500,
+                          Text(
+                            'THIS ENTRY PRODUCES',
+                            style: TextStyle(
+                              fontFamily: 'IBM Plex Mono',
+                              fontSize: 9,
+                              letterSpacing: 1.1,
+                              color: onCardMuted,
                             ),
                           ),
-                          TextSpan(
-                            text:
-                                ' block · jurisdiction breakdown appears once crew is entered',
-                            style: AppMonoText.value(
-                              onCardMuted,
-                              size: 13,
-                              weight: FontWeight.w400,
+                          const Spacer(),
+                          if (mismatch) ...[
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: const Color(0x33E3B47D),
+                                border: Border.all(
+                                  color: const Color(0x88E3B47D),
+                                ),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: const Text(
+                                '⇄ MISMATCH',
+                                style: TextStyle(
+                                  fontFamily: 'IBM Plex Mono',
+                                  fontSize: 9.5,
+                                  fontWeight: FontWeight.w600,
+                                  letterSpacing: 0.5,
+                                  color: Color(0xFFE3B47D),
+                                ),
+                              ),
                             ),
-                          ),
+                          ],
+                          if (hasBreakdown) ...[
+                            const SizedBox(width: 6),
+                            AnimatedRotation(
+                              turns: _expanded ? 0.5 : 0,
+                              duration: const Duration(milliseconds: 150),
+                              child: Icon(
+                                Icons.expand_more,
+                                size: 16,
+                                color: onCardMuted,
+                              ),
+                            ),
+                          ],
                         ],
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 6),
+                      Text.rich(
+                        TextSpan(
+                          children: [
+                            TextSpan(
+                              text: widget.blockTimeText,
+                              style: AppMonoText.value(
+                                onCard,
+                                size: 13,
+                                weight: FontWeight.w500,
+                              ),
+                            ),
+                            // Expanded, the breakdown below already shows
+                            // every quantity — repeating the same summary
+                            // inline here is redundant, so it's replaced
+                            // with a bare "block" until collapsed again.
+                            if (!hasBreakdown)
+                              TextSpan(
+                                text:
+                                    ' block · jurisdiction breakdown '
+                                    'appears once crew is entered',
+                                style: AppMonoText.value(
+                                  onCardMuted,
+                                  size: 13,
+                                  weight: FontWeight.w400,
+                                ),
+                              )
+                            else if (_expanded)
+                              TextSpan(
+                                text: ' block',
+                                style: AppMonoText.value(
+                                  onCardMuted,
+                                  size: 13,
+                                  weight: FontWeight.w400,
+                                ),
+                              )
+                            else ...[
+                              TextSpan(
+                                text: ' block · ',
+                                style: AppMonoText.value(
+                                  onCardMuted,
+                                  size: 13,
+                                  weight: FontWeight.w400,
+                                ),
+                              ),
+                              TextSpan(
+                                text: 'EASA: ',
+                                style: AppMonoText.value(
+                                  _easaAccent,
+                                  size: 13,
+                                  weight: FontWeight.w600,
+                                ),
+                              ),
+                              TextSpan(
+                                text: _summary(easaLines),
+                                style: AppMonoText.value(
+                                  onCardMuted,
+                                  size: 13,
+                                  weight: FontWeight.w400,
+                                ),
+                              ),
+                              if (widget.hasFaaLicence) ...[
+                                TextSpan(
+                                  text: ' · ',
+                                  style: AppMonoText.value(
+                                    onCardMuted,
+                                    size: 13,
+                                    weight: FontWeight.w400,
+                                  ),
+                                ),
+                                TextSpan(
+                                  text: 'FAA: ',
+                                  style: AppMonoText.value(
+                                    _faaAccent,
+                                    size: 13,
+                                    weight: FontWeight.w600,
+                                  ),
+                                ),
+                                TextSpan(
+                                  text: _summary(faaLines),
+                                  style: AppMonoText.value(
+                                    onCardMuted,
+                                    size: 13,
+                                    weight: FontWeight.w400,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ],
+                        ),
+                      ),
+                      if (_expanded && hasBreakdown) ...[
+                        const SizedBox(height: 10),
+                        _JurisdictionGroup(
+                          label: 'EASA',
+                          accent: _easaAccent,
+                          lines: easaLines,
+                          onCard: onCard,
+                          onCardMuted: onCardMuted,
+                        ),
+                        if (widget.hasFaaLicence) ...[
+                          const SizedBox(height: 10),
+                          _JurisdictionGroup(
+                            label: 'FAA',
+                            accent: _faaAccent,
+                            lines: faaLines,
+                            onCard: onCard,
+                            onCardMuted: onCardMuted,
+                          ),
+                        ],
+                      ],
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(height: 10),
               Row(
                 children: [
                   OutlinedButton(
-                    onPressed: onSaveDraft,
+                    onPressed: widget.onSaveDraft,
                     child: const Text('Draft'),
                   ),
                   const SizedBox(width: 10),
                   Expanded(
                     child: FilledButton(
-                      onPressed: onSave,
+                      onPressed: widget.onSave,
                       child: const Text('Save flight'),
                     ),
                   ),
@@ -115,8 +353,133 @@ class EntryFooter extends StatelessWidget {
   }
 }
 
-String _formatDuration(Duration d) {
-  final hours = d.inHours;
-  final minutes = d.inMinutes.remainder(60).abs();
-  return '$hours:${minutes.toString().padLeft(2, '0')}';
+/// One jurisdiction's slice of the expanded breakdown — a coloured label
+/// plus a left accent bar running the height of its rows, so EASA and FAA
+/// read as two visually distinct groups instead of one undifferentiated
+/// list (they used to share a single divider and no colour at all).
+class _JurisdictionGroup extends StatelessWidget {
+  const _JurisdictionGroup({
+    required this.label,
+    required this.accent,
+    required this.lines,
+    required this.onCard,
+    required this.onCardMuted,
+  });
+
+  final String label;
+  final Color accent;
+  final List<_Line> lines;
+  final Color onCard;
+  final Color onCardMuted;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 3,
+          margin: const EdgeInsets.only(top: 3),
+          decoration: BoxDecoration(
+            color: accent.withValues(alpha: 0.55),
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: TextStyle(
+                  fontFamily: 'IBM Plex Mono',
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1,
+                  color: accent,
+                ),
+              ),
+              if (lines.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 6),
+                  child: Text(
+                    'No time logged',
+                    style: TextStyle(
+                      fontFamily: 'Instrument Sans',
+                      fontSize: 11.5,
+                      color: onCardMuted,
+                    ),
+                  ),
+                )
+              else
+                for (final line in lines)
+                  _BreakdownRow(
+                    line: line,
+                    onCard: onCard,
+                    onCardMuted: onCardMuted,
+                  ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BreakdownRow extends StatelessWidget {
+  const _BreakdownRow({
+    required this.line,
+    required this.onCard,
+    required this.onCardMuted,
+  });
+
+  final _Line line;
+  final Color onCard;
+  final Color onCardMuted;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  line.label,
+                  style: TextStyle(
+                    fontFamily: 'Instrument Sans',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12,
+                    color: line.quantity.creditable
+                        ? onCard
+                        : const Color(0xFFE3B47D),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  line.quantity.explanation,
+                  style: TextStyle(
+                    fontFamily: 'Instrument Sans',
+                    fontSize: 10.5,
+                    height: 1.4,
+                    color: onCardMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          Text(
+            line.quantity.value.toHoursMinutes(),
+            style: AppMonoText.value(onCard, size: 14, weight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/ui/entry/widgets/entry_section_label.dart
+++ b/lib/ui/entry/widgets/entry_section_label.dart
@@ -55,7 +55,11 @@ class EntrySection extends StatelessWidget {
           else
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [EntrySectionLabel(label), trailing!],
+              children: [
+                Expanded(child: EntrySectionLabel(label)),
+                const SizedBox(width: 8),
+                trailing!,
+              ],
             ),
           const SizedBox(height: 8),
           child,

--- a/lib/ui/entry/widgets/remarks_section.dart
+++ b/lib/ui/entry/widgets/remarks_section.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+import '../entry_form_types.dart';
+import 'countersignature_block.dart';
+import 'entry_card.dart';
+import 'entry_section_label.dart';
+
+/// §4B/§4C + §7 of docs/entry-form.md: the remarks textarea (AMC1 FCL.050
+/// column 12), the mandatory-remarks nudge some purposes-of-flight force,
+/// and the countersignature block — shown whenever the flight needs one
+/// (receiving instruction, SPIC, or a claimed PICUS), never gated on
+/// whether the entry is a draft.
+class RemarksSection extends StatelessWidget {
+  const RemarksSection({
+    super.key,
+    required this.controller,
+    required this.remarksRequiredNote,
+    required this.showCountersignature,
+    required this.sign,
+    required this.onSignChanged,
+    required this.signedAt,
+    required this.signatoryName,
+  });
+
+  final TextEditingController controller;
+
+  /// Non-empty when the selected purpose of flight requires a remarks entry
+  /// and none has been given yet — `null`/empty otherwise.
+  final String? remarksRequiredNote;
+
+  final bool showCountersignature;
+  final SignChoice sign;
+  final ValueChanged<SignChoice> onSignChanged;
+  final DateTime? signedAt;
+  final String signatoryName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final needsRemarks = (remarksRequiredNote ?? '').isNotEmpty;
+
+    return EntrySection(
+      label: 'Remarks and endorsements',
+      child: EntryCard(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: controller,
+              maxLines: 3,
+              decoration: InputDecoration(
+                isDense: true,
+                hintText: needsRemarks
+                    ? 'Required for this purpose of flight'
+                    : 'Optional — column 12 is yours',
+                enabledBorder: needsRemarks && controller.text.isEmpty
+                    ? OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(9),
+                        borderSide: BorderSide(
+                          color: context.semanticColors.currencyWarning
+                              .withValues(alpha: 0.6),
+                        ),
+                      )
+                    : null,
+              ),
+            ),
+            if (needsRemarks && controller.text.isEmpty) ...[
+              const SizedBox(height: 6),
+              Text(
+                remarksRequiredNote!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: context.semanticColors.currencyWarning,
+                ),
+              ),
+            ],
+            if (showCountersignature) ...[
+              const SizedBox(height: 13),
+              CountersignatureBlock(
+                sign: sign,
+                onSignChanged: onSignChanged,
+                signedAt: signedAt,
+                signatoryName: signatoryName,
+              ),
+            ],
+            const SizedBox(height: 10),
+            Text(
+              'Validation annotates fields on blur and never blocks the '
+              'save. A flight can always be saved incomplete.',
+              style: theme.textTheme.bodySmall?.copyWith(color: ink.faint),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/entry/widgets/times_section.dart
+++ b/lib/ui/entry/widgets/times_section.dart
@@ -9,10 +9,26 @@ import 'entry_value_column.dart';
 /// legal figure under both EASA and FAA — this is not an "air time first"
 /// mode dressed up, it's the one time figure every jurisdiction agrees on.
 ///
-/// Local entry with a persistent UTC echo beneath: what's typed is what the
-/// pilot thinks in, UTC is what's stored (CLAUDE.md rule 3). The echo here
-/// is a stub — real timezone resolution against the departure aerodrome is
-/// a data-layer concern (#63), not this widget's.
+/// Entry is Zulu, not local — CLAUDE.md rule 3 ("all stored times are
+/// UTC... never persist a naive DateTime") applies just as much to what the
+/// pilot types as to what ends up in `Flight`, so there is no separate
+/// "local entry, UTC echo" mode to get out of sync with each other. A local
+/// reference under each field, computed from the departure/destination
+/// ICAO's timezone, was scoped for this pass but deferred: it needs either
+/// a bundled lat/lon→IANA-timezone dataset (the one Dart package found for
+/// this is a ~150MB geo-boundary database, impractical for a mobile app and
+/// a per-keystroke field) or a smaller airport-keyed dataset like
+/// OpenFlights' `airports.dat`, neither of which is in this repo yet. Land
+/// that as its own pass rather than half-wiring it here.
+///
+/// The block figure is itself editable: typing a value that differs from
+/// the computed one is an override (docs/entry-form.md §2 — "store the
+/// override alongside the raw times; never silently rewrite the times to
+/// match"). The override is display-only for now: it never rewrites
+/// [offBlocks]/[onBlocks], and — since `Flight` has nowhere to persist a
+/// block-time override yet — it isn't fed into the draft `Flight` used for
+/// the derivation strip either. That's `flight_draft_mapper.dart`'s
+/// [DraftFlightInputs] deliberately not taking one.
 class TimesSection extends StatefulWidget {
   const TimesSection({
     super.key,
@@ -21,6 +37,10 @@ class TimesSection extends StatefulWidget {
     required this.onTapOffBlocks,
     required this.onTapOnBlocks,
     required this.blockTime,
+    required this.blockOverrideText,
+    required this.onBlockOverrideChanged,
+    required this.startLabel,
+    required this.endLabel,
     required this.takeoff,
     required this.landing,
     required this.onTapTakeoff,
@@ -32,6 +52,16 @@ class TimesSection extends StatefulWidget {
   final VoidCallback onTapOffBlocks;
   final VoidCallback onTapOnBlocks;
   final Duration? blockTime;
+
+  /// The pilot's raw override text, or `null`/empty when not overridden.
+  final String? blockOverrideText;
+  final ValueChanged<String> onBlockOverrideChanged;
+
+  /// "Off blocks"/"On blocks" for an aeroplane, "Rotors start"/"Rotors
+  /// stop" for a helicopter — read from the resolved aircraft's category.
+  final String startLabel;
+  final String endLabel;
+
   final TimeOfDay? takeoff;
   final TimeOfDay? landing;
   final VoidCallback onTapTakeoff;
@@ -43,16 +73,49 @@ class TimesSection extends StatefulWidget {
 
 class _TimesSectionState extends State<TimesSection> {
   bool _airTimeExpanded = false;
+  late final TextEditingController _blockController;
+
+  String get _computedText =>
+      widget.blockTime != null ? _formatDuration(widget.blockTime!) : '—:—';
+
+  @override
+  void initState() {
+    super.initState();
+    _blockController = TextEditingController(
+      text: widget.blockOverrideText?.isNotEmpty == true
+          ? widget.blockOverrideText
+          : _computedText,
+    );
+  }
+
+  @override
+  void didUpdateWidget(TimesSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final overridden = widget.blockOverrideText?.isNotEmpty == true;
+    final shown = overridden ? widget.blockOverrideText! : _computedText;
+    if (_blockController.text != shown && !overridden) {
+      _blockController.text = shown;
+    }
+  }
+
+  @override
+  void dispose() {
+    _blockController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final ink = context.inkTiers;
     final theme = Theme.of(context);
+    final overridden =
+        widget.blockOverrideText?.isNotEmpty == true &&
+        widget.blockOverrideText != _computedText;
 
     return EntrySection(
       label: 'Times',
       trailing: Text(
-        'LOCAL · STORED UTC',
+        'ALL TIMES ZULU',
         style: theme.textTheme.labelSmall?.copyWith(
           color: ink.faint,
           letterSpacing: 0.6,
@@ -67,32 +130,32 @@ class _TimesSectionState extends State<TimesSection> {
               children: [
                 Expanded(
                   child: EntryValueColumn(
-                    label: 'Off blocks',
+                    label: widget.startLabel,
                     value: widget.offBlocks != null
-                        ? _formatTimeOfDay(widget.offBlocks!)
-                        : '--:--',
-                    subValue: widget.offBlocks != null
                         ? '${_formatTimeOfDay(widget.offBlocks!)}Z'
-                        : null,
+                        : '--:--',
                     placeholder: widget.offBlocks == null,
                     onTap: widget.onTapOffBlocks,
                   ),
                 ),
                 Expanded(
                   child: EntryValueColumn(
-                    label: 'On blocks',
+                    label: widget.endLabel,
                     value: widget.onBlocks != null
-                        ? _formatTimeOfDay(widget.onBlocks!)
-                        : '--:--',
-                    subValue: widget.onBlocks != null
                         ? '${_formatTimeOfDay(widget.onBlocks!)}Z'
-                        : null,
+                        : '--:--',
                     placeholder: widget.onBlocks == null,
                     onTap: widget.onTapOnBlocks,
                   ),
                 ),
                 Container(
                   padding: const EdgeInsets.only(left: 12),
+                  // Wide enough that a two-digit-hour block time ("15:19")
+                  // never gets clipped by the single-line TextField's
+                  // internal horizontal scroll — 74px cut the trailing
+                  // digit off on a real device (only single-digit hours
+                  // happened to fit in testing).
+                  width: 96,
                   decoration: BoxDecoration(
                     border: Border(
                       left: BorderSide(
@@ -100,13 +163,45 @@ class _TimesSectionState extends State<TimesSection> {
                       ),
                     ),
                   ),
-                  child: EntryValueColumn(
-                    label: 'Block',
-                    value: widget.blockTime != null
-                        ? _formatDuration(widget.blockTime!)
-                        : '—:—',
-                    accent: true,
-                    placeholder: widget.blockTime == null,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'BLOCK',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: ink.faint,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      TextField(
+                        controller: _blockController,
+                        onChanged: widget.onBlockOverrideChanged,
+                        style: TextStyle(
+                          fontFamily: 'IBM Plex Mono',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 19,
+                          color: overridden
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.onSurface,
+                        ),
+                        decoration: const InputDecoration(
+                          isDense: true,
+                          border: InputBorder.none,
+                          enabledBorder: InputBorder.none,
+                          focusedBorder: InputBorder.none,
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                      ),
+                      Text(
+                        overridden ? 'override · $_computedText' : 'computed',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          fontSize: 10,
+                          color: overridden
+                              ? context.semanticColors.currencyWarning
+                              : ink.faint,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ],
@@ -135,11 +230,14 @@ class _TimesSectionState extends State<TimesSection> {
                         color: ink.medium,
                       ),
                     ),
-                    const Spacer(),
-                    Text(
-                      'optional',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: ink.faint,
+                    Expanded(
+                      child: Text(
+                        'optional · not logged as total',
+                        textAlign: TextAlign.right,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: ink.faint,
+                        ),
                       ),
                     ),
                   ],
@@ -155,7 +253,7 @@ class _TimesSectionState extends State<TimesSection> {
                       child: EntryValueColumn(
                         label: 'Take-off',
                         value: widget.takeoff != null
-                            ? _formatTimeOfDay(widget.takeoff!)
+                            ? '${_formatTimeOfDay(widget.takeoff!)}Z'
                             : '--:--',
                         placeholder: widget.takeoff == null,
                         onTap: widget.onTapTakeoff,
@@ -165,7 +263,7 @@ class _TimesSectionState extends State<TimesSection> {
                       child: EntryValueColumn(
                         label: 'Landing',
                         value: widget.landing != null
-                            ? _formatTimeOfDay(widget.landing!)
+                            ? '${_formatTimeOfDay(widget.landing!)}Z'
                             : '--:--',
                         placeholder: widget.landing == null,
                         onTap: widget.onTapLanding,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -423,10 +423,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -439,10 +439,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -700,26 +700,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -748,10 +748,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,8 @@ flutter:
     - assets/aerodromes/
     - assets/jurisdictions/
     - assets/rules/
+    - assets/rules/easa/
+    - assets/rules/faa/
   fonts:
     # Variable font (wdth,wght axes) — the same file is listed once per
     # weight; Flutter/Skia resolves each request against the font's own

--- a/test/data/database_migration_test.dart
+++ b/test/data/database_migration_test.dart
@@ -161,14 +161,30 @@ void _seedV2Database(String path) {
 /// As [_seedV2Database], but at v3, with a `flights` row already on
 /// disk — to prove #121's `addColumn` step preserves existing flight data
 /// and backfills the new column's default rather than, say, requiring every
-/// row to be rewritten by the app first. `pilot_profile`/`held_*` are
-/// omitted for the same reason [_seedV1Database] omits the other v1
-/// tables: irrelevant to the one step under test here, and the `from < 2`/
-/// `from < 3` migration blocks never run for a database already at v3, so
-/// their absence doesn't trip anything.
+/// row to be rewritten by the app first. `held_*` is omitted for the same
+/// reason [_seedV1Database] omits the other v1 tables: irrelevant to the one
+/// step under test here, and the `from < 3` migration block never runs for a
+/// database already at v3, so its absence doesn't trip anything.
+///
+/// `pilot_profile` **is** included, at its pre-v5 shape (no
+/// `primary_jurisdiction_id`) — a real v3 database always has this table
+/// from its earlier v1->v2 upgrade, and the later `from < 5` step in
+/// `database.dart` alters it, so a seed that omitted it would fail that
+/// step with "no such table" rather than exercising it honestly.
 void _seedV3Database(String path) {
   final db = sqlite3.sqlite3.open(path);
   try {
+    db.execute('''
+      CREATE TABLE pilot_profile (
+        id TEXT NOT NULL,
+        date_of_birth TEXT NOT NULL,
+        PRIMARY KEY (id)
+      )
+    ''');
+    db.execute('INSERT INTO pilot_profile (id, date_of_birth) VALUES (?, ?)', [
+      'singleton',
+      '1990-01-01',
+    ]);
     db.execute('''
       CREATE TABLE aircraft (
         id TEXT NOT NULL,
@@ -285,7 +301,10 @@ void main() {
       expect(aircraftRows.single.registration, 'G-ABCD');
 
       final pilotProfiles = PilotProfileRepository(db);
-      const profile = PilotProfile(dateOfBirth: CalendarDate(1990, 1, 1));
+      const profile = PilotProfile(
+        dateOfBirth: CalendarDate(1990, 1, 1),
+        primaryJurisdictionId: 'eu.easa.part-fcl',
+      );
       await pilotProfiles.save(profile);
       expect(await pilotProfiles.find(), profile);
 
@@ -316,7 +335,13 @@ void main() {
       final pilotProfiles = PilotProfileRepository(db);
       expect(
         await pilotProfiles.find(),
-        const PilotProfile(dateOfBirth: CalendarDate(1990, 1, 1)),
+        // primaryJurisdictionId didn't exist at v2 -- the v4->v5 addColumn
+        // step backfills its default, same proof-of-backfill shape as
+        // #121's alternativeComplianceEvents column above.
+        const PilotProfile(
+          dateOfBirth: CalendarDate(1990, 1, 1),
+          primaryJurisdictionId: 'eu.easa.part-fcl',
+        ),
       );
 
       final heldRatings = HeldRatingRepository(db);

--- a/test/data/repositories/pilot_profile_repository_test.dart
+++ b/test/data/repositories/pilot_profile_repository_test.dart
@@ -21,7 +21,10 @@ void main() {
   });
 
   test('round-trips through save and find', () async {
-    const profile = PilotProfile(dateOfBirth: CalendarDate(1990, 6, 15));
+    const profile = PilotProfile(
+      dateOfBirth: CalendarDate(1990, 6, 15),
+      primaryJurisdictionId: 'eu.easa.part-fcl',
+    );
 
     await repository.save(profile);
 
@@ -32,15 +35,24 @@ void main() {
     'saving again replaces the single row rather than adding a second one',
     () async {
       await repository.save(
-        const PilotProfile(dateOfBirth: CalendarDate(1990, 6, 15)),
+        const PilotProfile(
+          dateOfBirth: CalendarDate(1990, 6, 15),
+          primaryJurisdictionId: 'eu.easa.part-fcl',
+        ),
       );
       await repository.save(
-        const PilotProfile(dateOfBirth: CalendarDate(1985, 1, 1)),
+        const PilotProfile(
+          dateOfBirth: CalendarDate(1985, 1, 1),
+          primaryJurisdictionId: 'us.faa.part61',
+        ),
       );
 
       expect(
         await repository.find(),
-        const PilotProfile(dateOfBirth: CalendarDate(1985, 1, 1)),
+        const PilotProfile(
+          dateOfBirth: CalendarDate(1985, 1, 1),
+          primaryJurisdictionId: 'us.faa.part61',
+        ),
       );
     },
   );

--- a/test/domain/currency/currency_dashboard_test.dart
+++ b/test/domain/currency/currency_dashboard_test.dart
@@ -1,0 +1,168 @@
+import 'package:easa_digital_log/domain/currency/currency_dashboard.dart';
+import 'package:easa_digital_log/domain/currency/currency_rule_loader.dart';
+import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
+import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _asOf = CalendarDate(2024, 6, 1);
+
+String _ruleYaml({
+  required String id,
+  required String jurisdiction,
+  required String heldRecordKind,
+}) =>
+    '''
+id: $id
+jurisdiction: $jurisdiction
+citation: "test citation"
+title: "Test rule $id"
+effective_from: 2011-01-01
+requirement:
+  kind: held_record_currently_valid
+  held_record_kind: $heldRecordKind
+''';
+
+void main() {
+  late CurrencyRuleLoader loader;
+
+  setUp(() {
+    loader = CurrencyRuleLoader.fromYaml([
+      _ruleYaml(
+        id: 'test.satisfied.far',
+        jurisdiction: 'eu.easa.part-fcl',
+        heldRecordKind: 'far',
+      ),
+      _ruleYaml(
+        id: 'test.satisfied.soon',
+        jurisdiction: 'eu.easa.part-fcl',
+        heldRecordKind: 'soon',
+      ),
+      _ruleYaml(
+        id: 'test.unsatisfied',
+        jurisdiction: 'us.faa.part61',
+        heldRecordKind: 'never-held',
+      ),
+    ]);
+  });
+
+  EvaluationSubject subjectWith(List<HeldRecord> records) =>
+      EvaluationSubject(flights: const [], heldRecords: records);
+
+  test(
+    'a satisfied rule expiring well outside the hero window is not at risk',
+    () {
+      final dashboard = buildCurrencyDashboard(
+        licences: [
+          const CurrencyLicenceSpec(
+            jurisdictionId: 'eu.easa.part-fcl',
+            label: 'EASA',
+            isPrimary: true,
+            privilegeSummary: 'PPL(A)',
+            ruleIds: ['test.satisfied.far'],
+          ),
+        ],
+        loader: loader,
+        subject: subjectWith([
+          HeldRecord(
+            kind: 'far',
+            validFrom: CalendarDate(2023, 1, 1),
+            validUntil: CalendarDate(2025, 1, 1),
+          ),
+        ]),
+        asOf: _asOf,
+      );
+
+      expect(dashboard.groups.single.rows.single.isAtRisk, isFalse);
+      expect(dashboard.atRiskRows, isEmpty);
+    },
+  );
+
+  test('a satisfied rule expiring inside the hero window is at risk', () {
+    final dashboard = buildCurrencyDashboard(
+      licences: [
+        const CurrencyLicenceSpec(
+          jurisdictionId: 'eu.easa.part-fcl',
+          label: 'EASA',
+          isPrimary: true,
+          privilegeSummary: 'PPL(A)',
+          ruleIds: ['test.satisfied.soon'],
+        ),
+      ],
+      loader: loader,
+      subject: subjectWith([
+        HeldRecord(
+          kind: 'soon',
+          validFrom: CalendarDate(2023, 1, 1),
+          validUntil: CalendarDate(2024, 6, 20), // 19 days from asOf.
+        ),
+      ]),
+      asOf: _asOf,
+      heroLeadDays: 30,
+    );
+
+    expect(dashboard.groups.single.rows.single.isAtRisk, isTrue);
+    expect(dashboard.atRiskRows, hasLength(1));
+  });
+
+  test('an unsatisfied rule is always at risk, even with no expiry date', () {
+    final dashboard = buildCurrencyDashboard(
+      licences: [
+        const CurrencyLicenceSpec(
+          jurisdictionId: 'us.faa.part61',
+          label: 'FAA',
+          isPrimary: false,
+          privilegeSummary: 'PPL ASEL',
+          ruleIds: ['test.unsatisfied'],
+        ),
+      ],
+      loader: loader,
+      subject: subjectWith(const []),
+      asOf: _asOf,
+    );
+
+    final row = dashboard.groups.single.rows.single;
+    expect(row.evaluation.result.satisfied, isFalse);
+    expect(row.evaluation.result.expiresOn, isNull);
+    expect(row.isAtRisk, isTrue);
+  });
+
+  test('grouping preserves licence order and the primary flag', () {
+    final dashboard = buildCurrencyDashboard(
+      licences: [
+        const CurrencyLicenceSpec(
+          jurisdictionId: 'eu.easa.part-fcl',
+          label: 'EASA',
+          isPrimary: true,
+          privilegeSummary: 'PPL(A)',
+          ruleIds: ['test.satisfied.far'],
+        ),
+        const CurrencyLicenceSpec(
+          jurisdictionId: 'us.faa.part61',
+          label: 'FAA',
+          isPrimary: false,
+          privilegeSummary: 'PPL ASEL',
+          ruleIds: ['test.unsatisfied'],
+        ),
+      ],
+      loader: loader,
+      subject: subjectWith([
+        HeldRecord(
+          kind: 'far',
+          validFrom: CalendarDate(2023, 1, 1),
+          validUntil: CalendarDate(2025, 1, 1),
+        ),
+      ]),
+      asOf: _asOf,
+    );
+
+    expect(dashboard.groups, hasLength(2));
+    expect(dashboard.groups[0].label, 'EASA');
+    expect(dashboard.groups[0].isPrimary, isTrue);
+    expect(dashboard.groups[1].label, 'FAA');
+    expect(dashboard.groups[1].isPrimary, isFalse);
+    // The at-risk row (test.unsatisfied, under FAA) still surfaces after
+    // the satisfied EASA one in atRiskRows -- group order, not risk order.
+    expect(dashboard.atRiskRows.single.title, 'Test rule test.unsatisfied');
+  });
+}

--- a/test/domain/currency/currency_expiry_projection_test.dart
+++ b/test/domain/currency/currency_expiry_projection_test.dart
@@ -151,6 +151,7 @@ void main() {
       id: 'test.recency',
       jurisdictionId: 'eu.easa.part-fcl',
       citation: 'test citation',
+      title: 'Test recency',
       effectiveFrom: CalendarDate(2020, 1, 1),
       requirement: Requirement.flightEventCount(
         event: CountableFlightEvent.landings,

--- a/test/domain/currency/currency_rule_evaluator_test.dart
+++ b/test/domain/currency/currency_rule_evaluator_test.dart
@@ -3,6 +3,7 @@ import 'package:easa_digital_log/domain/currency/currency_rule_evaluator.dart';
 import 'package:easa_digital_log/domain/currency/evaluation_subject.dart';
 import 'package:easa_digital_log/domain/currency/flight_condition.dart';
 import 'package:easa_digital_log/domain/currency/held_record.dart';
+import 'package:easa_digital_log/domain/currency/rule_result.dart';
 import 'package:easa_digital_log/domain/currency/rule_window.dart';
 import 'package:easa_digital_log/domain/model/aircraft.dart';
 import 'package:easa_digital_log/domain/model/calendar_date.dart';
@@ -786,6 +787,52 @@ void main() {
 
       expect(result.satisfied, isFalse);
     });
+
+    test('progress bubbles up from the alternative nearest to being met — a '
+        'bar needs one number, and only one branch has to succeed', () {
+      final requirement = Requirement.anyOf([
+        // 1 of 6 -- far from satisfied.
+        Requirement.flightEventCount(
+          event: CountableFlightEvent.approaches,
+          count: 6,
+          window: RuleWindow.rollingDays(90),
+        ),
+        // 3 of 3 -- the nearer alternative, in fact already satisfied.
+        Requirement.flightEventCount(
+          event: CountableFlightEvent.landings,
+          count: 3,
+          window: RuleWindow.rollingDays(90),
+        ),
+      ]);
+      final subject = EvaluationSubject(
+        flights: [
+          currencyTestRecord(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              approaches: [
+                const Approach(
+                  type: ApproachType.ils,
+                  aerodromeIcao: 'EGXX',
+                  runway: '09',
+                ),
+              ],
+              landings: const CircuitCounts(dayFullStop: 3),
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        subject,
+        CalendarDate(2024, 6, 1),
+      );
+
+      expect(result.progress!.kind, RuleProgressKind.count);
+      expect(result.progress!.currentCount, 3);
+      expect(result.progress!.requiredCount, 3);
+    });
   });
 
   group('allOf', () {
@@ -811,6 +858,52 @@ void main() {
       expect(result.components[0].satisfied, isTrue);
       expect(result.components[1].satisfied, isFalse);
     });
+
+    test('progress bubbles up from the tightest component — every branch must '
+        'succeed, so the closest-to-failing one is the one worth watching', () {
+      final requirement = Requirement.allOf([
+        // 3 of 3 -- comfortably met.
+        Requirement.flightEventCount(
+          event: CountableFlightEvent.landings,
+          count: 3,
+          window: RuleWindow.rollingDays(90),
+        ),
+        // 1 of 6 -- the tighter of the two.
+        Requirement.flightEventCount(
+          event: CountableFlightEvent.approaches,
+          count: 6,
+          window: RuleWindow.rollingDays(90),
+        ),
+      ]);
+      final subject = EvaluationSubject(
+        flights: [
+          currencyTestRecord(
+            '1',
+            _flight(
+              date: CalendarDate(2024, 5, 1),
+              landings: const CircuitCounts(dayFullStop: 3),
+              approaches: [
+                const Approach(
+                  type: ApproachType.ils,
+                  aerodromeIcao: 'EGXX',
+                  runway: '09',
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final result = evaluator.evaluateRequirement(
+        requirement,
+        subject,
+        CalendarDate(2024, 6, 1),
+      );
+
+      expect(result.progress!.kind, RuleProgressKind.count);
+      expect(result.progress!.currentCount, 1);
+      expect(result.progress!.requiredCount, 6);
+    });
   });
 
   group('CurrencyRuleEvaluator.evaluateRule', () {
@@ -819,6 +912,7 @@ void main() {
         id: 'test.rule',
         jurisdictionId: 'eu.easa.part-fcl',
         citation: 'FCL.060(b)(1)',
+        title: 'Test rule',
         effectiveFrom: CalendarDate(2020, 1, 1),
         requirement: Requirement.heldRecordCurrentlyValid('x'),
       );

--- a/test/domain/currency/currency_rule_loader_test.dart
+++ b/test/domain/currency/currency_rule_loader_test.dart
@@ -6,6 +6,7 @@ const _v1 = '''
 id: faa.61_56.flight_review
 jurisdiction: us.faa.part61
 citation: "§61.56 (pre-2020 wording)"
+title: "Flight review"
 effective_from: 2010-01-01
 expires_on: 2020-06-01
 requirement:
@@ -17,6 +18,7 @@ const _v2 = '''
 id: faa.61_56.flight_review
 jurisdiction: us.faa.part61
 citation: "§61.56"
+title: "Flight review"
 effective_from: 2020-06-01
 requirement:
   kind: held_record_currently_valid
@@ -27,6 +29,7 @@ const _otherRule = '''
 id: easa.fcl060.passenger_recency
 jurisdiction: eu.easa.part-fcl
 citation: "FCL.060(b)(1)"
+title: "Passenger recency"
 effective_from: 2011-11-08
 requirement:
   kind: held_record_currently_valid
@@ -119,6 +122,7 @@ void main() {
 id: faa.61_56.flight_review
 jurisdiction: us.faa.part61
 citation: "a different citation, same effective date"
+title: "Flight review"
 effective_from: 2010-01-01
 requirement:
   kind: held_record_currently_valid

--- a/test/domain/currency/currency_rule_schema_test.dart
+++ b/test/domain/currency/currency_rule_schema_test.dart
@@ -14,6 +14,7 @@ const _parserRequiredFields = [
   'id',
   'jurisdiction',
   'citation',
+  'title',
   'effective_from',
   'requirement',
 ];
@@ -22,6 +23,7 @@ const _validRuleYaml = '''
 id: easa.fcl060.passenger_recency
 jurisdiction: eu.easa.part-fcl
 citation: "FCL.060(b)(1)"
+title: "Passenger recency"
 effective_from: 2011-11-08
 requirement:
   kind: any_of

--- a/test/domain/currency/currency_rule_yaml_test.dart
+++ b/test/domain/currency/currency_rule_yaml_test.dart
@@ -13,6 +13,7 @@ void main() {
 id: easa.fcl060.passenger_recency
 jurisdiction: eu.easa.part-fcl
 citation: "FCL.060(b)(1)"
+title: "Passenger recency"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_count
@@ -45,6 +46,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 expires_on: 2020-01-01
 requirement:
@@ -62,6 +64,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_count
@@ -93,6 +96,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_hours
@@ -118,6 +122,7 @@ requirement:
 id: x
 jurisdiction: us.faa.part61
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_count
@@ -143,6 +148,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_hours
@@ -174,6 +180,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: flight_event_hours
@@ -194,6 +201,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: any_of
@@ -222,6 +230,7 @@ requirement:
       'id',
       'jurisdiction',
       'citation',
+      'title',
       'effective_from',
       'requirement',
     ]) {
@@ -232,6 +241,7 @@ requirement:
             'id': 'x',
             'jurisdiction': 'eu.easa.part-fcl',
             'citation': 'x',
+            'title': 'x',
             'effective_from': '2011-11-08',
           };
           fields.remove(missing);
@@ -262,6 +272,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: "not-a-date"
 requirement:
   kind: held_record_currently_valid
@@ -276,6 +287,7 @@ requirement:
 id: x
 jurisdiction: eu.easa.part-fcl
 citation: "x"
+title: "x"
 effective_from: 2011-11-08
 requirement:
   kind: not_a_real_kind

--- a/test/domain/model/calendar_date_test.dart
+++ b/test/domain/model/calendar_date_test.dart
@@ -38,6 +38,32 @@ void main() {
     });
   });
 
+  group('CalendarDate.differenceInDays', () {
+    test('is the inverse of addDays', () {
+      const start = CalendarDate(2024, 1, 28);
+      const end = CalendarDate(2024, 3, 2);
+
+      expect(end.differenceInDays(start), 34);
+      expect(start.addDays(34), end);
+    });
+
+    test('is negative when this date is earlier than other', () {
+      expect(
+        const CalendarDate(
+          2024,
+          1,
+          1,
+        ).differenceInDays(const CalendarDate(2024, 1, 10)),
+        -9,
+      );
+    });
+
+    test('is zero for the same date', () {
+      const date = CalendarDate(2024, 6, 15);
+      expect(date.differenceInDays(date), 0);
+    });
+  });
+
   group('CalendarDate', () {
     test('orders, compares and de-duplicates by value', () {
       const a = CalendarDate(2026, 6, 15);

--- a/test/ui/entry/new_flight_screen_test.dart
+++ b/test/ui/entry/new_flight_screen_test.dart
@@ -1,0 +1,494 @@
+import 'package:easa_digital_log/ui/entry/new_flight_screen.dart';
+import 'package:easa_digital_log/ui/entry/widgets/approach_row.dart';
+import 'package:easa_digital_log/ui/entry/widgets/conditions_section.dart';
+import 'package:easa_digital_log/ui/entry/widgets/times_section.dart';
+import 'package:easa_digital_log/ui/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Smoke coverage for the rebuilt Flight Entry Form (#58/#129,
+/// `Flight Entry Form.dc.html`). Not a full interaction suite — just enough
+/// to catch a render crash, a missing section, a layout overflow, or a
+/// jurisdiction-loading regression before it reaches a device.
+void main() {
+  Future<void> pumpScreen(WidgetTester tester) async {
+    // The default 800x600 test surface only builds the `ListView` children
+    // inside its viewport (Sliver lazy-list semantics) — a tall surface
+    // means every section builds, so `find.text` can see all of them and
+    // any layout overflow anywhere on the screen surfaces here rather than
+    // only on a device with a shorter, but differently-proportioned, page.
+    tester.view.physicalSize = const Size(390, 9000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // `_pickTime` (new_flight_screen.dart) already forces 24-hour entry on
+    // its own `showTimePicker` calls now — Zulu entry only makes sense in
+    // 24-hour form — so `setTime` below can drive values like hour 21
+    // without a test-side MediaQuery override to match.
+    await tester.pumpWidget(
+      MaterialApp(theme: AppTheme.light(), home: const NewFlightScreen()),
+    );
+    // Lets the async assets/jurisdictions/*.yaml load (see
+    // `_loadJurisdictions`) settle before assertions run.
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders every section in docs/entry-form.md §1 order', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    expect(find.text('New flight'), findsOneWidget);
+    expect(find.text('AIRCRAFT'), findsOneWidget);
+    expect(find.text('DATE & ROUTE'), findsOneWidget);
+    expect(find.text('TIMES'), findsOneWidget);
+    expect(find.text('WHO ELSE WAS ON BOARD?'), findsOneWidget);
+    expect(find.text('YOUR TAKE-OFFS AND LANDINGS'), findsOneWidget);
+    expect(find.text('CONDITIONS'), findsOneWidget);
+    expect(find.text('REMARKS AND ENDORSEMENTS'), findsOneWidget);
+    expect(find.text('Save flight'), findsOneWidget);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('picking a fleet aircraft resolves its type and chips', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.enterText(find.byType(TextField).first, 'G-ARRW');
+    await tester.pump();
+
+    expect(find.textContaining('Piper PA-28-161 Warrior'), findsOneWidget);
+    expect(find.text('SEP land'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'each of the four crew paths expands without throwing or overflowing, '
+    'and the FAA-only IR currency group always shows (licences stubbed on)',
+    (tester) async {
+      await pumpScreen(tester);
+
+      for (final label in [
+        'Just me',
+        'With an instructor',
+        'With another pilot',
+        'With passengers',
+      ]) {
+        await tester.tap(find.text(label));
+        await tester.pump();
+        expect(tester.takeException(), isNull, reason: 'selecting "$label"');
+      }
+
+      expect(find.text('IR CURRENCY AND PROFICIENCY'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'picking a multi-pilot aircraft and completing the instructor path '
+    '(purpose, countersignature) does not throw or overflow',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.enterText(find.byType(TextField).first, 'G-VMPS');
+      await tester.tap(find.text('Change aircraft'));
+      await tester.pump();
+      expect(find.text('MP'), findsOneWidget);
+
+      await tester.tap(find.text('With an instructor'));
+      await tester.pump();
+      await tester.tap(
+        find.widgetWithText(
+          DropdownButtonFormField<String>,
+          'Purpose of flight',
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Skill test').last);
+      await tester.pumpAndSettle();
+      expect(find.text('Examiner no.'), findsOneWidget);
+
+      expect(find.text('not signed'), findsOneWidget);
+      await tester.tap(find.text('Sign now'));
+      await tester.pump();
+      expect(find.text('not signed'), findsNothing);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'the "with another pilot" PICUS path (multi-pilot toggle, PICUS claim, '
+    'split manipulation time) does not throw or overflow',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('With another pilot'));
+      await tester.pump();
+      await tester.tap(find.text('Other pilot').first);
+      await tester.pump();
+
+      // EntryToggleRow's tap target is the Switch, not the label — tapping
+      // the label text alone (as with a ChoiceChip) is a no-op here.
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(Row, 'Multi-pilot operation'),
+          matching: find.byType(Switch),
+        ),
+      );
+      await tester.pump();
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(Row, 'Claim PICUS'),
+          matching: find.byType(Switch),
+        ),
+      );
+      await tester.pump();
+      expect(
+        find.textContaining('PIC intervention was not required'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Both — split'));
+      await tester.pump();
+      expect(find.text('My manipulation time'), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('adding and removing an IR approach row does not throw', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('+ Add approach'));
+    await tester.pump();
+    expect(find.text('Flown'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close).last);
+    await tester.pump();
+    expect(find.text('Flown'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a full ICAO code and runway designator are not clipped in an '
+      'approach row (regression: the default InputDecorationTheme padding '
+      'alone was wider than the box)', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('+ Add approach'));
+    await tester.pump();
+
+    final approachFields = find.descendant(
+      of: find.byType(ApproachRow),
+      matching: find.byType(TextField),
+    );
+    expect(approachFields, findsNWidgets(2));
+
+    await tester.enterText(approachFields.first, 'EGKA');
+    await tester.enterText(approachFields.last, '36L');
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(approachFields.first).controller!.text,
+      'EGKA',
+    );
+    expect(
+      tester.widget<TextField>(approachFields.last).controller!.text,
+      '36L',
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'the derivation strip stays a placeholder until block times are set, '
+    'even once aircraft and crew are',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.enterText(find.byType(TextField).first, 'G-ARRW');
+      await tester.pump();
+      await tester.tap(find.text('Just me'));
+      await tester.pump();
+
+      // Off/on blocks default to unset ("--:--"), so `buildDraftFlight`
+      // (flight_draft_mapper.dart) has nothing to project yet — the footer
+      // must keep showing its placeholder, not a half-built breakdown.
+      expect(
+        find.textContaining('jurisdiction breakdown appears once crew is'),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('the scroll body starts right under the top bar, not offset by a '
+      'second status-bar inset (regression: ListView auto-padding stacked '
+      'on top of EntryTopBar\'s own SafeArea)', (tester) async {
+    tester.view.padding = const FakeViewPadding(top: 30);
+    addTearDown(tester.view.resetPadding);
+    await pumpScreen(tester);
+
+    final topBarBottom =
+        tester.getBottomLeft(find.text('New flight')).dy +
+        8; // EntryTopBar's own bottom padding
+    final aircraftLabelTop = tester.getTopLeft(find.text('AIRCRAFT')).dy;
+
+    // EntrySection's own top padding (22px) is the only gap that should
+    // separate the two — not another ~30px status-bar inset on top of it.
+    expect(aircraftLabelTop - topBarBottom, lessThan(40));
+  });
+
+  Future<void> setTime(WidgetTester tester, String hour, String minute) async {
+    await tester.tap(find.text('--:--').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Switch to text input mode'));
+    await tester.pumpAndSettle();
+    final fields = find.descendant(
+      of: find.byType(Dialog),
+      matching: find.byType(TextField),
+    );
+    await tester.enterText(fields.at(0), hour);
+    await tester.enterText(fields.at(1), minute);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'the derivation strip produces a real EASA/FAA breakdown from crew and '
+    'block times alone (regression: previously required a resolved '
+    'aircraft even for the "Just me" path, which never reads one)',
+    (tester) async {
+      await pumpScreen(tester);
+
+      // No registration entered — deliberately left unresolved.
+      await setTime(tester, '09', '15'); // off blocks
+      await setTime(tester, '11', '30'); // on blocks
+      await tester.tap(find.text('Just me'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('jurisdiction breakdown appears once crew is'),
+        findsNothing,
+      );
+      expect(find.textContaining('EASA:'), findsOneWidget);
+      expect(find.textContaining('FAA:'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('toggling "IFR flight plan filed" changes the derivation strip '
+      '(regression: easa_instrument_time.dart\'s \'ifr\' quantity was '
+      'computed correctly but never included in the footer\'s label maps, '
+      'so the toggle appeared to do nothing)', (tester) async {
+    await pumpScreen(tester);
+
+    await setTime(tester, '09', '15'); // off blocks
+    await setTime(tester, '11', '30'); // on blocks
+    await tester.tap(find.text('Just me'));
+    await tester.pumpAndSettle();
+
+    // Expand the breakdown so the new "IFR" row, if any, is visible.
+    await tester.tap(find.text('THIS ENTRY PRODUCES').first);
+    await tester.pumpAndSettle();
+    expect(find.text('IFR'), findsNothing);
+
+    await tester.tap(
+      find.descendant(
+        of: find.widgetWithText(Row, 'IFR flight plan filed'),
+        matching: find.byType(Switch),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('IFR'), findsOneWidget);
+    expect(find.text('2:15'), findsWidgets); // block time, credited in full
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the "BLOCK" shortcut fills a Conditions duration field with the '
+      'current block time in one tap', (tester) async {
+    await pumpScreen(tester);
+
+    await setTime(tester, '09', '15'); // off blocks
+    await setTime(tester, '11', '30'); // on blocks -> 2:15 block
+
+    // "Night time" is the first duration field with the shortcut; find
+    // its TextFields directly rather than by type name, since
+    // ConditionsSection doesn't export one field's fields separately.
+    final nightHours = find.byWidgetPredicate(
+      (w) => w is TextField && w.decoration?.hintText == '0',
+    );
+    final nightMinutes = find.byWidgetPredicate(
+      (w) => w is TextField && w.decoration?.hintText == '00',
+    );
+    expect(tester.widget<TextField>(nightHours.first).controller!.text, '');
+
+    // Scoped to ConditionsSection — TimesSection has its own, unrelated
+    // static "BLOCK" caption above the block-time field.
+    final blockShortcut = find.descendant(
+      of: find.byType(ConditionsSection),
+      matching: find.text('BLOCK'),
+    );
+    await tester.tap(blockShortcut.first);
+    await tester.pump();
+
+    expect(tester.widget<TextField>(nightHours.first).controller!.text, '2');
+    expect(tester.widget<TextField>(nightMinutes.first).controller!.text, '15');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the "BLOCK" shortcut is hidden until block time is known', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    // Off/on blocks are left unset — no block time to fill from yet.
+    // (TimesSection's own unrelated "BLOCK" caption is unaffected and
+    // stays visible regardless.)
+    expect(
+      find.descendant(
+        of: find.byType(ConditionsSection),
+        matching: find.text('BLOCK'),
+      ),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'the aircraft picker search narrows the fleet list by registration or '
+    'type, and picking a match still resolves it',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('Change aircraft'));
+      await tester.pump();
+      expect(find.text('G-ARRW'), findsOneWidget);
+      expect(find.text('G-HELI'), findsOneWidget);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Search registration or type'),
+        'cessna',
+      );
+      await tester.pump();
+      expect(find.text('G-ABCD'), findsOneWidget);
+      expect(find.text('G-ARRW'), findsNothing);
+      expect(find.text('G-HELI'), findsNothing);
+
+      await tester.tap(find.text('G-ABCD'));
+      await tester.pump();
+      expect(find.textContaining('Cessna 152'), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('a two-digit-hour block time is not clipped by the BLOCK field '
+      '(regression: a 74px-wide box cut "15:19" down to "15:1")', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await setTime(tester, '21', '56'); // off blocks
+    await setTime(tester, '13', '15'); // on blocks — crosses midnight
+
+    final blockField = tester.widget<TextField>(
+      find.descendant(
+        of: find.byType(TimesSection),
+        matching: find.byType(TextField),
+      ),
+    );
+    expect(blockField.controller!.text, '15:19');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'the aircraft picker search reports no matches rather than an empty '
+    'silent list',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('Change aircraft'));
+      await tester.pump();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Search registration or type'),
+        'zzz-no-such-aircraft',
+      );
+      await tester.pump();
+
+      expect(find.textContaining('No aircraft match'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'typing a full 4-character ICAO code in a route leg advances focus to '
+    'the next leg',
+    (tester) async {
+      await pumpScreen(tester);
+
+      // The route row holds exactly two ICAO fields to start with
+      // (departure, destination).
+      final icaoFields = find.byWidgetPredicate(
+        (w) => w is TextField && w.decoration?.hintText == 'ICAO',
+      );
+      expect(icaoFields, findsNWidgets(2));
+
+      await tester.tap(icaoFields.first);
+      await tester.pump();
+      await tester.enterText(icaoFields.first, 'EGKA');
+      await tester.pump();
+
+      final secondField = tester.widget<TextField>(icaoFields.last);
+      expect(secondField.focusNode!.hasFocus, isTrue);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('off/on blocks are entered and displayed as Zulu, not local', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    expect(find.text('ALL TIMES ZULU'), findsOneWidget);
+
+    await setTime(tester, '21', '56');
+    expect(find.text('21:56Z'), findsOneWidget);
+    // No separate "local echo" is shown — that computation was
+    // deliberately deferred rather than half-wired (see
+    // times_section.dart's dartdoc).
+    expect(find.text('21:56'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'the expanded derivation strip groups EASA and FAA separately and '
+    'drops the redundant inline summary',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await setTime(tester, '09', '15');
+      await setTime(tester, '11', '30');
+      await tester.tap(find.text('Just me'));
+      await tester.pumpAndSettle();
+
+      // Collapsed: the inline summary is present.
+      expect(find.textContaining('EASA:'), findsOneWidget);
+
+      await tester.tap(find.text('THIS ENTRY PRODUCES').first);
+      await tester.pumpAndSettle();
+
+      // Expanded: the inline "EASA: ..." summary is gone (superseded by
+      // the grouped breakdown below), but the group headers are present.
+      expect(find.textContaining('EASA:'), findsNothing);
+      expect(find.text('EASA'), findsOneWidget);
+      expect(find.text('FAA'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- **Flight Entry Form** (#58, #129): the full entry screen from the mockup — aircraft picker, date/route with auto-advancing ICAO legs, Zulu-only time entry, the four-way crew selector, take-off/landing counters, conditions, remarks with countersignature, and a live EASA/FAA derivation strip.
- **Currency dashboard** (#62): real per-licence currency evaluation with a hero row of at-risk items and fill/tick progress bars, colours and layout sourced directly from the mockup's OKLCH swatches. Adds `RuleProgress` (structured numbers on `RuleResult`, including bubbling through `allOf`/`anyOf` composites), a `title` field on `CurrencyRule`, `PilotProfile.primaryJurisdictionId` (with a v4→v5 migration), and `CalendarDate.differenceInDays`.

Both screens run against documented sample fixtures, the same convention already used by the logbook screen, pending #56's live repository wiring.

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] `dart format --set-exit-if-changed .` clean
- [x] `flutter test --coverage` — 581 tests pass
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_domain_coverage.dart` / `check_schema_snapshot.dart` all pass locally
- [x] Verified on an Android emulator in both light and dark mode (entry form flows; Currency screen hero cards, progress bars, drill-down sheet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)