### PR TITLE
Aerodromes screen: Map placeholder and visits list (#62)

### DIFF
--- a/drift_schemas/drift_schema_v6.json
+++ b/drift_schemas/drift_schema_v6.json
@@ -1,0 +1,1636 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "alternative_compliance_events",
+            "getter_name": "alternativeComplianceEvents",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pilot_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_of_birth",
+            "getter_name": "dateOfBirth",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "primary_jurisdiction_id",
+            "getter_name": "primaryJurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'eu.easa.part-fcl\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "home_base_icao",
+            "getter_name": "homeBaseIcao",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "medical_certificates",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "certificate_class",
+            "getter_name": "certificateClass",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_aircraft_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_granted",
+            "getter_name": "dateGranted",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_name",
+            "getter_name": "signatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_credential_number",
+            "getter_name": "signatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_ratings",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "designator",
+            "getter_name": "designator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "expiry_date",
+            "getter_name": "expiryDate",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "language_proficiency_level",
+            "getter_name": "languageProficiencyLevel",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"alternative_compliance_events\" TEXT NOT NULL DEFAULT '', \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pilot_profile",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pilot_profile\" (\"id\" TEXT NOT NULL, \"date_of_birth\" TEXT NOT NULL, \"primary_jurisdiction_id\" TEXT NOT NULL DEFAULT 'eu.easa.part-fcl', \"home_base_icao\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "medical_certificates",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"medical_certificates\" (\"id\" TEXT NOT NULL, \"certificate_class\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_aircraft_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_aircraft_qualifications\" (\"id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"date_granted\" TEXT NOT NULL, \"signatory_name\" TEXT NULL, \"signatory_credential_number\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_ratings",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_ratings\" (\"id\" TEXT NOT NULL, \"kind\" TEXT NOT NULL, \"designator\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, \"expiry_date\" TEXT NULL, \"language_proficiency_level\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -32,7 +32,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.executor);
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   // SQLite does not enforce foreign keys — including this schema's
   // `onDelete: KeyAction.cascade` on the flight/aircraft child tables —
@@ -85,6 +85,17 @@ class AppDatabase extends _$AppDatabase {
           pilotProfileTable,
           pilotProfileTable.primaryJurisdictionId,
         );
+      }
+      // Adds homeBaseIcao to pilot_profile — the Aerodromes screen's
+      // "furthest" figure. Nullable and never defaulted, so the column's
+      // backfill leaves every existing row with no home base set rather than
+      // guessing one.
+      //
+      // Guarded to `from >= 2`, same reasoning as the `primaryJurisdictionId`
+      // step above: `from < 2`'s `createTable` already builds from today's
+      // Dart schema, which already includes this column.
+      if (from >= 2 && from < 6) {
+        await m.addColumn(pilotProfileTable, pilotProfileTable.homeBaseIcao);
       }
     },
     beforeOpen: (details) async {

--- a/lib/data/mappers/pilot_record_mapper.dart
+++ b/lib/data/mappers/pilot_record_mapper.dart
@@ -11,6 +11,7 @@ PilotProfileRow pilotProfileToRow(
     id: id,
     dateOfBirth: profile.dateOfBirth.toString(),
     primaryJurisdictionId: profile.primaryJurisdictionId,
+    homeBaseIcao: profile.homeBaseIcao,
   );
 }
 
@@ -18,6 +19,7 @@ domain.PilotProfile pilotProfileFromRow(PilotProfileRow row) {
   return domain.PilotProfile(
     dateOfBirth: CalendarDate.parse(row.dateOfBirth),
     primaryJurisdictionId: row.primaryJurisdictionId,
+    homeBaseIcao: row.homeBaseIcao,
   );
 }
 

--- a/lib/data/tables/pilot_record_tables.dart
+++ b/lib/data/tables/pilot_record_tables.dart
@@ -20,6 +20,10 @@ class PilotProfileTable extends Table {
   TextColumn get primaryJurisdictionId =>
       text().withDefault(const Constant('eu.easa.part-fcl'))();
 
+  /// Mirrors `PilotProfile.homeBaseIcao` — nullable, never defaulted, since a
+  /// pilot who hasn't set one should read back as unset, not backfilled.
+  TextColumn get homeBaseIcao => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }

--- a/lib/domain/aerodromes/aerodrome_summary.dart
+++ b/lib/domain/aerodromes/aerodrome_summary.dart
@@ -1,0 +1,116 @@
+import '../model/aerodrome.dart';
+import '../model/aerodrome_directory.dart';
+import '../model/calendar_date.dart';
+import '../model/geo_coordinate.dart';
+import '../repository/flight_read_repository.dart';
+
+/// Pure aggregation over a flight set for the Aerodromes screen — mirrors
+/// `totals_summary.dart`'s shape (no Flutter import, unit-tested,
+/// deterministic). The summary-card counts (aerodromes visited, countries)
+/// reuse `totals_summary.aerodromesVisited` rather than duplicating that
+/// logic here.
+///
+/// **Visits, not landings.** [Flight.landings] is a per-flight total, not
+/// broken down by which leg of a multi-stop route it happened on, so there
+/// is no raw fact saying how many landings occurred at any one aerodrome on
+/// a route like `[home, A, B, home]`. [rankAerodromesByVisits] counts
+/// flights that touched each aerodrome instead — always correct, and it's
+/// what the screen's own "most visited" framing actually means.
+
+/// One aerodrome's visit count, with its resolved [Aerodrome] where the
+/// directory has one. [aerodrome] is null for a code the directory doesn't
+/// know — a private strip or an unlicensed field (#14) — the screen falls
+/// back to showing the bare code.
+class AerodromeVisit {
+  const AerodromeVisit({
+    required this.icao,
+    required this.aerodrome,
+    required this.visitCount,
+  });
+
+  final String icao;
+  final Aerodrome? aerodrome;
+  final int visitCount;
+}
+
+/// Ranks every aerodrome appearing in [flights]' routes by how many flights
+/// touched it, most-visited first, then by ICAO code for a stable tie order.
+/// A flight visiting the same aerodrome twice in one route (e.g. `[A, A]`,
+/// an out-and-back with no intermediate stop) counts once, not twice — this
+/// counts flights per aerodrome, not route-leg occurrences.
+List<AerodromeVisit> rankAerodromesByVisits(
+  List<FlightRecord> flights,
+  AerodromeDirectory directory,
+) {
+  final visitCounts = <String, int>{};
+  for (final record in flights) {
+    for (final icao in record.flight.route.toSet()) {
+      visitCounts[icao] = (visitCounts[icao] ?? 0) + 1;
+    }
+  }
+
+  final visits = [
+    for (final entry in visitCounts.entries)
+      AerodromeVisit(
+        icao: entry.key,
+        aerodrome: directory.byIcao(entry.key),
+        visitCount: entry.value,
+      ),
+  ];
+  visits.sort((a, b) {
+    final byCount = b.visitCount.compareTo(a.visitCount);
+    return byCount != 0 ? byCount : a.icao.compareTo(b.icao);
+  });
+  return visits;
+}
+
+/// The furthest aerodrome visited from [homeBaseIcao], with its great-circle
+/// distance in nautical miles. Returns `null` if [homeBaseIcao] doesn't
+/// resolve in [directory], or if no other aerodrome has been visited — never
+/// a fabricated distance for a home base nobody has actually set.
+({String icao, double nm})? furthestAerodrome(
+  List<FlightRecord> flights,
+  AerodromeDirectory directory,
+  String homeBaseIcao,
+) {
+  final home = directory.byIcao(homeBaseIcao);
+  if (home == null) {
+    return null;
+  }
+
+  final icaoCodes = <String>{
+    for (final record in flights) ...record.flight.route,
+  }..remove(homeBaseIcao);
+
+  String? furthestIcao;
+  var furthestNm = 0.0;
+  for (final icao in icaoCodes) {
+    final aerodrome = directory.byIcao(icao);
+    if (aerodrome == null) {
+      continue;
+    }
+    final nm = greatCircleDistanceNm(home.position, aerodrome.position);
+    if (furthestIcao == null || nm > furthestNm) {
+      furthestIcao = icao;
+      furthestNm = nm;
+    }
+  }
+
+  return furthestIcao == null ? null : (icao: furthestIcao, nm: furthestNm);
+}
+
+/// Count of aerodromes whose earliest visiting flight falls in [asOf]'s
+/// calendar year — an aerodrome flown to for the first time this year.
+int newAerodromesThisYear(List<FlightRecord> flights, CalendarDate asOf) {
+  final firstVisitYear = <String, int>{};
+  for (final record in flights) {
+    final year = CalendarDate.fromUtcInstant(record.flight.offBlocks).year;
+    for (final icao in record.flight.route.toSet()) {
+      final existing = firstVisitYear[icao];
+      if (existing == null || year < existing) {
+        firstVisitYear[icao] = year;
+      }
+    }
+  }
+  return firstVisitYear.values.where((year) => year == asOf.year).length;
+}

--- a/lib/domain/pilot_record/pilot_profile.dart
+++ b/lib/domain/pilot_record/pilot_profile.dart
@@ -23,5 +23,12 @@ abstract class PilotProfile with _$PilotProfile {
     /// jurisdiction" must be this explicit settings value, never inferred
     /// from which licence happens to come first (CLAUDE.md).
     required String primaryJurisdictionId,
+
+    /// ICAO code of the aerodrome this pilot flies from most, used only for
+    /// the Aerodromes screen's "furthest" figure. Nullable and unlike
+    /// [primaryJurisdictionId] never defaulted on migration — a pilot who
+    /// hasn't set one yet should see that figure omitted, not a guessed
+    /// answer (CLAUDE.md: "never guess a missing discriminator").
+    String? homeBaseIcao,
   }) = _PilotProfile;
 }

--- a/lib/ui/aerodromes/aerodromes_screen.dart
+++ b/lib/ui/aerodromes/aerodromes_screen.dart
@@ -1,0 +1,608 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../../domain/aerodromes/aerodrome_summary.dart';
+import '../../domain/model/aerodrome_directory.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/repository/flight_read_repository.dart';
+import '../../domain/totals/totals_summary.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
+import '../totals/sample_totals_data.dart';
+
+enum _AeroTab { map, list }
+
+/// The number of ranked rows the List tab shows before "All N aerodromes"
+/// must be tapped to reveal the rest — matches the mockup's own "most
+/// visited" cut, which stops at 7 rows.
+const _collapsedRowCount = 7;
+
+/// Aerodromes screen (#62/Phase 3) — pushed from Totals' "Map" header pill
+/// and its Ops tab "Aerodromes visited" row, never a bottom-nav tab (the
+/// mockup: "the Totals tab stays lit — this is a push, not a fifth tab").
+///
+/// The Map tab is a deliberate placeholder for this phase — no mapping
+/// package has been added, agreed with the project owner rather than pulled
+/// in silently (CLAUDE.md: "ask before adding a dependency"). The List tab
+/// ranks by **visits** (flights whose route touched an aerodrome), not
+/// landings: [Flight.landings] is a per-flight total, not broken down by
+/// which leg of a multi-stop route it happened on, so there is no raw fact
+/// attributing a landing to one aerodrome over another on a route with more
+/// than two stops. See `aerodrome_summary.dart`.
+///
+/// Runs against `sample_totals_data.dart`'s fixture, the same convention
+/// every other screen in this redesign uses pending #56's live repository
+/// wiring.
+class AerodromesScreen extends StatefulWidget {
+  const AerodromesScreen({super.key});
+
+  @override
+  State<AerodromesScreen> createState() => _AerodromesScreenState();
+}
+
+class _AerodromesScreenState extends State<AerodromesScreen> {
+  _AeroTab _tab = _AeroTab.map;
+  bool _showAllAerodromes = false;
+
+  List<FlightRecord>? _flights;
+  AerodromeDirectory? _aerodromes;
+  late final CalendarDate _today;
+
+  @override
+  void initState() {
+    super.initState();
+    _today = CalendarDate.fromUtcInstant(
+      UtcInstant.fromDateTime(DateTime.now().toUtc()),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    // `cache: false` -- see `NewFlightScreen._loadJurisdictions`'s own note.
+    final csv = await rootBundle.loadString(
+      'assets/aerodromes/airports.csv',
+      cache: false,
+    );
+    final aerodromes = AerodromeDirectory.fromOurAirportsCsv(csv);
+    final flights = sampleTotalsFlights(_today);
+    if (!mounted) return;
+    setState(() {
+      _flights = flights;
+      _aerodromes = aerodromes;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final flights = _flights;
+    final aerodromes = _aerodromes;
+    if (flights == null || aerodromes == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      body: SafeArea(
+        bottom: false,
+        child: Column(
+          children: [
+            _Header(tab: _tab, onTabChanged: (t) => setState(() => _tab = t)),
+            Expanded(
+              child: _tab == _AeroTab.map
+                  ? _MapTab(
+                      flights: flights,
+                      aerodromes: aerodromes,
+                      homeBaseIcao: samplePilotProfile.homeBaseIcao,
+                    )
+                  : _ListTab(
+                      flights: flights,
+                      aerodromes: aerodromes,
+                      homeBaseIcao: samplePilotProfile.homeBaseIcao,
+                      showAll: _showAllAerodromes,
+                      onShowAll: () =>
+                          setState(() => _showAllAerodromes = true),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.tab, required this.onTabChanged});
+
+  final _AeroTab tab;
+  final ValueChanged<_AeroTab> onTabChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            onTap: () => Navigator.of(context).pop(),
+            borderRadius: BorderRadius.circular(6),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.chevron_left, size: 20, color: scheme.primary),
+                  Text(
+                    'Totals',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: scheme.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 2),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Aerodromes',
+                style: theme.textTheme.displaySmall?.copyWith(fontSize: 27),
+              ),
+              _AeroTabSwitch(selected: tab, onChanged: onTabChanged),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AeroTabSwitch extends StatelessWidget {
+  const _AeroTabSwitch({required this.selected, required this.onChanged});
+
+  final _AeroTab selected;
+  final ValueChanged<_AeroTab> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    const labels = {_AeroTab.map: 'Map', _AeroTab.list: 'List'};
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final entry in labels.entries)
+            InkWell(
+              onTap: () => onChanged(entry.key),
+              borderRadius: BorderRadius.circular(6),
+              child: Container(
+                width: 54,
+                padding: const EdgeInsets.symmetric(vertical: 6),
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: entry.key == selected ? scheme.surface : null,
+                  borderRadius: BorderRadius.circular(6),
+                  boxShadow: entry.key == selected
+                      ? [
+                          BoxShadow(
+                            color: scheme.onSurface.withValues(alpha: 0.14),
+                            blurRadius: 3,
+                            offset: const Offset(0, 1),
+                          ),
+                        ]
+                      : null,
+                ),
+                child: Text(
+                  entry.value,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: scheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MapTab extends StatelessWidget {
+  const _MapTab({
+    required this.flights,
+    required this.aerodromes,
+    required this.homeBaseIcao,
+  });
+
+  final List<FlightRecord> flights;
+  final AerodromeDirectory aerodromes;
+  final String? homeBaseIcao;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final scheme = theme.colorScheme;
+    final visited = aerodromesVisited(flights, aerodromes);
+    final newThisYear = newAerodromesThisYear(
+      flights,
+      CalendarDate.fromUtcInstant(
+        flights.isEmpty
+            ? UtcInstant.fromDateTime(DateTime.now().toUtc())
+            : flights
+                  .map((r) => r.flight.offBlocks)
+                  .reduce((a, b) => a > b ? a : b),
+      ),
+    );
+    final furthest = homeBaseIcao == null
+        ? null
+        : furthestAerodrome(flights, aerodromes, homeBaseIcao!);
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Container(
+            color: scheme.surfaceContainerLowest,
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 34,
+                    height: 34,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: ink.faint,
+                        width: 1.5,
+                        style: BorderStyle.solid,
+                      ),
+                    ),
+                    child: Center(
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: ink.faint,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 9),
+                  Text(
+                    'Map placeholder',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 40),
+                    child: Text(
+                      'Full-bleed map with every visited aerodrome plotted, '
+                      'pin size by visits, tap a pin for its flights — '
+                      'planned once a mapping package is added.',
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: ink.faint,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 14,
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(15, 13, 15, 13),
+            decoration: BoxDecoration(
+              color: scheme.surface,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: scheme.outlineVariant),
+              boxShadow: [
+                BoxShadow(
+                  color: scheme.onSurface.withValues(alpha: 0.16),
+                  blurRadius: 22,
+                  offset: const Offset(0, 8),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'AERODROMES VISITED',
+                          style: AppMonoText.tag(
+                            ink.muted,
+                          ).copyWith(letterSpacing: 1.1),
+                        ),
+                        const SizedBox(height: 5),
+                        Text(
+                          '${visited.aerodromes}',
+                          style: AppMonoText.value(
+                            theme.colorScheme.onSurface,
+                            size: 30,
+                            weight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          '${visited.countries}',
+                          style: AppMonoText.value(
+                            theme.colorScheme.onSurface,
+                            size: 14,
+                            weight: FontWeight.w600,
+                          ),
+                        ),
+                        Text(
+                          'COUNTRIES',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: ink.faint,
+                            letterSpacing: 0.7,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                Container(
+                  margin: const EdgeInsets.only(top: 12),
+                  padding: const EdgeInsets.only(top: 11),
+                  decoration: BoxDecoration(
+                    border: Border(
+                      top: BorderSide(color: scheme.outlineVariant),
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Text.rich(
+                          furthest == null
+                              ? TextSpan(
+                                  text: 'Furthest — set a home base to see',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: ink.muted,
+                                  ),
+                                )
+                              : TextSpan(
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: ink.muted,
+                                  ),
+                                  children: [
+                                    const TextSpan(text: 'Furthest '),
+                                    TextSpan(
+                                      text: furthest.icao,
+                                      style: AppMonoText.value(
+                                        theme.colorScheme.onSurface,
+                                        size: 11.5,
+                                        weight: FontWeight.w500,
+                                      ),
+                                    ),
+                                    TextSpan(
+                                      text: ' · ${furthest.nm.round()} nm',
+                                    ),
+                                  ],
+                                ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text.rich(
+                        TextSpan(
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: ink.muted,
+                          ),
+                          children: [
+                            const TextSpan(text: 'New this year '),
+                            TextSpan(
+                              text: '$newThisYear',
+                              style: AppMonoText.value(
+                                theme.colorScheme.onSurface,
+                                size: 11.5,
+                                weight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ListTab extends StatelessWidget {
+  const _ListTab({
+    required this.flights,
+    required this.aerodromes,
+    required this.homeBaseIcao,
+    required this.showAll,
+    required this.onShowAll,
+  });
+
+  final List<FlightRecord> flights;
+  final AerodromeDirectory aerodromes;
+  final String? homeBaseIcao;
+  final bool showAll;
+  final VoidCallback onShowAll;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final ranked = rankAerodromesByVisits(flights, aerodromes);
+    final furthest = homeBaseIcao == null
+        ? null
+        : furthestAerodrome(flights, aerodromes, homeBaseIcao!);
+    final visibleCount = showAll
+        ? ranked.length
+        : ranked.length.clamp(0, _collapsedRowCount);
+
+    return ListView(
+      children: [
+        Container(
+          color: theme.colorScheme.surfaceContainerLowest,
+          padding: const EdgeInsets.fromLTRB(20, 9, 20, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'MOST VISITED',
+                  style: AppMonoText.tag(
+                    ink.muted,
+                  ).copyWith(letterSpacing: 1.1),
+                ),
+              ),
+              Text('VISITS', style: AppMonoText.tag(ink.faint)),
+            ],
+          ),
+        ),
+        const _Divider(),
+        for (var i = 0; i < visibleCount; i++) ...[
+          _AerodromeRow(
+            visit: ranked[i],
+            isHomeBase: ranked[i].icao == homeBaseIcao,
+            isFurthest: ranked[i].icao == furthest?.icao,
+            furthestNm: furthest?.nm,
+          ),
+          const _Divider(),
+        ],
+        if (!showAll && ranked.length > _collapsedRowCount)
+          InkWell(
+            onTap: onShowAll,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'All ${ranked.length} aerodromes',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right,
+                    size: 18,
+                    color: theme.colorScheme.primary,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+class _AerodromeRow extends StatelessWidget {
+  const _AerodromeRow({
+    required this.visit,
+    required this.isHomeBase,
+    required this.isFurthest,
+    required this.furthestNm,
+  });
+
+  final AerodromeVisit visit;
+  final bool isHomeBase;
+  final bool isFurthest;
+  final double? furthestNm;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final name = visit.aerodrome?.name;
+    final subtitle = [
+      ?name,
+      if (isHomeBase) 'home base',
+      if (isFurthest && furthestNm != null)
+        'furthest ${furthestNm!.round()} nm',
+    ].join(' · ');
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  visit.icao,
+                  style: AppMonoText.value(
+                    theme.colorScheme.onSurface,
+                    size: 14,
+                    weight: FontWeight.w600,
+                  ),
+                ),
+                if (subtitle.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          Text(
+            '${visit.visitCount}',
+            style: AppMonoText.value(
+              theme.colorScheme.onSurface,
+              size: 13.5,
+              weight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider();
+
+  @override
+  Widget build(BuildContext context) =>
+      Divider(height: 1, color: Theme.of(context).colorScheme.outlineVariant);
+}

--- a/lib/ui/currency/sample_currency_data.dart
+++ b/lib/ui/currency/sample_currency_data.dart
@@ -31,6 +31,7 @@ import '../../domain/repository/flight_read_repository.dart';
 const samplePilotProfile = PilotProfile(
   dateOfBirth: CalendarDate(1985, 6, 15),
   primaryJurisdictionId: 'eu.easa.part-fcl',
+  homeBaseIcao: 'EGKA',
 );
 
 const sampleAircraft = Aircraft(

--- a/lib/ui/totals/totals_screen.dart
+++ b/lib/ui/totals/totals_screen.dart
@@ -12,6 +12,7 @@ import '../../domain/primitives/default_primitives.dart';
 import '../../domain/projection/jurisdiction_projection.dart';
 import '../../domain/repository/flight_read_repository.dart';
 import '../../domain/totals/totals_summary.dart';
+import '../aerodromes/aerodromes_screen.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
 import 'sample_totals_data.dart';
@@ -169,10 +170,14 @@ class _Header extends StatelessWidget {
               ),
               Row(
                 children: [
-                  // Pushes to the Aerodromes screen, which doesn't exist yet
-                  // (Phase 4) — a harmless no-op, same convention as
-                  // Currency's "Edit".
-                  _HeaderPillButton(label: 'Map', onTap: () {}),
+                  _HeaderPillButton(
+                    label: 'Map',
+                    onTap: () => Navigator.of(context).push<void>(
+                      MaterialPageRoute(
+                        builder: (_) => const AerodromesScreen(),
+                      ),
+                    ),
+                  ),
                   const SizedBox(width: 8),
                   // CLAUDE.md requires an explicit jurisdiction choice before
                   // anything is exported; that flow doesn't exist yet
@@ -767,27 +772,32 @@ class _OpsTab extends StatelessWidget {
         const _TabDivider(),
         // FSTD sessions have no persistence or read path yet (#28) --
         // omitted rather than fabricated.
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Aerodromes visited', style: theme.textTheme.titleSmall),
-              const SizedBox(height: 2),
-              Text(
-                '${visited.aerodromes} across ${visited.countries} '
-                'countries',
-                style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
-              ),
-              const SizedBox(height: 6),
-              Text(
-                '${visited.aerodromes}',
-                style: AppMonoText.value(
-                  theme.colorScheme.onSurface,
-                  size: 13.5,
+        InkWell(
+          onTap: () => Navigator.of(context).push<void>(
+            MaterialPageRoute(builder: (_) => const AerodromesScreen()),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Aerodromes visited', style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(
+                  '${visited.aerodromes} across ${visited.countries} '
+                  'countries',
+                  style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
                 ),
-              ),
-            ],
+                const SizedBox(height: 6),
+                Text(
+                  '${visited.aerodromes}',
+                  style: AppMonoText.value(
+                    theme.colorScheme.onSurface,
+                    size: 13.5,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
         const _TabDivider(),

--- a/test/data/database_migration_test.dart
+++ b/test/data/database_migration_test.dart
@@ -272,6 +272,33 @@ void _seedV3Database(String path) {
   }
 }
 
+/// As [_seedV3Database], but at v5 with `primary_jurisdiction_id` already
+/// present (from the earlier v4->v5 step) — isolates the v5->v6 step under
+/// test here, the same way [_seedV3Database] isolates v3->v4. Proves the new
+/// step adds `home_base_icao` and backfills it to null rather than guessing a
+/// value, and leaves the pre-existing `primary_jurisdiction_id` untouched.
+void _seedV5Database(String path) {
+  final db = sqlite3.sqlite3.open(path);
+  try {
+    db.execute('''
+      CREATE TABLE pilot_profile (
+        id TEXT NOT NULL,
+        date_of_birth TEXT NOT NULL,
+        primary_jurisdiction_id TEXT NOT NULL DEFAULT 'eu.easa.part-fcl',
+        PRIMARY KEY (id)
+      )
+    ''');
+    db.execute(
+      'INSERT INTO pilot_profile (id, date_of_birth, primary_jurisdiction_id) '
+      'VALUES (?, ?, ?)',
+      ['singleton', '1990-01-01', 'us.faa.part61'],
+    );
+    db.execute('PRAGMA user_version = 5');
+  } finally {
+    db.close();
+  }
+}
+
 void main() {
   late Directory tempDir;
   late File dbFile;
@@ -373,5 +400,26 @@ void main() {
     expect(flightRows.single.id, 'flight-1');
     expect(flightRows.single.remarks, 'a pre-existing flight');
     expect(flightRows.single.alternativeComplianceEvents, isEmpty);
+  });
+
+  test('migrating a real v5 database to v6 preserves primaryJurisdictionId and '
+      'backfills homeBaseIcao to null', () async {
+    _seedV5Database(dbFile.path);
+
+    final db = await openWithBackup(dbFile, () async {
+      final database = AppDatabase(NativeDatabase(dbFile));
+      await database.customStatement('SELECT 1');
+      return database;
+    });
+    addTearDown(db.close);
+
+    final pilotProfiles = PilotProfileRepository(db);
+    expect(
+      await pilotProfiles.find(),
+      const PilotProfile(
+        dateOfBirth: CalendarDate(1990, 1, 1),
+        primaryJurisdictionId: 'us.faa.part61',
+      ),
+    );
   });
 }

--- a/test/domain/aerodromes/aerodrome_summary_test.dart
+++ b/test/domain/aerodromes/aerodrome_summary_test.dart
@@ -1,0 +1,273 @@
+import 'package:easa_digital_log/domain/aerodromes/aerodrome_summary.dart';
+import 'package:easa_digital_log/domain/model/aerodrome.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/geo_coordinate.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _picCapacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _testAircraft = Aircraft(
+  registration: 'G-TEST',
+  manufacturer: 'Cessna',
+  model: '152',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight({required CalendarDate date, required List<String> route}) {
+  final offBlocks = UtcInstant.utc(date.year, date.month, date.day, 10);
+  return Flight(
+    aircraftRegistration: 'G-TEST',
+    route: route,
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: offBlocks.add(const Duration(hours: 1)),
+    capacity: _picCapacity,
+    carryingPassengers: false,
+    takeoffs: const CircuitCounts(dayFullStop: 1),
+    landings: const CircuitCounts(dayFullStop: 1),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: const [],
+    holdingProceduresCount: 0,
+    trackingPerformed: false,
+    remarks: '',
+  );
+}
+
+FlightRecord _record(String id, Flight flight) =>
+    FlightRecord(id: id, flight: flight, aircraft: _testAircraft);
+
+AerodromeDirectory _directory() => AerodromeDirectory([
+  Aerodrome(
+    icaoCode: 'EGKA',
+    name: 'Shoreham',
+    position: GeoCoordinate(latitude: 50.8356, longitude: -0.2971),
+    isoCountry: 'GB',
+  ),
+  Aerodrome(
+    icaoCode: 'EGHH',
+    name: 'Bournemouth',
+    position: GeoCoordinate(latitude: 50.78, longitude: -1.8425),
+    isoCountry: 'GB',
+  ),
+  Aerodrome(
+    icaoCode: 'LFAT',
+    name: 'Le Touquet',
+    position: GeoCoordinate(latitude: 50.5172, longitude: 1.6208),
+    isoCountry: 'FR',
+  ),
+]);
+
+void main() {
+  group('rankAerodromesByVisits', () {
+    test('ranks aerodromes by number of flights that touched them', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            route: ['EGKA', 'EGHH', 'EGKA'],
+          ),
+        ),
+        _record(
+          'f2',
+          _flight(
+            date: const CalendarDate(2026, 1, 2),
+            route: ['EGKA', 'EGKA'],
+          ),
+        ),
+        _record(
+          'f3',
+          _flight(
+            date: const CalendarDate(2026, 1, 3),
+            route: ['EGKA', 'LFAT', 'EGKA'],
+          ),
+        ),
+      ];
+
+      final ranked = rankAerodromesByVisits(flights, _directory());
+
+      expect(ranked.map((v) => v.icao).toList(), ['EGKA', 'EGHH', 'LFAT']);
+      expect(ranked[0].visitCount, 3);
+      expect(ranked[1].visitCount, 1);
+      expect(ranked[2].visitCount, 1);
+      expect(ranked[0].aerodrome?.name, 'Shoreham');
+    });
+
+    test(
+      'a flight visiting the same aerodrome twice in one route counts once',
+      () {
+        final flights = [
+          _record(
+            'f1',
+            _flight(
+              date: const CalendarDate(2026, 1, 1),
+              route: ['EGKA', 'EGKA', 'EGKA'],
+            ),
+          ),
+        ];
+
+        final ranked = rankAerodromesByVisits(flights, _directory());
+
+        expect(ranked, hasLength(1));
+        expect(ranked.single.visitCount, 1);
+      },
+    );
+
+    test('an unresolved ICAO code still ranks, with a null aerodrome', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            route: ['EGKA', 'PRIVATE-STRIP'],
+          ),
+        ),
+      ];
+
+      final ranked = rankAerodromesByVisits(flights, _directory());
+
+      final unresolved = ranked.firstWhere((v) => v.icao == 'PRIVATE-STRIP');
+      expect(unresolved.aerodrome, isNull);
+    });
+
+    test('ties break by ICAO code', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(date: const CalendarDate(2026, 1, 1), route: ['LFAT']),
+        ),
+        _record(
+          'f2',
+          _flight(date: const CalendarDate(2026, 1, 2), route: ['EGHH']),
+        ),
+      ];
+
+      final ranked = rankAerodromesByVisits(flights, _directory());
+
+      expect(ranked.map((v) => v.icao).toList(), ['EGHH', 'LFAT']);
+    });
+
+    test('an empty flight set ranks nothing', () {
+      expect(rankAerodromesByVisits(const [], _directory()), isEmpty);
+    });
+  });
+
+  group('furthestAerodrome', () {
+    test('returns the furthest visited aerodrome from the home base', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            route: ['EGKA', 'EGHH', 'EGKA'],
+          ),
+        ),
+        _record(
+          'f2',
+          _flight(
+            date: const CalendarDate(2026, 1, 2),
+            route: ['EGKA', 'LFAT', 'EGKA'],
+          ),
+        ),
+      ];
+
+      final furthest = furthestAerodrome(flights, _directory(), 'EGKA');
+
+      // LFAT (Le Touquet, France) is further from EGKA than EGHH
+      // (Bournemouth) is.
+      expect(furthest?.icao, 'LFAT');
+      expect(furthest?.nm, greaterThan(0));
+    });
+
+    test('returns null when the home base does not resolve', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            route: ['EGKA', 'EGHH'],
+          ),
+        ),
+      ];
+
+      expect(furthestAerodrome(flights, _directory(), 'UNKNOWN'), isNull);
+    });
+
+    test('returns null when nothing else has been visited', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(date: const CalendarDate(2026, 1, 1), route: ['EGKA']),
+        ),
+      ];
+
+      expect(furthestAerodrome(flights, _directory(), 'EGKA'), isNull);
+    });
+
+    test('returns null for an empty flight set', () {
+      expect(furthestAerodrome(const [], _directory(), 'EGKA'), isNull);
+    });
+  });
+
+  group('newAerodromesThisYear', () {
+    test('counts aerodromes first visited in the given year', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(date: const CalendarDate(2025, 6, 1), route: ['EGKA']),
+        ),
+        _record(
+          'f2',
+          _flight(date: const CalendarDate(2026, 3, 1), route: ['EGHH']),
+        ),
+        _record(
+          'f3',
+          _flight(date: const CalendarDate(2026, 4, 1), route: ['LFAT']),
+        ),
+        // A later flight back to an aerodrome first visited last year
+        // doesn't make it "new" this year.
+        _record(
+          'f4',
+          _flight(date: const CalendarDate(2026, 5, 1), route: ['EGKA']),
+        ),
+      ];
+
+      final count = newAerodromesThisYear(
+        flights,
+        const CalendarDate(2026, 12, 31),
+      );
+
+      expect(count, 2); // EGHH and LFAT
+    });
+
+    test('an empty flight set has no new aerodromes', () {
+      expect(
+        newAerodromesThisYear(const [], const CalendarDate(2026, 1, 1)),
+        0,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Aerodromes screen (Phase 3 of the Currency/Totals/Aerodromes/Settings redesign) — pushed from Totals' "Map" header pill and its Ops "Aerodromes visited" row, never a bottom-nav tab (matches the mockup: "the Totals tab stays lit — this is a push, not a fifth tab").
- **Map tab**: a deliberate placeholder (full-bleed panel + floating summary card) — no mapping package added this phase, confirmed with the project owner rather than pulled in silently.
- **List tab**: ranks aerodromes by **visits** (flights whose route touched them), not landings — a flight's landing count is a per-flight total, not broken down by which leg of a multi-stop route it happened on, so there's no raw fact attributing a landing to one aerodrome over another on a route with more than two stops. Column is labelled "Visits", not "LDG".
- New `PilotProfile.homeBaseIcao` (nullable), schema v5→v6, same pattern as `primaryJurisdictionId` — needed for the "furthest aerodrome" figure. Sample data sets it to `EGKA`.
- New domain module `lib/domain/aerodromes/aerodrome_summary.dart` (ranking, furthest-aerodrome, new-this-year) — pure Dart, reuses `totals_summary.aerodromesVisited` for the summary-card counts.
- Reuses `sampleTotalsFlights` from the Totals phase rather than a new fixture.

## Test plan
- [x] `flutter test` — 620 tests pass, including 11 new `aerodrome_summary_test.dart` cases and a new v5→v6 migration test.
- [x] `dart run tool/check_domain_coverage.dart` — 95.8% on `lib/domain/` (threshold 90%).
- [x] `flutter analyze --fatal-infos`, `check_layering`, `check_domain_types`, `check_currency_rules`, `check_schema_snapshot` (v6) all clean.
- [x] On-device verification (Android emulator, light + dark): Map tab, List tab, and both entry points from Totals (Map pill, Ops "Aerodromes visited" row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)