### PR TITLE
Totals screen: Time/Aircraft/Function/Conditions/Ops (#62)

### DIFF
--- a/lib/domain/totals/totals_summary.dart
+++ b/lib/domain/totals/totals_summary.dart
@@ -1,0 +1,425 @@
+import '../model/aircraft.dart';
+import '../model/aerodrome_directory.dart';
+import '../model/calendar_date.dart';
+import '../model/countersignature.dart';
+import '../model/flight.dart';
+import '../model/flight_duration.dart';
+import '../model/flight_times.dart';
+import '../projection/projection.dart';
+import '../repository/flight_read_repository.dart';
+
+/// Pure aggregation over a flight set for the Totals screen — mirrors
+/// `currency_dashboard.dart`'s shape (no Flutter import, unit-tested,
+/// deterministic). Every figure here is either jurisdiction-agnostic (total
+/// time of flight, aircraft hours, take-off/landing counts — CLAUDE.md rule
+/// 5) or a raw-fact sum straight off [Flight]/[PilotCapacity]; anything
+/// genuinely jurisdiction-dependent (PIC/dual/night/instrument/...) goes
+/// through the existing [Projection.projectAggregate] instead, unchanged.
+
+// ---- Time tab.
+
+enum Granularity { year, month, week, day }
+
+class TimeBucket {
+  const TimeBucket({
+    required this.label,
+    required this.value,
+    required this.isCurrent,
+  });
+
+  final String label;
+  final FlightDuration value;
+
+  /// Whether this is the bucket [asOf] itself falls in — the chart's own
+  /// "current period" highlight.
+  final bool isCurrent;
+}
+
+/// Buckets total time of flight into the last [count] periods ending at
+/// [asOf], oldest first.
+///
+/// [Granularity.week] is 8 rolling 7-day windows ending at [asOf], not ISO
+/// calendar weeks — a deliberate simplification for a chart axis label, not
+/// a figure anything else depends on.
+List<TimeBucket> bucketTotals(
+  List<FlightRecord> flights,
+  Granularity granularity,
+  CalendarDate asOf, {
+  int count = 8,
+}) {
+  switch (granularity) {
+    case Granularity.year:
+      return _bucketByCalendarField(
+        flights,
+        asOf,
+        count,
+        fieldOf: (date) => date.year,
+        currentField: asOf.year,
+        labelOf: (year) => '$year',
+        stepBack: (field, steps) => field - steps,
+      );
+    case Granularity.month:
+      final currentIndex = asOf.year * 12 + (asOf.month - 1);
+      return _bucketByCalendarField(
+        flights,
+        asOf,
+        count,
+        fieldOf: (date) => date.year * 12 + (date.month - 1),
+        currentField: currentIndex,
+        labelOf: (index) => _monthAbbreviations[index % 12],
+        stepBack: (field, steps) => field - steps,
+      );
+    case Granularity.week:
+      return _bucketByDayWindow(flights, asOf, count, windowDays: 7);
+    case Granularity.day:
+      return _bucketByDayWindow(flights, asOf, count, windowDays: 1);
+  }
+}
+
+const _monthAbbreviations = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+List<TimeBucket> _bucketByCalendarField(
+  List<FlightRecord> flights,
+  CalendarDate asOf,
+  int count, {
+  required int Function(CalendarDate date) fieldOf,
+  required int currentField,
+  required String Function(int field) labelOf,
+  required int Function(int field, int steps) stepBack,
+}) {
+  final totals = <int, FlightDuration>{};
+  for (final record in flights) {
+    final field = fieldOf(CalendarDate.fromUtcInstant(record.flight.offBlocks));
+    totals[field] =
+        (totals[field] ?? FlightDuration.zero) + record.flight.blockTime;
+  }
+
+  return [
+    for (var i = 0; i < count; i++)
+      () {
+        final field = stepBack(currentField, count - 1 - i);
+        return TimeBucket(
+          label: labelOf(field),
+          value: totals[field] ?? FlightDuration.zero,
+          isCurrent: field == currentField,
+        );
+      }(),
+  ];
+}
+
+List<TimeBucket> _bucketByDayWindow(
+  List<FlightRecord> flights,
+  CalendarDate asOf,
+  int count, {
+  required int windowDays,
+}) {
+  // Bucket 0 is the oldest window, bucket `count - 1` is the one containing
+  // `asOf` itself; a flight `daysAgo` days before `asOf` falls in window
+  // `daysAgo ~/ windowDays` counting back from the current one.
+  final sums = List<FlightDuration>.filled(count, FlightDuration.zero);
+  for (final record in flights) {
+    final date = CalendarDate.fromUtcInstant(record.flight.offBlocks);
+    final daysAgo = asOf.differenceInDays(date);
+    if (daysAgo < 0) continue; // A flight logged in the future — ignore it.
+    final windowsBack = daysAgo ~/ windowDays;
+    if (windowsBack >= count) continue;
+    final index = count - 1 - windowsBack;
+    sums[index] = sums[index] + record.flight.blockTime;
+  }
+
+  return [
+    for (var i = 0; i < count; i++)
+      TimeBucket(
+        label: windowDays == 1
+            ? '${asOf.addDays(-(count - 1 - i)).day}'
+            : (count - 1 - i == 0
+                  ? 'now'
+                  : '-${(count - 1 - i) * windowDays}d'),
+        value: sums[i],
+        isCurrent: i == count - 1,
+      ),
+  ];
+}
+
+/// Total time of flight for every flight whose off-blocks date falls within
+/// `[from, to]`, inclusive both ends — the four fixed summary rows (this
+/// year / last 12 months / last 90 days / last 28 days).
+FlightDuration sumBlockTimeInRange(
+  List<FlightRecord> flights,
+  CalendarDate from,
+  CalendarDate to,
+) {
+  return FlightDuration.sum([
+    for (final record in flights)
+      if (_dateOf(record) case final date when date >= from && date <= to)
+        record.flight.blockTime,
+  ]);
+}
+
+CalendarDate _dateOf(FlightRecord record) =>
+    CalendarDate.fromUtcInstant(record.flight.offBlocks);
+
+// ---- Aircraft tab.
+
+/// "SEP (land)" / "MEP (land)" / "TMG" from an aircraft's own facts — pure
+/// formatting, not regulatory logic, so it lives here rather than as a
+/// primitive. Turboprop/turbofan/turbojet aircraft (typically type-rated,
+/// not class-rated) fall back to their own type label, which
+/// [groupByAircraft] then collapses a class down to a single row for —
+/// there is no separate "class" concept above a jet's own type the way
+/// there is for a piston single or twin.
+String aircraftClassLabel(Aircraft aircraft) {
+  if (aircraft.category == AircraftCategory.touringMotorGlider) {
+    return 'TMG';
+  }
+  if (aircraft.category == AircraftCategory.aeroplane &&
+      aircraft.engineType == EngineType.piston) {
+    final surface = switch (aircraft.operatingSurface) {
+      OperatingSurface.land => 'land',
+      OperatingSurface.sea => 'sea',
+      OperatingSurface.amphibian => 'amphibian',
+    };
+    final prefix = aircraft.engineCount == 1 ? 'SEP' : 'MEP';
+    return '$prefix ($surface)';
+  }
+  return aircraftTypeLabel(aircraft);
+}
+
+/// The specific type an aircraft resolves to for grouping — the same
+/// fallback chain `Aircraft.typeRatingDesignator`'s own dartdoc describes
+/// for joining two registrations of one type into a single held rating.
+String aircraftTypeLabel(Aircraft aircraft) =>
+    aircraft.typeRatingDesignator ??
+    aircraft.icaoTypeDesignator ??
+    '${aircraft.manufacturer} ${aircraft.model}'.trim();
+
+class AircraftTypeTotal {
+  const AircraftTypeTotal({required this.typeLabel, required this.total});
+  final String typeLabel;
+  final FlightDuration total;
+}
+
+class AircraftClassTotal {
+  const AircraftClassTotal({
+    required this.classLabel,
+    required this.total,
+    required this.types,
+  });
+  final String classLabel;
+  final FlightDuration total;
+  final List<AircraftTypeTotal> types;
+
+  /// True when this class has exactly one type sharing its own label (the
+  /// jet case [aircraftClassLabel] describes) — the row this collapses to a
+  /// single line for, rather than a class header repeating its only child.
+  bool get isSingleType =>
+      types.length == 1 && types.single.typeLabel == classLabel;
+}
+
+class AircraftGroupTotal {
+  const AircraftGroupTotal({
+    required this.multiPilot,
+    required this.total,
+    required this.classes,
+  });
+  final bool multiPilot;
+  final FlightDuration total;
+  final List<AircraftClassTotal> classes;
+}
+
+/// Single-pilot/multi-pilot (`PilotCapacity.multiPilotOperation`) → class
+/// (`aircraftClassLabel`) → specific type (`aircraftTypeLabel`), each level
+/// carrying its own summed block time. Single-pilot sorts before
+/// multi-pilot always (there are only ever the two); classes and types
+/// within a group sort by descending total.
+List<AircraftGroupTotal> groupByAircraft(List<FlightRecord> flights) {
+  final byMultiPilot = <bool, Map<String, Map<String, FlightDuration>>>{};
+
+  for (final record in flights) {
+    final multiPilot = record.flight.capacity.multiPilotOperation;
+    final classLabel = aircraftClassLabel(record.aircraft);
+    final typeLabel = aircraftTypeLabel(record.aircraft);
+    final classes = byMultiPilot.putIfAbsent(multiPilot, () => {});
+    final types = classes.putIfAbsent(classLabel, () => {});
+    types[typeLabel] =
+        (types[typeLabel] ?? FlightDuration.zero) + record.flight.blockTime;
+  }
+
+  final groups = <AircraftGroupTotal>[];
+  for (final multiPilot in [false, true]) {
+    final classes = byMultiPilot[multiPilot];
+    if (classes == null || classes.isEmpty) continue;
+
+    final classTotals = [
+      for (final entry in classes.entries)
+        AircraftClassTotal(
+          classLabel: entry.key,
+          total: FlightDuration.sum(entry.value.values),
+          types: [
+            for (final typeEntry in entry.value.entries)
+              AircraftTypeTotal(
+                typeLabel: typeEntry.key,
+                total: typeEntry.value,
+              ),
+          ]..sort((a, b) => b.total.compareTo(a.total)),
+        ),
+    ]..sort((a, b) => b.total.compareTo(a.total));
+
+    groups.add(
+      AircraftGroupTotal(
+        multiPilot: multiPilot,
+        total: FlightDuration.sum(classTotals.map((c) => c.total)),
+        classes: classTotals,
+      ),
+    );
+  }
+  return groups;
+}
+
+/// Distinct aircraft (by registration) flown across [flights].
+int distinctAircraftFlown(List<FlightRecord> flights) =>
+    {for (final record in flights) record.aircraft.registration}.length;
+
+// ---- Function tab: "other arrangements".
+
+/// Sum of block time for flights flown as sole occupant.
+FlightDuration soloTime(List<FlightRecord> flights) => FlightDuration.sum([
+  for (final record in flights)
+    if (record.flight.capacity.soleOccupant) record.flight.blockTime,
+]);
+
+/// Sum of block time for flights whose countersignature is still
+/// [CountersignatureStatus.pending] — a raw fact straight off
+/// [PilotCapacity.countersignature], not something [Projection] needs to
+/// compute: this is the same fact `easa_pilot_function_time.dart`'s own
+/// `_countersignedQuantity` already branches on, just summed directly
+/// rather than folded into an excluded-total string.
+FlightDuration awaitingCountersignatureTime(List<FlightRecord> flights) =>
+    FlightDuration.sum([
+      for (final record in flights)
+        if (record.flight.capacity.countersignature?.status ==
+            CountersignatureStatus.pending)
+          record.flight.blockTime,
+    ]);
+
+// ---- Conditions tab.
+
+/// Cross-country time, restricted to flights flown with command authority —
+/// the Conditions tab's "of which PIC" sub-row. Reads the per-flight
+/// cross-country quantity from [projection] rather than re-deriving it.
+FlightDuration crossCountryOfWhichPic(
+  List<FlightRecord> flights,
+  Projection projection,
+) {
+  var total = FlightDuration.zero;
+  for (final record in flights) {
+    if (!record.flight.capacity.commandAuthority) continue;
+    final result = projection.project(record.flight, record.aircraft);
+    final quantity = result['crossCountry'];
+    if (quantity != null && quantity.creditable) {
+      total = total + quantity.value;
+    }
+  }
+  return total;
+}
+
+FlightDuration longestFlight(List<FlightRecord> flights) => flights.isEmpty
+    ? FlightDuration.zero
+    : flights.map((r) => r.flight.blockTime).reduce((a, b) => a > b ? a : b);
+
+// ---- Ops tab.
+
+class OpsCounts {
+  const OpsCounts({
+    required this.dayFullStopTakeoffs,
+    required this.dayFullStopLandings,
+    required this.dayTouchAndGoTakeoffs,
+    required this.dayTouchAndGoLandings,
+    required this.nightFullStopTakeoffs,
+    required this.nightFullStopLandings,
+    required this.nightTouchAndGoTakeoffs,
+    required this.nightTouchAndGoLandings,
+    required this.instrumentApproaches,
+  });
+
+  final int dayFullStopTakeoffs;
+  final int dayFullStopLandings;
+  final int dayTouchAndGoTakeoffs;
+  final int dayTouchAndGoLandings;
+  final int nightFullStopTakeoffs;
+  final int nightFullStopLandings;
+  final int nightTouchAndGoTakeoffs;
+  final int nightTouchAndGoLandings;
+  final int instrumentApproaches;
+}
+
+OpsCounts opsCounts(List<FlightRecord> flights) {
+  var dfsT = 0, dfsL = 0, dtgT = 0, dtgL = 0;
+  var nfsT = 0, nfsL = 0, ntgT = 0, ntgL = 0;
+  var approaches = 0;
+
+  for (final record in flights) {
+    final t = record.flight.takeoffs;
+    final l = record.flight.landings;
+    dfsT += t.dayFullStop;
+    dtgT += t.dayTouchAndGo;
+    nfsT += t.nightFullStop;
+    ntgT += t.nightTouchAndGo;
+    dfsL += l.dayFullStop;
+    dtgL += l.dayTouchAndGo;
+    nfsL += l.nightFullStop;
+    ntgL += l.nightTouchAndGo;
+    for (final approach in record.flight.approaches) {
+      approaches += approach.count;
+    }
+  }
+
+  return OpsCounts(
+    dayFullStopTakeoffs: dfsT,
+    dayFullStopLandings: dfsL,
+    dayTouchAndGoTakeoffs: dtgT,
+    dayTouchAndGoLandings: dtgL,
+    nightFullStopTakeoffs: nfsT,
+    nightFullStopLandings: nfsL,
+    nightTouchAndGoTakeoffs: ntgT,
+    nightTouchAndGoLandings: ntgL,
+    instrumentApproaches: approaches,
+  );
+}
+
+/// Aerodromes visited across every route leg, resolved for country via
+/// [directory] — the Ops tab's "Aerodromes visited" row. An identifier the
+/// directory doesn't recognise (a private strip, an unlicensed field —
+/// `Flight.route`'s own dartdoc) still counts toward [aerodromes] but not
+/// toward [countries], since there is nothing to resolve it to.
+///
+/// Deliberately does not compute a "furthest" distance — that needs a home
+/// base reference point that doesn't exist anywhere in the domain yet.
+({int aerodromes, int countries}) aerodromesVisited(
+  List<FlightRecord> flights,
+  AerodromeDirectory directory,
+) {
+  final icaoCodes = <String>{};
+  for (final record in flights) {
+    icaoCodes.addAll(record.flight.route);
+  }
+  final countries = <String>{
+    for (final code in icaoCodes)
+      if (directory.byIcao(code)?.isoCountry != null)
+        directory.byIcao(code)!.isoCountry!,
+  };
+  return (aerodromes: icaoCodes.length, countries: countries.length);
+}

--- a/lib/ui/totals/sample_totals_data.dart
+++ b/lib/ui/totals/sample_totals_data.dart
@@ -1,0 +1,304 @@
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/countersignature.dart';
+import '../../domain/model/flight.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/instructor_presence.dart';
+import '../../domain/model/pilot_capacity.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/repository/flight_read_repository.dart';
+
+export '../currency/sample_currency_data.dart' show samplePilotProfile;
+
+/// Sample data for the Totals screen — the same "real engine over a
+/// documented fixture, pending #56" convention as
+/// `sample_currency_data.dart`/`sample_logbook_data.dart`. That fixture's 4
+/// flights are deliberately narrow (each hand-tuned for one currency state);
+/// a meaningful multi-year chart needs real breadth instead, so this is a
+/// separate, larger fixture rather than reusing Currency's.
+///
+/// [sampleTotalsFlights] is **generated, not hand-authored, and
+/// deliberately not `Random()`-seeded** — every flight's date, aircraft,
+/// capacity and route come from `i`'s own remainder against a few small
+/// numbers, so the exact same 360 flights render on every run. This keeps
+/// the screen reviewable (the generator is the whole story) and the tests
+/// that exercise `totals_summary.dart` against it reproducible.
+const _sepWarrior = Aircraft(
+  registration: 'G-ARRW',
+  manufacturer: 'Piper',
+  model: 'PA-28-161 Warrior',
+  icaoTypeDesignator: 'P28A',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+const _sepSkyhawk = Aircraft(
+  registration: 'N456BD',
+  manufacturer: 'Cessna',
+  model: '172S Skyhawk',
+  icaoTypeDesignator: 'C172',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+const _mepSeneca = Aircraft(
+  registration: 'G-MULTI',
+  manufacturer: 'Piper',
+  model: 'PA-34-200T Seneca',
+  icaoTypeDesignator: 'PA34',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 2,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+const _citationJet = Aircraft(
+  registration: 'N123CJ',
+  manufacturer: 'Cessna',
+  model: 'Citation CJ2',
+  icaoTypeDesignator: 'C25A',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.turbofan,
+  engineCount: 2,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: true,
+);
+
+/// 70% Warrior/Skyhawk (single-pilot SEP), 20% Seneca (single-pilot MEP),
+/// 10% the jet (multi-pilot) — roughly the mockup's own SEP-heavy fleet mix.
+Aircraft _aircraftFor(int i) => switch (i % 10) {
+  0 || 1 || 2 || 3 => _sepWarrior,
+  4 || 5 || 6 => _sepSkyhawk,
+  7 || 8 => _mepSeneca,
+  _ => _citationJet,
+};
+
+/// A small pool of real GA aerodromes, the same flavour
+/// `sample_logbook_data.dart` already uses — `_homeBase` is where most
+/// flights start and end; the others give `aerodromesVisited` and the
+/// cross-country primitives something real to resolve.
+const _homeBase = 'EGKA';
+const _destinations = ['EGHH', 'EGTB', 'LFAT', 'EGLF', 'EGBJ'];
+
+const _picSolo = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _picWithPax = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: false,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _dualReceived = PilotCapacity(
+  commandAuthority: false,
+  soleManipulator: true,
+  soleOccupant: false,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+  instructor: InstructorPresence(
+    capacity: InstructorCapacity.flightInstructor,
+    influencedFlight: true,
+    name: 'J. Reilly',
+  ),
+);
+
+const _actingAsInstructor = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: false,
+  soleOccupant: false,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: true,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _multiPilotCopilot = PilotCapacity(
+  commandAuthority: false,
+  soleManipulator: false,
+  soleOccupant: false,
+  multiPilotOperation: true,
+  additionalCrewRequiredByRule: true,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+  otherPilotRole: OtherPilotRole.requiredCrew,
+);
+
+const _multiPilotPic = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: false,
+  soleOccupant: false,
+  multiPilotOperation: true,
+  additionalCrewRequiredByRule: true,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+  otherPilotRole: OtherPilotRole.requiredCrew,
+);
+
+PilotCapacity _capacityFor(int i, Aircraft aircraft) {
+  if (aircraft == _citationJet) {
+    return i.isEven ? _multiPilotPic : _multiPilotCopilot;
+  }
+  return switch (i % 7) {
+    0 || 1 || 2 => _picSolo,
+    3 => _picWithPax,
+    4 => _dualReceived,
+    5 => _actingAsInstructor,
+    _ => _picSolo,
+  };
+}
+
+const Duration _localFlightDuration = Duration(minutes: 45);
+const Duration _crossCountryFlightDuration = Duration(hours: 2, minutes: 15);
+
+/// Generated flight count, oldest to newest, before the one hand-authored
+/// pending-countersignature flight [sampleTotalsFlights] appends.
+const _generatedFlightCount = 360;
+
+List<FlightRecord> sampleTotalsFlights(CalendarDate today) => [
+  for (var i = 0; i < _generatedFlightCount; i++) _generatedFlight(i, today),
+  _pendingCountersignatureFlight(today),
+];
+
+FlightRecord _generatedFlight(int i, CalendarDate today) {
+  // Roughly every 3 days, oldest first — ~3 years of history.
+  final date = today.addDays(-(_generatedFlightCount - 1 - i) * 3);
+  final aircraft = _aircraftFor(i);
+  final capacity = _capacityFor(i, aircraft);
+  final isCrossCountry = i % 5 == 0;
+  final isNight = i % 13 == 0;
+  final isIfr = i % 17 == 0;
+  final duration = isCrossCountry
+      ? _crossCountryFlightDuration
+      : _localFlightDuration;
+
+  // 22:00 UTC is past civil dusk at EGKA's latitude year-round (even at
+  // midsummer BST), so a night-flagged flight actually falls at night rather
+  // than merely carrying a night circuit count while the derived Night time
+  // stays zero.
+  final offBlocks = UtcInstant.utc(
+    date.year,
+    date.month,
+    date.day,
+    isNight ? 22 : 10,
+  );
+  final flight = Flight(
+    aircraftRegistration: aircraft.registration,
+    // `i ~/ 5` rather than `i` -- `isCrossCountry` is itself `i % 5 == 0`, so
+    // indexing the destination pool by `i` would always land on index 0 and
+    // every cross-country flight would visit the same single aerodrome.
+    route: isCrossCountry
+        ? [_homeBase, _destinations[(i ~/ 5) % _destinations.length], _homeBase]
+        : const [_homeBase, _homeBase],
+    prePlannedNavigation: isCrossCountry,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(duration),
+    capacity: capacity,
+    carryingPassengers: capacity == _picWithPax,
+    takeoffs: CircuitCounts(
+      dayFullStop: isNight ? 0 : 1,
+      nightFullStop: isNight ? 1 : 0,
+    ),
+    landings: CircuitCounts(
+      dayFullStop: isNight ? 0 : 1,
+      nightFullStop: isNight ? 1 : 0,
+    ),
+    ifrFlightPlanFiled: isIfr,
+    actualInstrumentTime: isIfr
+        ? const FlightDuration(20)
+        : FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: isIfr
+        ? const [
+            Approach(
+              type: ApproachType.ils,
+              aerodromeIcao: _homeBase,
+              runway: '02',
+            ),
+          ]
+        : const [],
+    holdingProceduresCount: 0,
+    trackingPerformed: false,
+    remarks: '',
+  );
+  return FlightRecord(
+    id: 'sample-totals-$i',
+    flight: flight,
+    aircraft: aircraft,
+  );
+}
+
+/// The one flight the plan calls out explicitly: a PICUS claim still
+/// awaiting its countersignature, exercising
+/// `totals_summary.awaitingCountersignatureTime`.
+FlightRecord _pendingCountersignatureFlight(CalendarDate today) {
+  final date = today.addDays(-14);
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 9);
+  return FlightRecord(
+    id: 'sample-totals-picus-pending',
+    flight: Flight(
+      aircraftRegistration: _mepSeneca.registration,
+      route: const [_homeBase, _homeBase],
+      prePlannedNavigation: false,
+      offBlocks: offBlocks,
+      onBlocks: offBlocks.add(const Duration(hours: 1, minutes: 40)),
+      capacity: const PilotCapacity(
+        commandAuthority: false,
+        soleManipulator: false,
+        soleOccupant: false,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: true,
+        picInterventionNotRequired: true,
+        otherPilotRole: OtherPilotRole.notRequiredCrew,
+        countersignature: Countersignature(
+          status: CountersignatureStatus.pending,
+        ),
+      ),
+      carryingPassengers: false,
+      takeoffs: const CircuitCounts(dayFullStop: 1),
+      landings: const CircuitCounts(dayFullStop: 1),
+      ifrFlightPlanFiled: false,
+      actualInstrumentTime: FlightDuration.zero,
+      simulatedInstrumentTime: FlightDuration.zero,
+      approaches: const [],
+      holdingProceduresCount: 0,
+      trackingPerformed: false,
+      remarks: '',
+    ),
+    aircraft: _mepSeneca,
+  );
+}

--- a/lib/ui/totals/totals_screen.dart
+++ b/lib/ui/totals/totals_screen.dart
@@ -1,26 +1,805 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
-import '../widgets/large_title_scaffold.dart';
+import '../../domain/jurisdiction/jurisdiction_profile.dart';
+import '../../domain/jurisdiction/jurisdiction_registry.dart';
+import '../../domain/model/aerodrome_directory.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/flight_times.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/primitives/default_primitives.dart';
+import '../../domain/projection/jurisdiction_projection.dart';
+import '../../domain/repository/flight_read_repository.dart';
+import '../../domain/totals/totals_summary.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
+import 'sample_totals_data.dart';
+import 'widgets/totals_bar_chart.dart';
+import 'widgets/totals_row.dart';
 
-/// Placeholder for #85 (totals and summary view, M7).
-class TotalsScreen extends StatelessWidget {
+const _tabLabels = ['Time', 'Aircraft', 'Function', 'Conditions', 'Ops'];
+const _granularityLabels = ['Year', 'Month', 'Week', 'Day'];
+
+const _jurisdictionLabels = {
+  'eu.easa.part-fcl': 'EASA Part-FCL',
+  'us.faa.part61': 'FAA Part 61',
+};
+
+/// #85: totals and summary view — five sub-tabs over one flight set, all
+/// rendered under the pilot's **primary** jurisdiction only (CLAUDE.md's
+/// multi-jurisdiction UX rule). Total time of flight, aircraft hours and
+/// take-off/landing counts are jurisdiction-agnostic facts computed directly
+/// off `Flight`/`PilotCapacity`; PIC/dual/night/instrument/cross-country go
+/// through the existing `JurisdictionProjection` unchanged. Runs against
+/// `sample_totals_data.dart`'s fixture, the same convention Currency and the
+/// entry form already use pending #56's live repository wiring.
+class TotalsScreen extends StatefulWidget {
   const TotalsScreen({super.key});
 
   @override
+  State<TotalsScreen> createState() => _TotalsScreenState();
+}
+
+class _TotalsScreenState extends State<TotalsScreen> {
+  int _tabIndex = 0;
+  Granularity _granularity = Granularity.year;
+
+  List<FlightRecord>? _flights;
+  AerodromeDirectory? _aerodromes;
+  JurisdictionProjection? _projection;
+  late final CalendarDate _today;
+
+  @override
+  void initState() {
+    super.initState();
+    _today = CalendarDate.fromUtcInstant(
+      UtcInstant.fromDateTime(DateTime.now().toUtc()),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    // `cache: false` — see `NewFlightScreen._loadJurisdictions`'s own note.
+    final results = await Future.wait([
+      rootBundle.loadString(
+        'assets/jurisdictions/eu.easa.part-fcl.yaml',
+        cache: false,
+      ),
+      rootBundle.loadString(
+        'assets/jurisdictions/us.faa.part61.yaml',
+        cache: false,
+      ),
+      rootBundle.loadString('assets/aerodromes/airports.csv', cache: false),
+    ]);
+    final registry = JurisdictionRegistry([
+      parseJurisdictionProfileYaml(results[0]),
+      parseJurisdictionProfileYaml(results[1]),
+    ]);
+    final aerodromes = AerodromeDirectory.fromOurAirportsCsv(results[2]);
+    final projection = JurisdictionProjection(
+      registry: registry,
+      primitives: defaultPrimitives,
+      aerodromes: aerodromes,
+      jurisdictionId: samplePilotProfile.primaryJurisdictionId,
+    );
+    final flights = sampleTotalsFlights(_today);
+    if (!mounted) return;
+    setState(() {
+      _flights = flights;
+      _aerodromes = aerodromes;
+      _projection = projection;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return LargeTitleScaffold(
-      title: 'Totals',
-      slivers: [
-        SliverFillRemaining(
-          hasScrollBody: false,
-          child: EmptyStateMessage(
-            icon: Icons.query_stats_outlined,
-            headline: 'Totals land in a later milestone',
-            caption:
-                'Reserved here so the shell\'s navigation is complete now.',
+    final flights = _flights;
+    final aerodromes = _aerodromes;
+    final projection = _projection;
+    if (flights == null || aerodromes == null || projection == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverSafeArea(
+            bottom: false,
+            sliver: SliverToBoxAdapter(
+              child: Column(
+                children: [
+                  _Header(
+                    jurisdictionLabel:
+                        _jurisdictionLabels[samplePilotProfile
+                            .primaryJurisdictionId] ??
+                        samplePilotProfile.primaryJurisdictionId,
+                  ),
+                  _MainTabs(
+                    selected: _tabIndex,
+                    onChanged: (i) => setState(() => _tabIndex = i),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: switch (_tabIndex) {
+              0 => _TimeTab(
+                flights: flights,
+                today: _today,
+                granularity: _granularity,
+                onGranularityChanged: (g) => setState(() => _granularity = g),
+              ),
+              1 => _AircraftTab(flights: flights),
+              2 => _FunctionTab(flights: flights, projection: projection),
+              3 => _ConditionsTab(flights: flights, projection: projection),
+              _ => _OpsTab(flights: flights, aerodromes: aerodromes),
+            },
+          ),
+          const SliverPadding(padding: EdgeInsets.only(bottom: 96)),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.jurisdictionLabel});
+
+  final String jurisdictionLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Totals',
+                style: theme.textTheme.displaySmall?.copyWith(fontSize: 27),
+              ),
+              Row(
+                children: [
+                  // Pushes to the Aerodromes screen, which doesn't exist yet
+                  // (Phase 4) — a harmless no-op, same convention as
+                  // Currency's "Edit".
+                  _HeaderPillButton(label: 'Map', onTap: () {}),
+                  const SizedBox(width: 8),
+                  // CLAUDE.md requires an explicit jurisdiction choice before
+                  // anything is exported; that flow doesn't exist yet
+                  // either, so this deliberately exports nothing rather than
+                  // exporting without asking.
+                  _HeaderPillButton(
+                    label: 'Export',
+                    filled: true,
+                    onTap: () {},
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Derived under $jurisdictionLabel — your primary licence',
+            style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeaderPillButton extends StatelessWidget {
+  const _HeaderPillButton({
+    required this.label,
+    required this.onTap,
+    this.filled = false,
+  });
+
+  final String label;
+  final VoidCallback onTap;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(15),
+      child: Container(
+        height: 30,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: filled ? scheme.primary : scheme.surface,
+          border: filled ? null : Border.all(color: scheme.outlineVariant),
+          borderRadius: BorderRadius.circular(15),
+        ),
+        child: Text(
+          label,
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: filled ? scheme.onPrimary : scheme.primary,
+            fontWeight: FontWeight.w600,
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _MainTabs extends StatelessWidget {
+  const _MainTabs({required this.selected, required this.onChanged});
+
+  final int selected;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
+      child: Row(
+        children: [
+          for (var i = 0; i < _tabLabels.length; i++)
+            Expanded(
+              child: InkWell(
+                onTap: () => onChanged(i),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 11),
+                  decoration: BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(
+                        color: i == selected
+                            ? theme.colorScheme.primary
+                            : Colors.transparent,
+                        width: 2.5,
+                      ),
+                    ),
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    _tabLabels[i],
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: i == selected
+                          ? theme.colorScheme.primary
+                          : ink.medium,
+                      fontWeight: i == selected
+                          ? FontWeight.w700
+                          : FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GranularitySwitch extends StatelessWidget {
+  const _GranularitySwitch({required this.selected, required this.onChanged});
+
+  final Granularity selected;
+  final ValueChanged<Granularity> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          for (var i = 0; i < Granularity.values.length; i++)
+            Expanded(
+              child: InkWell(
+                onTap: () => onChanged(Granularity.values[i]),
+                borderRadius: BorderRadius.circular(6),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: Granularity.values[i] == selected
+                        ? scheme.surface
+                        : null,
+                    borderRadius: BorderRadius.circular(6),
+                    boxShadow: Granularity.values[i] == selected
+                        ? [
+                            BoxShadow(
+                              color: scheme.onSurface.withValues(alpha: 0.14),
+                              blurRadius: 3,
+                              offset: const Offset(0, 1),
+                            ),
+                          ]
+                        : null,
+                  ),
+                  child: Text(
+                    _granularityLabels[i],
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: scheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimeTab extends StatelessWidget {
+  const _TimeTab({
+    required this.flights,
+    required this.today,
+    required this.granularity,
+    required this.onGranularityChanged,
+  });
+
+  final List<FlightRecord> flights;
+  final CalendarDate today;
+  final Granularity granularity;
+  final ValueChanged<Granularity> onGranularityChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final total = FlightDuration.sum([
+      for (final record in flights) record.flight.blockTime,
+    ]);
+    final buckets = bucketTotals(flights, granularity, today);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _TabDivider(),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 13),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'TOTAL TIME OF FLIGHT',
+                    style: AppMonoText.tag(
+                      ink.muted,
+                    ).copyWith(letterSpacing: 1.1),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    total.toHoursMinutes(),
+                    style: AppMonoText.value(
+                      theme.colorScheme.onSurface,
+                      size: 34,
+                      weight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    '${flights.length}',
+                    style: AppMonoText.value(
+                      theme.colorScheme.onSurface,
+                      size: 17,
+                      weight: FontWeight.w700,
+                    ),
+                  ),
+                  Text(
+                    'FLIGHTS',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.faint,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const _TabDivider(),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 11, 20, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _GranularitySwitch(
+                selected: granularity,
+                onChanged: onGranularityChanged,
+              ),
+              const SizedBox(height: 12),
+              TotalsBarChart(buckets: buckets),
+            ],
+          ),
+        ),
+        const _TabDivider(),
+        TotalsRow(
+          label: 'This year',
+          value: sumBlockTimeInRange(
+            flights,
+            CalendarDate(today.year, 1, 1),
+            today,
+          ).toHoursMinutes(),
+        ),
+        const _TabDivider(),
+        TotalsRow(
+          label: 'Last 12 months',
+          value: sumBlockTimeInRange(
+            flights,
+            today.addDays(-365),
+            today,
+          ).toHoursMinutes(),
+        ),
+        const _TabDivider(),
+        TotalsRow(
+          label: 'Last 90 days',
+          value: sumBlockTimeInRange(
+            flights,
+            today.addDays(-90),
+            today,
+          ).toHoursMinutes(),
+        ),
+        const _TabDivider(),
+        TotalsRow(
+          label: 'Last 28 days',
+          value: sumBlockTimeInRange(
+            flights,
+            today.addDays(-28),
+            today,
+          ).toHoursMinutes(),
+        ),
+        const _TabDivider(),
       ],
     );
   }
+}
+
+class _AircraftTab extends StatelessWidget {
+  const _AircraftTab({required this.flights});
+
+  final List<FlightRecord> flights;
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = groupByAircraft(flights);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _TabDivider(),
+        for (final group in groups) ...[
+          TotalsSectionHeader(
+            label: group.multiPilot ? 'MULTI-PILOT' : 'SINGLE-PILOT',
+            trailing: group.total.toHoursMinutes(),
+          ),
+          for (final classTotal in group.classes) ...[
+            const _TabDivider(),
+            if (classTotal.isSingleType)
+              TotalsRow(
+                label: classTotal.classLabel,
+                value: classTotal.total.toHoursMinutes(),
+                emphasis: true,
+              )
+            else ...[
+              TotalsRow(
+                label: classTotal.classLabel,
+                value: classTotal.total.toHoursMinutes(),
+                emphasis: true,
+              ),
+              for (final type in classTotal.types) ...[
+                const _TabDivider(),
+                TotalsRow(
+                  label: type.typeLabel,
+                  value: type.total.toHoursMinutes(),
+                  indent: true,
+                ),
+              ],
+            ],
+          ],
+        ],
+        const _TabDivider(),
+        TotalsRow(
+          label: 'Aircraft flown',
+          value: '${distinctAircraftFlown(flights)}',
+        ),
+        const _TabDivider(),
+      ],
+    );
+  }
+}
+
+class _FunctionTab extends StatelessWidget {
+  const _FunctionTab({required this.flights, required this.projection});
+
+  final List<FlightRecord> flights;
+  final JurisdictionProjection projection;
+
+  @override
+  Widget build(BuildContext context) {
+    final result = projection.projectAggregate([
+      for (final record in flights) (record.flight, record.aircraft),
+    ]);
+    const functionQuantityNames = [
+      'pic',
+      'picus',
+      'spic',
+      'copilot',
+      'dual',
+      'instructor',
+    ];
+    final total = FlightDuration.sum([
+      for (final name in functionQuantityNames)
+        if (result[name] case final quantity? when quantity.creditable)
+          quantity.value,
+    ]);
+
+    String valueOf(String name) =>
+        (result[name]?.value ?? FlightDuration.zero).toHoursMinutes();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _TabDivider(),
+        TotalsSectionHeader(
+          label: 'PILOT FUNCTION TIME',
+          trailing: total.toHoursMinutes(),
+        ),
+        for (final name in const [
+          ('pic', 'PIC'),
+          ('picus', 'PICUS'),
+          ('spic', 'SPIC'),
+          ('copilot', 'Co-pilot'),
+          ('dual', 'Dual'),
+          ('instructor', 'Instructor'),
+        ])
+          if (result[name.$1] != null) ...[
+            const _TabDivider(),
+            TotalsRow(label: name.$2, value: valueOf(name.$1)),
+          ],
+        const _TabDivider(),
+        const TotalsSectionHeader(label: 'OTHER ARRANGEMENTS'),
+        const _TabDivider(),
+        TotalsRow(label: 'Solo', value: soloTime(flights).toHoursMinutes()),
+        const _TabDivider(),
+        Builder(
+          builder: (context) {
+            final awaiting = awaitingCountersignatureTime(flights);
+            return TotalsRow(
+              label: 'Awaiting countersignature',
+              value: awaiting.toHoursMinutes(),
+              valueColor: awaiting == FlightDuration.zero
+                  ? null
+                  : context.semanticColors.currencyWarning,
+            );
+          },
+        ),
+        const _TabDivider(),
+      ],
+    );
+  }
+}
+
+class _ConditionsTab extends StatelessWidget {
+  const _ConditionsTab({required this.flights, required this.projection});
+
+  final List<FlightRecord> flights;
+  final JurisdictionProjection projection;
+
+  @override
+  Widget build(BuildContext context) {
+    final result = projection.projectAggregate([
+      for (final record in flights) (record.flight, record.aircraft),
+    ]);
+
+    String valueOf(String name) =>
+        (result[name]?.value ?? FlightDuration.zero).toHoursMinutes();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _TabDivider(),
+        const TotalsSectionHeader(label: 'OPERATIONAL CONDITION TIME'),
+        for (final name in const [
+          ('night', 'Night'),
+          ('ifr', 'IFR'),
+          ('actualInstrument', 'Actual instrument'),
+          ('simulatedInstrument', 'Simulated instrument'),
+          ('crossCountry', 'Cross-country'),
+        ])
+          if (result[name.$1] != null) ...[
+            const _TabDivider(),
+            TotalsRow(label: name.$2, value: valueOf(name.$1)),
+            if (name.$1 == 'crossCountry') ...[
+              const _TabDivider(),
+              TotalsRow(
+                label: 'of which PIC',
+                value: crossCountryOfWhichPic(
+                  flights,
+                  projection,
+                ).toHoursMinutes(),
+                indent: true,
+              ),
+            ],
+          ],
+        const _TabDivider(),
+        TotalsRow(
+          label: 'Longest flight',
+          value: longestFlight(flights).toHoursMinutes(),
+        ),
+        const _TabDivider(),
+      ],
+    );
+  }
+}
+
+class _OpsTab extends StatelessWidget {
+  const _OpsTab({required this.flights, required this.aerodromes});
+
+  final List<FlightRecord> flights;
+  final AerodromeDirectory aerodromes;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final counts = opsCounts(flights);
+    final visited = aerodromesVisited(flights, aerodromes);
+
+    Widget circuitRow(String label, int takeoffs, int landings) => Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+      child: Row(
+        children: [
+          Expanded(child: Text(label, style: theme.textTheme.titleSmall)),
+          SizedBox(
+            width: 46,
+            child: Text(
+              '$takeoffs',
+              textAlign: TextAlign.right,
+              style: AppMonoText.value(theme.colorScheme.onSurface, size: 13.5),
+            ),
+          ),
+          SizedBox(
+            width: 46,
+            child: Text(
+              '$landings',
+              textAlign: TextAlign.right,
+              style: AppMonoText.value(theme.colorScheme.onSurface, size: 13.5),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _TabDivider(),
+        Container(
+          color: theme.colorScheme.surfaceContainerLowest,
+          padding: const EdgeInsets.fromLTRB(20, 9, 20, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'TAKE-OFFS & LANDINGS',
+                  style: AppMonoText.tag(
+                    ink.muted,
+                  ).copyWith(letterSpacing: 1.1),
+                ),
+              ),
+              SizedBox(
+                width: 46,
+                child: Text(
+                  'T/O',
+                  textAlign: TextAlign.right,
+                  style: AppMonoText.tag(ink.faint),
+                ),
+              ),
+              SizedBox(
+                width: 46,
+                child: Text(
+                  'LDG',
+                  textAlign: TextAlign.right,
+                  style: AppMonoText.tag(ink.faint),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const _TabDivider(),
+        circuitRow(
+          'Day, full stop',
+          counts.dayFullStopTakeoffs,
+          counts.dayFullStopLandings,
+        ),
+        const _TabDivider(),
+        circuitRow(
+          'Day, touch & go',
+          counts.dayTouchAndGoTakeoffs,
+          counts.dayTouchAndGoLandings,
+        ),
+        const _TabDivider(),
+        circuitRow(
+          'Night, full stop',
+          counts.nightFullStopTakeoffs,
+          counts.nightFullStopLandings,
+        ),
+        const _TabDivider(),
+        circuitRow(
+          'Night, touch & go',
+          counts.nightTouchAndGoTakeoffs,
+          counts.nightTouchAndGoLandings,
+        ),
+        const _TabDivider(),
+        const TotalsSectionHeader(label: 'APPROACHES & FSTD'),
+        const _TabDivider(),
+        TotalsRow(
+          label: 'Instrument approaches',
+          value: '${counts.instrumentApproaches}',
+        ),
+        const _TabDivider(),
+        // FSTD sessions have no persistence or read path yet (#28) --
+        // omitted rather than fabricated.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Aerodromes visited', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 2),
+              Text(
+                '${visited.aerodromes} across ${visited.countries} '
+                'countries',
+                style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '${visited.aerodromes}',
+                style: AppMonoText.value(
+                  theme.colorScheme.onSurface,
+                  size: 13.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const _TabDivider(),
+      ],
+    );
+  }
+}
+
+class _TabDivider extends StatelessWidget {
+  const _TabDivider();
+
+  @override
+  Widget build(BuildContext context) =>
+      Divider(height: 1, color: Theme.of(context).colorScheme.outlineVariant);
 }

--- a/lib/ui/totals/widgets/totals_bar_chart.dart
+++ b/lib/ui/totals/widgets/totals_bar_chart.dart
@@ -1,0 +1,96 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../../domain/totals/totals_summary.dart';
+import '../../theme/app_colors.dart';
+import '../../theme/app_typography.dart';
+
+/// The Time tab's granularity chart — [buckets] in oldest-to-newest order,
+/// the current period filled with the accent colour, every other bar a
+/// neutral tint, matching the mockup's own "past bars muted, current one
+/// solid" convention.
+class TotalsBarChart extends StatelessWidget {
+  const TotalsBarChart({super.key, required this.buckets});
+
+  final List<TimeBucket> buckets;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final maxMinutes = buckets
+        .map((b) => b.value.inMinutes)
+        .fold(0, (a, b) => a > b ? a : b);
+    // A flat maxY of 0 (no flying at all in view) would make every bar's
+    // fraction NaN -- floor it to something a chart can still lay out.
+    final maxY = (maxMinutes == 0 ? 60 : maxMinutes).toDouble();
+
+    return SizedBox(
+      height: 100,
+      child: BarChart(
+        BarChartData(
+          maxY: maxY,
+          alignment: BarChartAlignment.spaceAround,
+          gridData: const FlGridData(show: false),
+          borderData: FlBorderData(show: false),
+          barTouchData: BarTouchData(enabled: false),
+          titlesData: FlTitlesData(
+            leftTitles: const AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            topTitles: const AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            rightTitles: const AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                reservedSize: 18,
+                getTitlesWidget: (value, meta) {
+                  final index = value.toInt();
+                  if (index < 0 || index >= buckets.length) {
+                    return const SizedBox.shrink();
+                  }
+                  final bucket = buckets[index];
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      bucket.label,
+                      style: AppMonoText.value(
+                        bucket.isCurrent
+                            ? theme.colorScheme.primary
+                            : ink.faint,
+                        size: 9,
+                        weight: bucket.isCurrent
+                            ? FontWeight.w700
+                            : FontWeight.w500,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          barGroups: [
+            for (var i = 0; i < buckets.length; i++)
+              BarChartGroupData(
+                x: i,
+                barRods: [
+                  BarChartRodData(
+                    toY: buckets[i].value.inMinutes.toDouble(),
+                    width: 14,
+                    color: buckets[i].isCurrent
+                        ? theme.colorScheme.primary
+                        : theme.colorScheme.outlineVariant,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/totals/widgets/totals_row.dart
+++ b/lib/ui/totals/widgets/totals_row.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+import '../../theme/app_typography.dart';
+
+/// A label-left, mono-value-right row — the repeating shape almost every
+/// Totals list row is (Function/Conditions/Ops figures, aircraft subtotals).
+/// [indent] pushes a sub-row in under its parent (a type under its class, an
+/// "of which PIC" line under Cross-country) without a second widget shape.
+class TotalsRow extends StatelessWidget {
+  const TotalsRow({
+    super.key,
+    required this.label,
+    required this.value,
+    this.indent = false,
+    this.emphasis = false,
+    this.valueColor,
+  });
+
+  final String label;
+  final String value;
+  final bool indent;
+
+  /// Section-total rows (class/group subtotals) read slightly larger and
+  /// bolder than a plain leaf row — matches the mockup's own weight step
+  /// between a class header and its indented types.
+  final bool emphasis;
+  final Color? valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(indent ? 34 : 20, 11, 20, 11),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: indent
+                ? theme.textTheme.bodyMedium?.copyWith(color: ink.muted)
+                : theme.textTheme.titleSmall,
+          ),
+          Text(
+            value,
+            style: AppMonoText.value(
+              valueColor ?? theme.colorScheme.onSurface,
+              size: indent ? 12.5 : 13.5,
+              weight: emphasis ? FontWeight.w700 : FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The small mono-caps section header ("PILOT FUNCTION TIME",
+/// "TAKE-OFFS & LANDINGS"), with an optional trailing subtotal.
+class TotalsSectionHeader extends StatelessWidget {
+  const TotalsSectionHeader({super.key, required this.label, this.trailing});
+
+  final String label;
+  final String? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 9, 20, 8),
+      color: theme.colorScheme.surfaceContainerLowest,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: AppMonoText.tag(ink.muted).copyWith(letterSpacing: 1.1),
+          ),
+          if (trailing != null)
+            Text(trailing!, style: AppMonoText.value(ink.faint, size: 11)),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.34.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -241,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -810,4 +826,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,10 @@ dependencies:
   # drift_dev 2.34.0 actually resolved against — fixes the schema dump
   # command; verified all 355 existing tests still pass at this version.
   drift: 2.34.0
+  # Totals' Time-tab bar chart (year/month/week/day granularity) — agreed
+  # during the Currency-screen scoping pass rather than hand-rolling bars,
+  # since later screens may need richer charts too.
+  fl_chart: ^1.1.1
   flutter:
     sdk: flutter
   flutter_riverpod: ^3.4.2

--- a/test/domain/totals/totals_summary_test.dart
+++ b/test/domain/totals/totals_summary_test.dart
@@ -1,0 +1,546 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/countersignature.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/flight_times.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/projection/derived_quantity.dart';
+import 'package:easa_digital_log/domain/projection/projection.dart';
+import 'package:easa_digital_log/domain/projection/projection_result.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/domain/totals/totals_summary.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _picCapacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _testAircraft = Aircraft(
+  registration: 'G-TEST',
+  manufacturer: 'Cessna',
+  model: '152',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight({
+  required CalendarDate date,
+  Duration blockDuration = const Duration(hours: 1),
+  PilotCapacity capacity = _picCapacity,
+  CircuitCounts? takeoffs,
+  CircuitCounts? landings,
+  List<Approach> approaches = const [],
+  List<String> route = const ['EGXX'],
+}) {
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
+  return Flight(
+    aircraftRegistration: 'G-TEST',
+    route: route,
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(blockDuration),
+    capacity: capacity,
+    carryingPassengers: false,
+    takeoffs: takeoffs ?? const CircuitCounts(dayFullStop: 1),
+    landings: landings ?? const CircuitCounts(dayFullStop: 1),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: approaches,
+    holdingProceduresCount: 0,
+    trackingPerformed: false,
+    remarks: '',
+  );
+}
+
+FlightRecord _record(
+  String id,
+  Flight flight, {
+  Aircraft aircraft = _testAircraft,
+}) => FlightRecord(id: id, flight: flight, aircraft: aircraft);
+
+/// Returns `crossCountry` equal to block time for a flight, so
+/// [crossCountryOfWhichPic] tests can assert exact totals without a real
+/// jurisdiction profile.
+class _FakeProjection implements Projection {
+  const _FakeProjection();
+
+  @override
+  ProjectionResult project(Flight flight, Aircraft aircraft) =>
+      ProjectionResult(
+        jurisdictionId: 'test',
+        quantities: {
+          'crossCountry': DerivedQuantity.creditable(flight.blockTime, 'test'),
+        },
+      );
+
+  @override
+  ProjectionResult projectAggregate(Iterable<(Flight, Aircraft)> flights) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  group('bucketTotals', () {
+    const asOf = CalendarDate(2026, 8, 21);
+
+    test('year: sums each flight into its calendar year, current flagged', () {
+      final flights = [
+        _record('1', _flight(date: const CalendarDate(2026, 3, 1))),
+        _record('2', _flight(date: const CalendarDate(2026, 6, 1))),
+        _record('3', _flight(date: const CalendarDate(2025, 1, 1))),
+        _record(
+          '4',
+          _flight(date: const CalendarDate(2019, 1, 1)),
+        ), // the oldest of 8 years
+        _record(
+          '5',
+          _flight(date: const CalendarDate(2018, 1, 1)),
+        ), // outside the 8-year window
+      ];
+
+      final buckets = bucketTotals(flights, Granularity.year, asOf);
+
+      expect(buckets, hasLength(8));
+      expect(buckets.last.label, '2026');
+      expect(buckets.last.value, const FlightDuration(120));
+      expect(buckets.last.isCurrent, isTrue);
+      expect(buckets[buckets.length - 2].label, '2025');
+      expect(buckets[buckets.length - 2].value, const FlightDuration(60));
+      // 2026 back through 2019 is exactly 8 years -- 2019 is the oldest
+      // bucket shown; 2018 (one year further) never appears at all.
+      expect(buckets.first.label, '2019');
+      expect(buckets.first.value, const FlightDuration(60));
+    });
+
+    test('month: crosses a year boundary correctly', () {
+      final flights = [
+        _record(
+          '1',
+          _flight(date: const CalendarDate(2026, 8, 15)),
+        ), // current month
+        _record(
+          '2',
+          _flight(date: const CalendarDate(2026, 1, 15)),
+        ), // 7 months back
+        _record(
+          '3',
+          _flight(date: const CalendarDate(2025, 12, 15)),
+        ), // 8 months back -> excluded
+      ];
+
+      final buckets = bucketTotals(flights, Granularity.month, asOf, count: 8);
+
+      expect(buckets.last.label, 'Aug');
+      expect(buckets.last.value, const FlightDuration(60));
+      expect(buckets.first.label, 'Jan');
+      expect(buckets.first.value, const FlightDuration(60));
+    });
+
+    test('day: a flight exactly 7 days back lands in the oldest bucket', () {
+      final flights = [
+        _record('1', _flight(date: asOf)),
+        _record('2', _flight(date: asOf.addDays(-7))),
+        _record(
+          '3',
+          _flight(date: asOf.addDays(-8)),
+        ), // outside the 8-day window
+      ];
+
+      final buckets = bucketTotals(flights, Granularity.day, asOf, count: 8);
+
+      expect(buckets.last.value, const FlightDuration(60));
+      expect(buckets.last.isCurrent, isTrue);
+      expect(buckets.first.value, const FlightDuration(60));
+    });
+
+    test('week: an 8th rolling week is 7*7=49 to 55 days back', () {
+      final flights = [
+        _record(
+          '1',
+          _flight(date: asOf.addDays(-49)),
+        ), // first day of the oldest window
+        _record('2', _flight(date: asOf.addDays(-56))), // one day outside it
+      ];
+
+      final buckets = bucketTotals(flights, Granularity.week, asOf, count: 8);
+
+      expect(buckets.first.value, const FlightDuration(60));
+    });
+
+    test('an empty flight set produces all-zero buckets', () {
+      final buckets = bucketTotals(const [], Granularity.year, asOf);
+      expect(buckets.every((b) => b.value == FlightDuration.zero), isTrue);
+    });
+  });
+
+  group('sumBlockTimeInRange', () {
+    test('includes both range endpoints', () {
+      final flights = [
+        _record('1', _flight(date: const CalendarDate(2026, 1, 1))),
+        _record('2', _flight(date: const CalendarDate(2026, 6, 15))),
+        _record('3', _flight(date: const CalendarDate(2026, 12, 31))),
+        _record('4', _flight(date: const CalendarDate(2027, 1, 1))),
+      ];
+
+      final total = sumBlockTimeInRange(
+        flights,
+        const CalendarDate(2026, 1, 1),
+        const CalendarDate(2026, 12, 31),
+      );
+
+      expect(total, const FlightDuration(180));
+    });
+  });
+
+  group('aircraftClassLabel', () {
+    test('single-engine piston aeroplane is SEP', () {
+      expect(aircraftClassLabel(_testAircraft), 'SEP (land)');
+    });
+
+    test('twin-engine piston aeroplane is MEP', () {
+      const twin = Aircraft(
+        registration: 'G-TWIN',
+        manufacturer: 'Piper',
+        model: 'PA-34',
+        category: AircraftCategory.aeroplane,
+        engineType: EngineType.piston,
+        engineCount: 2,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: false,
+      );
+      expect(aircraftClassLabel(twin), 'MEP (land)');
+    });
+
+    test('a touring motor glider is TMG regardless of engine count', () {
+      const tmg = Aircraft(
+        registration: 'G-TMG',
+        manufacturer: 'Diamond',
+        model: 'HK36',
+        category: AircraftCategory.touringMotorGlider,
+        engineType: EngineType.piston,
+        engineCount: 1,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: false,
+      );
+      expect(aircraftClassLabel(tmg), 'TMG');
+    });
+
+    test('a turbofan jet falls back to its own type label', () {
+      const jet = Aircraft(
+        registration: 'G-JET',
+        manufacturer: 'Cessna',
+        model: 'Citation CJ2',
+        icaoTypeDesignator: 'C25A',
+        category: AircraftCategory.aeroplane,
+        engineType: EngineType.turbofan,
+        engineCount: 2,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: true,
+      );
+      expect(aircraftClassLabel(jet), 'C25A');
+      expect(aircraftClassLabel(jet), aircraftTypeLabel(jet));
+    });
+  });
+
+  group('groupByAircraft', () {
+    const jet = Aircraft(
+      registration: 'G-JET',
+      manufacturer: 'Cessna',
+      model: 'Citation CJ2',
+      icaoTypeDesignator: 'C25A',
+      category: AircraftCategory.aeroplane,
+      engineType: EngineType.turbofan,
+      engineCount: 2,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: true,
+    );
+    const twin = Aircraft(
+      registration: 'G-TWIN',
+      manufacturer: 'Piper',
+      model: 'PA-34',
+      category: AircraftCategory.aeroplane,
+      engineType: EngineType.piston,
+      engineCount: 2,
+      operatingSurface: OperatingSurface.land,
+      requiresMultiCrew: false,
+    );
+
+    test(
+      'groups single-pilot before multi-pilot, with class and type subtotals',
+      () {
+        final flights = [
+          _record(
+            '1',
+            _flight(
+              date: const CalendarDate(2026, 1, 1),
+              blockDuration: const Duration(hours: 2),
+            ),
+          ), // single-pilot SEP, G-TEST
+          _record(
+            '2',
+            _flight(
+              date: const CalendarDate(2026, 1, 2),
+              blockDuration: const Duration(hours: 1),
+              capacity: _picCapacity.copyWith(multiPilotOperation: false),
+            ),
+            aircraft: twin,
+          ), // single-pilot MEP
+          _record(
+            '3',
+            _flight(
+              date: const CalendarDate(2026, 1, 3),
+              blockDuration: const Duration(hours: 3),
+              capacity: _picCapacity.copyWith(multiPilotOperation: true),
+            ),
+            aircraft: jet,
+          ), // multi-pilot jet
+        ];
+
+        final groups = groupByAircraft(flights);
+
+        expect(groups, hasLength(2));
+        expect(groups[0].multiPilot, isFalse);
+        expect(groups[0].total, const FlightDuration(180));
+        // SEP (2h) sorts before MEP (1h).
+        expect(groups[0].classes[0].classLabel, 'SEP (land)');
+        expect(groups[0].classes[1].classLabel, 'MEP (land)');
+
+        expect(groups[1].multiPilot, isTrue);
+        expect(groups[1].total, const FlightDuration(180));
+        expect(groups[1].classes.single.isSingleType, isTrue);
+      },
+    );
+
+    test('an empty flight set produces no groups', () {
+      expect(groupByAircraft(const []), isEmpty);
+    });
+  });
+
+  test('distinctAircraftFlown counts unique registrations', () {
+    final flights = [
+      _record('1', _flight(date: const CalendarDate(2026, 1, 1))),
+      _record('2', _flight(date: const CalendarDate(2026, 1, 2))),
+    ];
+    expect(distinctAircraftFlown(flights), 1);
+  });
+
+  test('soloTime sums only sole-occupant flights', () {
+    final flights = [
+      _record(
+        '1',
+        _flight(date: const CalendarDate(2026, 1, 1), capacity: _picCapacity),
+      ),
+      _record(
+        '2',
+        _flight(
+          date: const CalendarDate(2026, 1, 2),
+          capacity: _picCapacity.copyWith(soleOccupant: false),
+        ),
+      ),
+    ];
+    expect(soloTime(flights), const FlightDuration(60));
+  });
+
+  group('awaitingCountersignatureTime', () {
+    test('sums only flights with a pending countersignature', () {
+      final flights = [
+        _record(
+          '1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            capacity: _picCapacity.copyWith(
+              countersignature: const Countersignature(
+                status: CountersignatureStatus.pending,
+              ),
+            ),
+          ),
+        ),
+        _record(
+          '2',
+          _flight(
+            date: const CalendarDate(2026, 1, 2),
+            capacity: _picCapacity.copyWith(
+              countersignature: const Countersignature(
+                status: CountersignatureStatus.signed,
+              ),
+            ),
+          ),
+        ),
+        _record(
+          '3',
+          _flight(
+            date: const CalendarDate(2026, 1, 3),
+            capacity: _picCapacity.copyWith(
+              countersignature: const Countersignature(
+                status: CountersignatureStatus.refused,
+              ),
+            ),
+          ),
+        ),
+        _record('4', _flight(date: const CalendarDate(2026, 1, 4))), // null
+      ];
+
+      expect(awaitingCountersignatureTime(flights), const FlightDuration(60));
+    });
+  });
+
+  test(
+    'crossCountryOfWhichPic sums only flights flown with command authority',
+    () {
+      final flights = [
+        _record(
+          '1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            blockDuration: const Duration(hours: 2),
+            capacity: _picCapacity,
+          ),
+        ),
+        _record(
+          '2',
+          _flight(
+            date: const CalendarDate(2026, 1, 2),
+            blockDuration: const Duration(hours: 1),
+            capacity: _picCapacity.copyWith(commandAuthority: false),
+          ),
+        ),
+      ];
+
+      expect(
+        crossCountryOfWhichPic(flights, const _FakeProjection()),
+        const FlightDuration(120),
+      );
+    },
+  );
+
+  group('longestFlight', () {
+    test('returns the longest block time', () {
+      final flights = [
+        _record(
+          '1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            blockDuration: const Duration(hours: 1),
+          ),
+        ),
+        _record(
+          '2',
+          _flight(
+            date: const CalendarDate(2026, 1, 2),
+            blockDuration: const Duration(hours: 4),
+          ),
+        ),
+      ];
+      expect(longestFlight(flights), const FlightDuration(240));
+    });
+
+    test('is zero for an empty flight set', () {
+      expect(longestFlight(const []), FlightDuration.zero);
+    });
+  });
+
+  test('opsCounts sums takeoffs, landings and approaches across flights', () {
+    final flights = [
+      _record(
+        '1',
+        _flight(
+          date: const CalendarDate(2026, 1, 1),
+          takeoffs: const CircuitCounts(dayFullStop: 2, nightTouchAndGo: 1),
+          landings: const CircuitCounts(dayFullStop: 2, nightTouchAndGo: 1),
+          approaches: const [
+            Approach(
+              type: ApproachType.ils,
+              aerodromeIcao: 'EGXX',
+              runway: '09',
+              count: 2,
+            ),
+          ],
+        ),
+      ),
+      _record(
+        '2',
+        _flight(
+          date: const CalendarDate(2026, 1, 2),
+          takeoffs: const CircuitCounts(dayFullStop: 1),
+          landings: const CircuitCounts(dayFullStop: 1),
+        ),
+      ),
+    ];
+
+    final counts = opsCounts(flights);
+
+    expect(counts.dayFullStopTakeoffs, 3);
+    expect(counts.dayFullStopLandings, 3);
+    expect(counts.nightTouchAndGoTakeoffs, 1);
+    expect(counts.nightTouchAndGoLandings, 1);
+    expect(counts.instrumentApproaches, 2);
+  });
+
+  group('aerodromesVisited', () {
+    test(
+      'counts unique ICAO codes, resolving countries where the directory knows them',
+      () {
+        final directory = AerodromeDirectory([
+          Aerodrome(
+            icaoCode: 'EGKA',
+            name: 'Shoreham',
+            position: GeoCoordinate(latitude: 50.8, longitude: -0.3),
+            isoCountry: 'GB',
+          ),
+          Aerodrome(
+            icaoCode: 'LFAT',
+            name: 'Le Touquet',
+            position: GeoCoordinate(latitude: 50.5, longitude: 1.6),
+            isoCountry: 'FR',
+          ),
+        ]);
+        final flights = [
+          _record(
+            '1',
+            _flight(
+              date: const CalendarDate(2026, 1, 1),
+              route: const ['EGKA', 'LFAT', 'EGKA'],
+            ),
+          ),
+          _record(
+            '2',
+            _flight(
+              date: const CalendarDate(2026, 1, 2),
+              route: const ['EGKA', 'PRIVATE-STRIP'],
+            ),
+          ),
+        ];
+
+        final result = aerodromesVisited(flights, directory);
+
+        expect(result.aerodromes, 3); // EGKA, LFAT, PRIVATE-STRIP
+        expect(
+          result.countries,
+          2,
+        ); // GB, FR -- the private strip resolves to neither
+      },
+    );
+
+    test('an empty flight set visits nothing', () {
+      final result = aerodromesVisited(const [], AerodromeDirectory(const []));
+      expect(result.aerodromes, 0);
+      expect(result.countries, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Totals dashboard (Phase 2 of the Currency/Totals/Aerodromes/Settings redesign): five tabs — Time (granularity-switchable `fl_chart` bar chart + fixed range totals), Aircraft (single/multi-pilot → class → type rollup), Function (PIC/PICUS/SPIC/co-pilot/dual/instructor + solo/awaiting-countersignature), Conditions (night/IFR/instrument/cross-country + "of which PIC"), Ops (take-off/landing grid + approaches + aerodromes visited).
- New pure domain layer `lib/domain/totals/totals_summary.dart` — bucketing, aircraft grouping, solo/countersignature/cross-country-of-which-PIC aggregation — needs no `Flight`/`DerivedQuantity` schema change, all reachable from existing raw facts and `JurisdictionProjection`.
- New deterministic sample fixture (`lib/ui/totals/sample_totals_data.dart`, 361 flights across ~3 years) standing in for #56's live repository wiring, same convention as Currency's sample data.
- New dependency: `fl_chart` (agreed during Currency's own scoping).

## Test plan
- [x] `flutter test` — 602 tests pass, including 21 new `totals_summary_test.dart` cases.
- [x] `dart run tool/check_domain_coverage.dart` — 95.7% on `lib/domain/` (threshold 90%).
- [x] `flutter analyze --fatal-infos`, `check_layering`, `check_domain_types`, `check_currency_rules`, `check_schema_snapshot` all clean.
- [x] On-device verification (Android emulator, light + dark) of all five tabs and the Year/Month/Week/Day granularity switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)