### PR TITLE
Settings screen: real theme/time-display preferences (#62)

### DIFF
--- a/lib/domain/currency/rule_set_summary.dart
+++ b/lib/domain/currency/rule_set_summary.dart
@@ -1,0 +1,55 @@
+import 'currency_rule.dart';
+
+/// Which rules are actually loaded, grouped for the Settings "About" section
+/// — pure aggregation over already-loaded [CurrencyRule]s, no evaluation.
+class RuleSetSummary {
+  const RuleSetSummary({
+    required this.total,
+    required this.byJurisdiction,
+    required this.medicalCount,
+  });
+
+  final int total;
+
+  /// Rule count keyed by [CurrencyRule.jurisdictionId].
+  final Map<String, int> byJurisdiction;
+
+  /// How many rules are medical-certificate-validity rules — a rule counts
+  /// if any [Requirement] in its tree names a `medical_certificate.*` held
+  /// record kind. Cuts across jurisdiction rather than being a third
+  /// category alongside it: a medical rule is still counted in its own
+  /// jurisdiction's total too.
+  final int medicalCount;
+}
+
+/// Groups [rules] by jurisdiction and counts how many are medical-validity
+/// rules. Every rule known to the engine has a [CurrencyRule.jurisdictionId]
+/// — medicals are evaluated by the same generic rule engine as any other
+/// currency rule, not a separate mechanism (see
+/// `assets/rules/easa/med_a045_class1_validity.yaml`).
+RuleSetSummary summarizeRuleSet(List<CurrencyRule> rules) {
+  final byJurisdiction = <String, int>{};
+  var medicalCount = 0;
+  for (final rule in rules) {
+    byJurisdiction[rule.jurisdictionId] =
+        (byJurisdiction[rule.jurisdictionId] ?? 0) + 1;
+    if (_isMedical(rule.requirement)) {
+      medicalCount++;
+    }
+  }
+  return RuleSetSummary(
+    total: rules.length,
+    byJurisdiction: byJurisdiction,
+    medicalCount: medicalCount,
+  );
+}
+
+/// Walks a [Requirement] tree (through `allOf`/`anyOf`'s [Requirement.of])
+/// looking for a `held_record_currently_valid` leaf naming a
+/// `medical_certificate.*` kind.
+bool _isMedical(Requirement requirement) {
+  if (requirement.heldRecordKind?.startsWith('medical_certificate.') ?? false) {
+    return true;
+  }
+  return requirement.of.any(_isMedical);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'ui/preferences/app_preferences.dart';
 import 'ui/shell/app_shell.dart';
 import 'ui/theme/app_theme.dart';
 
-void main() {
-  runApp(const ProviderScope(child: MainApp()));
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  runApp(
+    ProviderScope(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      child: const MainApp(),
+    ),
+  );
 }
 
-class MainApp extends StatelessWidget {
+class MainApp extends ConsumerWidget {
   const MainApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp(
       title: 'Logbook',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
-      themeMode: ThemeMode.system,
+      themeMode: ref.watch(themeModeProvider),
       home: const AppShell(),
     );
   }

--- a/lib/ui/currency/currency_screen.dart
+++ b/lib/ui/currency/currency_screen.dart
@@ -8,32 +8,10 @@ import '../../domain/model/utc_instant.dart';
 import '../../domain/repository/flight_read_repository.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
+import 'rule_asset_paths.dart';
 import 'sample_currency_data.dart';
 import 'widgets/currency_hero_card.dart';
 import 'widgets/currency_rule_row.dart';
-
-/// Every rule file the Currency screen loads at start-up — see
-/// `assets/rules/README.md`. Loading the full set rather than only the ids
-/// [sampleCurrencyLicences] happens to reference keeps this list from
-/// needing to track the sample fixture's own choices, which are themselves
-/// a stand-in for a real per-licence rule resolver (see that file's
-/// dartdoc).
-const _ruleAssetPaths = [
-  'assets/rules/easa/fcl060_b1_passenger_recency.yaml',
-  'assets/rules/easa/fcl060_b3_night_passenger_recency.yaml',
-  'assets/rules/easa/fcl740a_sep_land_revalidation.yaml',
-  'assets/rules/easa/med_a045_class1_validity.yaml',
-  'assets/rules/easa/med_a045_class2_validity.yaml',
-  'assets/rules/faa/61_23_first_class_medical_validity.yaml',
-  'assets/rules/faa/61_23_second_class_medical_validity.yaml',
-  'assets/rules/faa/61_23_third_class_medical_validity.yaml',
-  'assets/rules/faa/61_56_flight_review.yaml',
-  'assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml',
-  'assets/rules/faa/61_57_a_takeoff_landing_currency.yaml',
-  'assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml',
-  'assets/rules/faa/61_57_c_instrument_currency.yaml',
-  'assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml',
-];
 
 /// #62: the currency dashboard — every held licence, grouped, with a reason
 /// for each pill. Runs the real `CurrencyRuleEvaluator`/`CurrencyRuleLoader`
@@ -66,7 +44,7 @@ class _CurrencyScreenState extends State<CurrencyScreen> {
     // `rootBundle`'s process-wide cache otherwise returns a permanently-
     // pending `Future` to a later widget-test run that reopens this screen.
     final yamlContents = await Future.wait([
-      for (final path in _ruleAssetPaths)
+      for (final path in ruleAssetPaths)
         rootBundle.loadString(path, cache: false),
     ]);
     final loader = CurrencyRuleLoader.fromYaml(yamlContents);

--- a/lib/ui/currency/rule_asset_paths.dart
+++ b/lib/ui/currency/rule_asset_paths.dart
@@ -1,0 +1,22 @@
+/// Every rule file the app loads at start-up — see `assets/rules/README.md`.
+/// Shared by the Currency and Settings screens: Currency loads the full set
+/// rather than only the ids `sampleCurrencyLicences` happens to reference
+/// (keeps this list from needing to track the sample fixture's own
+/// choices); Settings' "Rule set in use" figure needs the same complete set
+/// to summarize.
+const ruleAssetPaths = [
+  'assets/rules/easa/fcl060_b1_passenger_recency.yaml',
+  'assets/rules/easa/fcl060_b3_night_passenger_recency.yaml',
+  'assets/rules/easa/fcl740a_sep_land_revalidation.yaml',
+  'assets/rules/easa/med_a045_class1_validity.yaml',
+  'assets/rules/easa/med_a045_class2_validity.yaml',
+  'assets/rules/faa/61_23_first_class_medical_validity.yaml',
+  'assets/rules/faa/61_23_second_class_medical_validity.yaml',
+  'assets/rules/faa/61_23_third_class_medical_validity.yaml',
+  'assets/rules/faa/61_56_flight_review.yaml',
+  'assets/rules/faa/61_57_a2_tailwheel_takeoff_landing_currency.yaml',
+  'assets/rules/faa/61_57_a_takeoff_landing_currency.yaml',
+  'assets/rules/faa/61_57_b_night_takeoff_landing_currency.yaml',
+  'assets/rules/faa/61_57_c_instrument_currency.yaml',
+  'assets/rules/faa/61_57_c_instrument_currency_grace_period.yaml',
+];

--- a/lib/ui/preferences/app_preferences.dart
+++ b/lib/ui/preferences/app_preferences.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The app's first real Riverpod state (`ProviderScope` has wrapped
+/// `main.dart` since M0, but nothing used it until Settings). Overridden in
+/// `main()` with the real instance from `SharedPreferences.getInstance()`
+/// before `runApp` — reading this before that override is a programming
+/// error, not a recoverable one.
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw UnimplementedError(
+    'sharedPreferencesProvider must be overridden in main() before runApp',
+  );
+});
+
+const _themeModeKey = 'settings.theme_mode';
+
+ThemeMode _decodeThemeMode(String? value) => switch (value) {
+  'light' => ThemeMode.light,
+  'dark' => ThemeMode.dark,
+  _ => ThemeMode.system,
+};
+
+String _encodeThemeMode(ThemeMode mode) => switch (mode) {
+  ThemeMode.light => 'light',
+  ThemeMode.dark => 'dark',
+  ThemeMode.system => 'system',
+};
+
+/// The app's theme override — Light/Dark/System, persisted via
+/// `shared_preferences`. `ThemeMode.system` (follow the device) is the
+/// default for a pilot who has never opened Settings.
+class ThemeModeNotifier extends Notifier<ThemeMode> {
+  @override
+  ThemeMode build() => _decodeThemeMode(
+    ref.watch(sharedPreferencesProvider).getString(_themeModeKey),
+  );
+
+  void set(ThemeMode mode) {
+    state = mode;
+    ref
+        .read(sharedPreferencesProvider)
+        .setString(_themeModeKey, _encodeThemeMode(mode));
+  }
+}
+
+final themeModeProvider = NotifierProvider<ThemeModeNotifier, ThemeMode>(
+  ThemeModeNotifier.new,
+);
+
+/// Whether the Settings clock-sample row shows the device's local time
+/// alongside Zulu, or Zulu only. Doesn't yet drive any rendering outside
+/// Settings itself — no other screen in the app currently displays a flight
+/// time in anything but UTC (CLAUDE.md rule 3), so there is nowhere else for
+/// this preference to apply yet.
+enum TimeDisplayPreference { localWithUtc, utcOnly }
+
+const _timeDisplayKey = 'settings.time_display';
+
+TimeDisplayPreference _decodeTimeDisplay(String? value) => value == 'utcOnly'
+    ? TimeDisplayPreference.utcOnly
+    : TimeDisplayPreference.localWithUtc;
+
+String _encodeTimeDisplay(TimeDisplayPreference preference) =>
+    switch (preference) {
+      TimeDisplayPreference.utcOnly => 'utcOnly',
+      TimeDisplayPreference.localWithUtc => 'localWithUtc',
+    };
+
+class TimeDisplayNotifier extends Notifier<TimeDisplayPreference> {
+  @override
+  TimeDisplayPreference build() => _decodeTimeDisplay(
+    ref.watch(sharedPreferencesProvider).getString(_timeDisplayKey),
+  );
+
+  void set(TimeDisplayPreference preference) {
+    state = preference;
+    ref
+        .read(sharedPreferencesProvider)
+        .setString(_timeDisplayKey, _encodeTimeDisplay(preference));
+  }
+}
+
+final timeDisplayProvider =
+    NotifierProvider<TimeDisplayNotifier, TimeDisplayPreference>(
+      TimeDisplayNotifier.new,
+    );

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -1,29 +1,560 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
-import '../widgets/large_title_scaffold.dart';
+import '../../domain/currency/currency_dashboard.dart';
+import '../../domain/currency/currency_rule_loader.dart';
+import '../../domain/currency/rule_set_summary.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/totals/totals_summary.dart';
+import '../currency/rule_asset_paths.dart';
+import '../currency/sample_currency_data.dart';
+import '../preferences/app_preferences.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
+import '../totals/sample_totals_data.dart';
 
-/// Placeholder for the Settings tab. Aircraft management (#61) and crew
-/// records live here as sections rather than as their own tab — decided
-/// 2026-08-10 to keep the phone nav to four destinations. Licence/profile
-/// settings (the mockups' "Onboarding · licences" screen) belong here too.
-class SettingsScreen extends StatelessWidget {
+const _jurisdictionLabels = {
+  'eu.easa.part-fcl': 'EASA Part-FCL',
+  'us.faa.part61': 'FAA Part 61',
+};
+
+/// A plain UI-only sample string — `PilotProfile` has no name field, and
+/// adding one wasn't part of this phase's approved scope (see the redesign
+/// plan). Purely decorative header text, not backed by any persisted or
+/// domain-derived value.
+const _pilotDisplayName = 'A. Whitmore';
+
+/// Settings screen (#62/Phase 4 of the redesign) — replaces the M0
+/// placeholder. The one screen in this redesign that touches real app-wide
+/// state: Theme and Time-display are genuinely persisted via
+/// `shared_preferences` (see `app_preferences.dart`) rather than sample data,
+/// since a preference is itself the thing being modelled, not a stand-in for
+/// a future repository. Licences, aircraft/aerodrome counts and the rule-set
+/// summary still run against the shared sample fixtures every other screen
+/// in this redesign uses, pending #56.
+class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
 
   @override
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  RuleSetSummary? _ruleSetSummary;
+  PackageInfo? _packageInfo;
+  int? _aircraftCount;
+  int? _aerodromeCount;
+  late final CalendarDate _today;
+
+  @override
+  void initState() {
+    super.initState();
+    _today = CalendarDate.fromUtcInstant(
+      UtcInstant.fromDateTime(DateTime.now().toUtc()),
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    // `cache: false` — see `NewFlightScreen._loadJurisdictions`'s own note.
+    final results = await Future.wait([
+      for (final path in ruleAssetPaths)
+        rootBundle.loadString(path, cache: false),
+    ]);
+    final loader = CurrencyRuleLoader.fromYaml(results);
+    final ruleSetSummary = summarizeRuleSet(loader.allInForce(_today));
+    final packageInfo = await PackageInfo.fromPlatform();
+    final flights = sampleTotalsFlights(_today);
+    final aircraftCount = distinctAircraftFlown(flights);
+    // A bare unique-ICAO count, not `totals_summary.aerodromesVisited` --
+    // that also resolves country via the full ~85,000-row OurAirports CSV,
+    // which this row's plain count doesn't need to load just for a number.
+    final aerodromeCount = <String>{
+      for (final record in flights) ...record.flight.route,
+    }.length;
+    if (!mounted) return;
+    setState(() {
+      _ruleSetSummary = ruleSetSummary;
+      _packageInfo = packageInfo;
+      _aircraftCount = aircraftCount;
+      _aerodromeCount = aerodromeCount;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return LargeTitleScaffold(
-      title: 'Settings',
-      slivers: [
-        SliverFillRemaining(
-          hasScrollBody: false,
-          child: EmptyStateMessage(
-            icon: Icons.settings_outlined,
-            headline: 'Settings land next',
-            caption:
-                'Aircraft, crew, held licences and app preferences will live here.',
+    final ruleSetSummary = _ruleSetSummary;
+    final packageInfo = _packageInfo;
+    final aircraftCount = _aircraftCount;
+    final aerodromeCount = _aerodromeCount;
+    if (ruleSetSummary == null ||
+        packageInfo == null ||
+        aircraftCount == null ||
+        aerodromeCount == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          const SliverSafeArea(
+            bottom: false,
+            sliver: SliverToBoxAdapter(child: _Header()),
           ),
+          SliverToBoxAdapter(
+            child: Column(
+              children: [
+                const _SectionHeader('LICENCES & AUTHORITIES'),
+                for (final licence in sampleCurrencyLicences) ...[
+                  const _Divider(),
+                  _LicenceRow(licence: licence),
+                ],
+                const _Divider(),
+                const _AddLicenceRow(),
+                const _SectionHeader('DISPLAY'),
+                const _Divider(),
+                const _ThemeRow(),
+                const _Divider(),
+                const _TimeDisplayRow(),
+                const _Divider(),
+                const _DateFormatRow(),
+                const _SectionHeader('DATA'),
+                const _Divider(),
+                _InertRow(
+                  title: 'Aircraft & aerodromes',
+                  subtitle:
+                      '$aircraftCount aircraft · $aerodromeCount aerodromes',
+                ),
+                const _Divider(),
+                const _InertRow(
+                  title: 'Import',
+                  subtitle:
+                      'ForeFlight or Garmin CSV · preview before applying',
+                ),
+                const _Divider(),
+                // `exportDatabaseBackup`/`isBackupOverdue`
+                // (lib/data/database_backup.dart) are real and tested, but
+                // no screen has ever opened a live `AppDatabase` (#56) --
+                // every screen in the app, this one included, runs on
+                // sample data. Wiring "Back up now" today would either back
+                // up an empty database or require building the app's first
+                // live DB connection as a side effect of a Settings screen;
+                // both are out of scope here.
+                const _InertRow(
+                  title: 'Backup & encryption',
+                  subtitle: 'Available once live data exists (#56)',
+                ),
+                const _Divider(),
+                // `flight_history.dart`'s replay logic exists; no query
+                // layer or viewer UI has been built to call it from yet.
+                const _InertRow(
+                  title: 'Revision history',
+                  subtitle: 'No viewer yet',
+                ),
+                const _SectionHeader('ABOUT'),
+                const _Divider(),
+                _InertRow(
+                  title: 'Rule set in use',
+                  subtitle:
+                      '${ruleSetSummary.total} rules · '
+                      'EASA ${ruleSetSummary.byJurisdiction['eu.easa.part-fcl'] ?? 0} · '
+                      'FAA ${ruleSetSummary.byJurisdiction['us.faa.part61'] ?? 0} · '
+                      'medicals ${ruleSetSummary.medicalCount}',
+                ),
+                const _Divider(),
+                _InertRow(
+                  title: 'Version',
+                  subtitle:
+                      '${packageInfo.version} (${packageInfo.buildNumber})',
+                ),
+                const _Divider(),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Settings',
+            style: theme.textTheme.displaySmall?.copyWith(fontSize: 27),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _pilotDisplayName,
+            style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ink = context.inkTiers;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 14, 20, 6),
+      color: Theme.of(context).colorScheme.surfaceContainerLowest,
+      child: Text(
+        label,
+        style: AppMonoText.tag(ink.muted).copyWith(letterSpacing: 1.1),
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider();
+
+  @override
+  Widget build(BuildContext context) =>
+      Divider(height: 1, color: Theme.of(context).colorScheme.outlineVariant);
+}
+
+/// A plain label/subtitle row with no interaction — for status information
+/// that has nowhere to navigate to yet (Import, Backup, Revision history,
+/// Rule set, Version). Deliberately not wrapped in an `InkWell`: a tappable
+/// row implies a destination, and showing one where nothing happens is a
+/// worse signal than a plain info row.
+class _InertRow extends StatelessWidget {
+  const _InertRow({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    // `SizedBox(width: double.infinity)` -- a bare `Column` has no width
+    // opinion of its own and shrink-wraps to its widest child, so without
+    // this the whole row centres in its parent `Column` instead of sitting
+    // flush left (regression: every _InertRow rendered centred on-device).
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: theme.textTheme.titleSmall),
+            const SizedBox(height: 2),
+            Text(
+              subtitle,
+              style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+            ),
+          ],
         ),
-      ],
+      ),
+    );
+  }
+}
+
+class _LicenceRow extends StatelessWidget {
+  const _LicenceRow({required this.licence});
+
+  final CurrencyLicenceSpec licence;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final scheme = theme.colorScheme;
+    final label =
+        _jurisdictionLabels[licence.jurisdictionId] ?? licence.jurisdictionId;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(
+                  licence.privilegeSummary,
+                  style: theme.textTheme.labelSmall?.copyWith(color: ink.muted),
+                ),
+              ],
+            ),
+          ),
+          if (licence.isPrimary)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: scheme.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                'PRIMARY',
+                style: AppMonoText.tag(
+                  context.semanticColors.overriddenText,
+                ).copyWith(letterSpacing: 0.7),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A real multi-licence model (issuing authority, primary flag, an add-flow)
+/// is a separate, larger feature than this screen — deferred rather than
+/// shoehorned in. Same no-op convention as Currency's "Edit" pending a
+/// licence editor.
+class _AddLicenceRow extends StatelessWidget {
+  const _AddLicenceRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return InkWell(
+      onTap: () {},
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+        child: Row(
+          children: [
+            Icon(Icons.add, size: 18, color: scheme.primary),
+            const SizedBox(width: 8),
+            Text(
+              'Add a licence',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: scheme.primary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A pill switch generic over any small enum-like value — the same visual
+/// pattern as Totals' `_GranularitySwitch`/Aerodromes' `_AeroTabSwitch`,
+/// generalised here since this screen uses it twice (Theme, Time display).
+class _PillSwitch<T> extends StatelessWidget {
+  const _PillSwitch({
+    required this.value,
+    required this.options,
+    required this.onChanged,
+  });
+
+  final T value;
+  final Map<T, String> options;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final entry in options.entries)
+            InkWell(
+              onTap: () => onChanged(entry.key),
+              borderRadius: BorderRadius.circular(6),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: entry.key == value ? scheme.surface : null,
+                  borderRadius: BorderRadius.circular(6),
+                  boxShadow: entry.key == value
+                      ? [
+                          BoxShadow(
+                            color: scheme.onSurface.withValues(alpha: 0.14),
+                            blurRadius: 3,
+                            offset: const Offset(0, 1),
+                          ),
+                        ]
+                      : null,
+                ),
+                child: Text(
+                  entry.value,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: scheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThemeRow extends ConsumerWidget {
+  const _ThemeRow();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final mode = ref.watch(themeModeProvider);
+    final note = switch (mode) {
+      ThemeMode.system =>
+        'Following the device — twilight palette after sunset if it uses one.',
+      ThemeMode.dark => 'Always dark, whatever the device is set to.',
+      ThemeMode.light => 'Always light, whatever the device is set to.',
+    };
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('Theme', style: theme.textTheme.titleSmall),
+              _PillSwitch<ThemeMode>(
+                value: mode,
+                options: const {
+                  ThemeMode.light: 'Light',
+                  ThemeMode.dark: 'Dark',
+                  ThemeMode.system: 'System',
+                },
+                onChanged: (m) => ref.read(themeModeProvider.notifier).set(m),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            note,
+            style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimeDisplayRow extends ConsumerWidget {
+  const _TimeDisplayRow();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final preference = ref.watch(timeDisplayProvider);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('Time display', style: theme.textTheme.titleSmall),
+              _PillSwitch<TimeDisplayPreference>(
+                value: preference,
+                options: const {
+                  TimeDisplayPreference.localWithUtc: 'Local, UTC echo',
+                  TimeDisplayPreference.utcOnly: 'UTC only',
+                },
+                onChanged: (p) => ref.read(timeDisplayProvider.notifier).set(p),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'stored in UTC either way',
+            style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _clockSample(preference),
+            style: AppMonoText.value(theme.colorScheme.onSurface, size: 13),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Previews the *device's own current* offset via plain `DateTime`
+  /// (`.timeZoneName`/`.timeZoneOffset` need no timezone database for "right
+  /// now") — never a stored flight instant resolved against a named zone,
+  /// which is the historical-lookup case CLAUDE.md reserves for M4.
+  String _clockSample(TimeDisplayPreference preference) {
+    final now = DateTime.now();
+    final utc = now.toUtc();
+    final utcLabel =
+        '${utc.hour.toString().padLeft(2, '0')}'
+        '${utc.minute.toString().padLeft(2, '0')}Z';
+    if (preference == TimeDisplayPreference.utcOnly) {
+      return utcLabel;
+    }
+    final localLabel =
+        '${now.hour.toString().padLeft(2, '0')}:'
+        '${now.minute.toString().padLeft(2, '0')} ${now.timeZoneName}';
+    return '$localLabel · $utcLabel';
+  }
+}
+
+/// Not a switchable preference — the app only ever renders one date
+/// convention anywhere (`docs/entry-form.md`'s date field:
+/// `'${date.day} ${month} ${date.year}'`, e.g. "17 Aug 2026"). A picker with
+/// a single non-greyed option would be fabricated UI, not a real
+/// preference, so this is real, current, informational text instead.
+class _DateFormatRow extends StatelessWidget {
+  const _DateFormatRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text('Date format', style: theme.textTheme.titleSmall),
+          Text(
+            'D MMM YYYY',
+            style: AppMonoText.value(theme.colorScheme.onSurface, size: 13),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import package_info_plus
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -280,6 +288,11 @@ packages:
     version: "3.4.2"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -491,6 +504,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.2.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   path:
     dependency: "direct dev"
     description:
@@ -499,6 +528,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -563,6 +632,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.27"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -816,6 +941,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: "direct main"
     description:
@@ -826,4 +967,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.27.4"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
   flutter_riverpod: ^3.4.2
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
+  package_info_plus: ^10.2.1
+  shared_preferences: ^2.5.5
   sqlite3_flutter_libs: ^0.6.0+eol
   yaml: ^3.1.3
 

--- a/test/domain/currency/rule_set_summary_test.dart
+++ b/test/domain/currency/rule_set_summary_test.dart
@@ -1,0 +1,120 @@
+import 'package:easa_digital_log/domain/currency/currency_rule.dart';
+import 'package:easa_digital_log/domain/currency/rule_set_summary.dart';
+import 'package:easa_digital_log/domain/currency/rule_window.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+CurrencyRule _rule({
+  required String id,
+  required String jurisdictionId,
+  required Requirement requirement,
+}) => CurrencyRule(
+  id: id,
+  jurisdictionId: jurisdictionId,
+  citation: 'test citation',
+  title: 'Test rule',
+  effectiveFrom: const CalendarDate(2020, 1, 1),
+  requirement: requirement,
+);
+
+void main() {
+  group('summarizeRuleSet', () {
+    test('groups rules by jurisdiction and counts the total', () {
+      final rules = [
+        _rule(
+          id: 'a',
+          jurisdictionId: 'eu.easa.part-fcl',
+          requirement: Requirement.flightEventCount(
+            event: CountableFlightEvent.landings,
+            count: 3,
+            window: RuleWindow.rollingDays(90),
+          ),
+        ),
+        _rule(
+          id: 'b',
+          jurisdictionId: 'eu.easa.part-fcl',
+          requirement: Requirement.flightEventCount(
+            event: CountableFlightEvent.landings,
+            count: 3,
+            window: RuleWindow.rollingDays(90),
+          ),
+        ),
+        _rule(
+          id: 'c',
+          jurisdictionId: 'us.faa.part61',
+          requirement: Requirement.flightEventCount(
+            event: CountableFlightEvent.landings,
+            count: 3,
+            window: RuleWindow.rollingDays(90),
+          ),
+        ),
+      ];
+
+      final summary = summarizeRuleSet(rules);
+
+      expect(summary.total, 3);
+      expect(summary.byJurisdiction, {
+        'eu.easa.part-fcl': 2,
+        'us.faa.part61': 1,
+      });
+    });
+
+    test('counts a top-level held_record_currently_valid medical rule', () {
+      final rules = [
+        _rule(
+          id: 'med',
+          jurisdictionId: 'eu.easa.part-fcl',
+          requirement: Requirement.heldRecordCurrentlyValid(
+            'medical_certificate.easaClass1',
+          ),
+        ),
+      ];
+
+      expect(summarizeRuleSet(rules).medicalCount, 1);
+    });
+
+    test('counts a medical rule nested inside an allOf/anyOf composite', () {
+      final rules = [
+        _rule(
+          id: 'composite',
+          jurisdictionId: 'us.faa.part61',
+          requirement: Requirement.allOf([
+            Requirement.flightEventCount(
+              event: CountableFlightEvent.landings,
+              count: 3,
+              window: RuleWindow.rollingDays(90),
+            ),
+            Requirement.anyOf([
+              Requirement.heldRecordCurrentlyValid(
+                'medical_certificate.faaThirdClass',
+              ),
+            ]),
+          ]),
+        ),
+      ];
+
+      expect(summarizeRuleSet(rules).medicalCount, 1);
+    });
+
+    test('does not count a non-medical held-record requirement', () {
+      final rules = [
+        _rule(
+          id: 'rating',
+          jurisdictionId: 'eu.easa.part-fcl',
+          requirement: Requirement.heldRecordCurrentlyValid(
+            'held_rating.instrumentRating',
+          ),
+        ),
+      ];
+
+      expect(summarizeRuleSet(rules).medicalCount, 0);
+    });
+
+    test('an empty rule list summarizes to all zeros', () {
+      final summary = summarizeRuleSet(const []);
+      expect(summary.total, 0);
+      expect(summary.byJurisdiction, isEmpty);
+      expect(summary.medicalCount, 0);
+    });
+  });
+}

--- a/test/ui/preferences/app_preferences_test.dart
+++ b/test/ui/preferences/app_preferences_test.dart
@@ -1,0 +1,84 @@
+import 'package:easa_digital_log/ui/preferences/app_preferences.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<ProviderContainer> _container({
+  Map<String, Object> initial = const {},
+}) async {
+  SharedPreferences.setMockInitialValues(initial);
+  final prefs = await SharedPreferences.getInstance();
+  final container = ProviderContainer(
+    overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('themeModeProvider', () {
+    test('defaults to system when nothing has been saved', () async {
+      final container = await _container();
+      expect(container.read(themeModeProvider), ThemeMode.system);
+    });
+
+    test('reads back a previously saved value', () async {
+      final container = await _container(
+        initial: {'settings.theme_mode': 'dark'},
+      );
+      expect(container.read(themeModeProvider), ThemeMode.dark);
+    });
+
+    test(
+      'set() updates state and persists through SharedPreferences',
+      () async {
+        final container = await _container();
+
+        container.read(themeModeProvider.notifier).set(ThemeMode.light);
+
+        expect(container.read(themeModeProvider), ThemeMode.light);
+        final prefs = container.read(sharedPreferencesProvider);
+        expect(prefs.getString('settings.theme_mode'), 'light');
+      },
+    );
+  });
+
+  group('timeDisplayProvider', () {
+    test('defaults to localWithUtc when nothing has been saved', () async {
+      final container = await _container();
+      expect(
+        container.read(timeDisplayProvider),
+        TimeDisplayPreference.localWithUtc,
+      );
+    });
+
+    test('reads back a previously saved value', () async {
+      final container = await _container(
+        initial: {'settings.time_display': 'utcOnly'},
+      );
+      expect(
+        container.read(timeDisplayProvider),
+        TimeDisplayPreference.utcOnly,
+      );
+    });
+
+    test(
+      'set() updates state and persists through SharedPreferences',
+      () async {
+        final container = await _container();
+
+        container
+            .read(timeDisplayProvider.notifier)
+            .set(TimeDisplayPreference.utcOnly);
+
+        expect(
+          container.read(timeDisplayProvider),
+          TimeDisplayPreference.utcOnly,
+        );
+        final prefs = container.read(sharedPreferencesProvider);
+        expect(prefs.getString('settings.time_display'), 'utcOnly');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Settings screen (Phase 4, last of the Currency/Totals/Aerodromes/Settings redesign), replacing the M0 "Settings land next" placeholder.
- **Theme and Time-display are genuinely persisted**, not stubbed — `shared_preferences` (pre-approved in the Currency phase) backs the app's first real Riverpod state, wired through `main.dart`'s `MaterialApp.themeMode`. Verified on-device: Light/Dark/System actually overrides the rendered theme independent of the device's own OS setting, and the choice survives a full app restart.
- **Licences & Authorities is read-only**, reusing Currency's existing `sampleCurrencyLicences` fixture rather than inventing a real multi-licence data model — that's a separate, larger feature (new domain type + drift table + migration + add-flow) deferred to its own future phase. "Add a licence" is a no-op stub.
- **Backup & encryption is stubbed, not wired**, for a documented reason: no screen in the app has ever opened a live `AppDatabase` (`main.dart` never calls `openAppDatabase` — everything runs on sample data pending #56). `exportDatabaseBackup`/`isBackupOverdue` (`lib/data/database_backup.dart`) are real and tested; wiring a "Back up now" button today would either back up an empty database or require building the app's first live DB connection as a side effect of a Settings screen.
- New `package_info_plus` dependency for the real app version/build number.
- New domain aggregation `lib/domain/currency/rule_set_summary.dart` for the "Rule set in use" figure — real counts (14 rules · EASA 5 · FAA 9 · medicals 5), deliberately differing from the mockup's own inconsistent illustrative numbers (5+9=14≠16 in the mockup itself).
- Promoted Currency's private rule-asset-path list to a shared `lib/ui/currency/rule_asset_paths.dart` now that Settings needs the same set.

## Test plan
- [x] `flutter test` — 625 tests pass, including 5 new `rule_set_summary_test.dart` cases and 6 new preferences-notifier tests.
- [x] `dart run tool/check_domain_coverage.dart` — 95.8% on `lib/domain/` (threshold 90%).
- [x] `flutter analyze --fatal-infos`, `check_layering`, `check_domain_types`, `check_currency_rules`, `check_schema_snapshot` all clean.
- [x] On-device (Android emulator, light + dark): confirmed Theme actually overrides rendered theme regardless of OS setting, confirmed persistence across a full app kill/relaunch, confirmed both Time-display options render correctly, confirmed Aircraft/aerodromes counts (4/6) and Rule-set counts (14/5/9/5) are correct. Caught and fixed a real layout bug during verification (`_InertRow` rendering centred instead of flush-left due to `Column`'s shrink-wrap behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)