### PR TITLE
Jurisdiction dropdown for Currency/Totals + easy tracker fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,15 @@ showing a red or green pill. "Not current" with no explanation is a bug.
 
 ## Multi-jurisdiction UX
 
-- Totals, flight entry and dashboard render in the **primary** jurisdiction only.
+- Totals defaults to the **primary** jurisdiction, with an explicit dropdown to view the same
+  figures under any other held licence instead. The dropdown always shows the jurisdiction
+  currently in view, so a switch is a visible, chosen state — never a global toggle that silently
+  changes what the numbers mean.
+- Flight entry and the dashboard still render primary-only.
 - A flight whose derived values differ under a secondary licence gets a badge opening a
-  side-by-side comparison. Do not render both columns everywhere; do not use a global toggle
-  that silently changes what the numbers mean.
-- Currency is the exception: show all held licences grouped, always.
+  side-by-side comparison. Do not render both columns everywhere.
+- Currency shows all held licences grouped by default, with an optional jurisdiction filter (also
+  a visible dropdown, not a silent default) to narrow the view to one authority.
 - Export asks which jurisdiction explicitly. Never infer it.
 - Adding a licence triggers a recompute plus a **"N past flights need more information" queue**.
   Never guess a missing discriminator, never silently default it.

--- a/lib/domain/aerodromes/aerodrome_summary.dart
+++ b/lib/domain/aerodromes/aerodrome_summary.dart
@@ -114,3 +114,29 @@ int newAerodromesThisYear(List<FlightRecord> flights, CalendarDate asOf) {
   }
   return firstVisitYear.values.where((year) => year == asOf.year).length;
 }
+
+/// Total great-circle distance flown, summing every flight's route
+/// leg-by-leg rather than a single point-to-point figure — a multi-stop
+/// flight's real distance is the sum of each leg, the same principle
+/// `cross_country_support.dart`'s route-distance summation already uses for
+/// the cross-country primitives. A leg whose aerodrome doesn't resolve in
+/// [directory] is skipped rather than guessed, so this is always an honest
+/// lower bound, never a fabricated total.
+double totalDistanceFlownNm(
+  List<FlightRecord> flights,
+  AerodromeDirectory directory,
+) {
+  var total = 0.0;
+  for (final record in flights) {
+    final route = record.flight.route;
+    for (var i = 1; i < route.length; i++) {
+      final from = directory.byIcao(route[i - 1]);
+      final to = directory.byIcao(route[i]);
+      if (from == null || to == null) {
+        continue;
+      }
+      total += greatCircleDistanceNm(from.position, to.position);
+    }
+  }
+  return total;
+}

--- a/lib/ui/aerodromes/aerodromes_screen.dart
+++ b/lib/ui/aerodromes/aerodromes_screen.dart
@@ -249,6 +249,7 @@ class _MapTab extends StatelessWidget {
     final furthest = homeBaseIcao == null
         ? null
         : furthestAerodrome(flights, aerodromes, homeBaseIcao!);
+    final totalDistanceNm = totalDistanceFlownNm(flights, aerodromes);
 
     return Stack(
       children: [
@@ -432,6 +433,25 @@ class _MapTab extends StatelessWidget {
                               ),
                             ),
                           ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text.rich(
+                  TextSpan(
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                    children: [
+                      const TextSpan(text: 'Total distance flown '),
+                      TextSpan(
+                        text: '${totalDistanceNm.round()} nm',
+                        style: AppMonoText.value(
+                          theme.colorScheme.onSurface,
+                          size: 11.5,
+                          weight: FontWeight.w500,
                         ),
                       ),
                     ],

--- a/lib/ui/currency/currency_screen.dart
+++ b/lib/ui/currency/currency_screen.dart
@@ -8,10 +8,17 @@ import '../../domain/model/utc_instant.dart';
 import '../../domain/repository/flight_read_repository.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
+import '../widgets/jurisdiction_dropdown.dart';
+import '../widgets/large_title_scaffold.dart';
 import 'rule_asset_paths.dart';
 import 'sample_currency_data.dart';
 import 'widgets/currency_hero_card.dart';
 import 'widgets/currency_rule_row.dart';
+
+const _jurisdictionLabels = {
+  'eu.easa.part-fcl': 'EASA Part-FCL',
+  'us.faa.part61': 'FAA Part 61',
+};
 
 /// #62: the currency dashboard — every held licence, grouped, with a reason
 /// for each pill. Runs the real `CurrencyRuleEvaluator`/`CurrencyRuleLoader`
@@ -29,6 +36,10 @@ class _CurrencyScreenState extends State<CurrencyScreen> {
   CurrencyDashboard? _dashboard;
   List<FlightRecord> _flights = const [];
   late final CalendarDate _today;
+
+  /// `null` means "Both" — the default, matching CLAUDE.md's "show all held
+  /// licences grouped by default."
+  String? _selectedJurisdictionId;
 
   @override
   void initState() {
@@ -83,7 +94,45 @@ class _CurrencyScreenState extends State<CurrencyScreen> {
     }
 
     final theme = Theme.of(context);
-    final heroRows = dashboard.atRiskRows;
+    final selected = _selectedJurisdictionId;
+    final visibleGroups = selected == null
+        ? dashboard.groups
+        : [
+            for (final group in dashboard.groups)
+              if (group.jurisdictionId == selected) group,
+          ];
+    final heroRows = [
+      for (final group in visibleGroups)
+        for (final row in group.rows)
+          if (row.isAtRisk) row,
+    ];
+
+    if (_flights.isEmpty) {
+      return Scaffold(
+        body: SafeArea(
+          bottom: false,
+          child: Column(
+            children: [
+              _Header(
+                asOf: _today,
+                groups: dashboard.groups,
+                selectedJurisdictionId: selected,
+                onJurisdictionChanged: (id) =>
+                    setState(() => _selectedJurisdictionId = id),
+              ),
+              const Expanded(
+                child: EmptyStateMessage(
+                  icon: Icons.verified_outlined,
+                  headline: 'No flights logged yet',
+                  caption:
+                      'Currency requirements will appear here once you log your first flight.',
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       body: CustomScrollView(
@@ -99,7 +148,13 @@ class _CurrencyScreenState extends State<CurrencyScreen> {
                 color: theme.colorScheme.surfaceContainerLowest,
                 child: Column(
                   children: [
-                    _Header(asOf: _today),
+                    _Header(
+                      asOf: _today,
+                      groups: dashboard.groups,
+                      selectedJurisdictionId: selected,
+                      onJurisdictionChanged: (id) =>
+                          setState(() => _selectedJurisdictionId = id),
+                    ),
                     if (heroRows.isNotEmpty) ...[
                       // A `ListView` needs a bounded cross-axis height from
                       // its parent — it can't ask a horizontally-scrolling
@@ -144,7 +199,7 @@ class _CurrencyScreenState extends State<CurrencyScreen> {
               ),
               child: Column(
                 children: [
-                  for (final group in dashboard.groups)
+                  for (final group in visibleGroups)
                     _LicenceGroupSection(
                       group: group,
                       asOf: _today,
@@ -203,9 +258,19 @@ class _HeroPageDots extends StatelessWidget {
 }
 
 class _Header extends StatelessWidget {
-  const _Header({required this.asOf});
+  const _Header({
+    required this.asOf,
+    required this.groups,
+    required this.selectedJurisdictionId,
+    required this.onJurisdictionChanged,
+  });
 
   final CalendarDate asOf;
+  final List<CurrencyLicenceGroup> groups;
+
+  /// `null` means "Both".
+  final String? selectedJurisdictionId;
+  final ValueChanged<String?> onJurisdictionChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -213,25 +278,51 @@ class _Header extends StatelessWidget {
     final ink = context.inkTiers;
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.baseline,
-        textBaseline: TextBaseline.alphabetic,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Currency',
-            style: theme.textTheme.displaySmall?.copyWith(fontSize: 27),
-          ),
-          Text.rich(
-            TextSpan(
-              children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Currency',
+                style: theme.textTheme.displaySmall?.copyWith(fontSize: 27),
+              ),
+              Text.rich(
                 TextSpan(
-                  text: 'as at ',
-                  style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+                  children: [
+                    TextSpan(
+                      text: 'as at ',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: ink.muted,
+                      ),
+                    ),
+                    TextSpan(
+                      text: '$asOf',
+                      style: AppMonoText.value(ink.medium),
+                    ),
+                  ],
                 ),
-                TextSpan(text: '$asOf', style: AppMonoText.value(ink.medium)),
-              ],
-            ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          JurisdictionDropdown<String?>(
+            value: selectedJurisdictionId,
+            label: selectedJurisdictionId == null
+                ? 'Both'
+                : (_jurisdictionLabels[selectedJurisdictionId] ??
+                      selectedJurisdictionId!),
+            options: {
+              null: 'Both',
+              for (final group in groups)
+                group.jurisdictionId:
+                    _jurisdictionLabels[group.jurisdictionId] ??
+                    group.jurisdictionId,
+            },
+            onChanged: onJurisdictionChanged,
           ),
         ],
       ),

--- a/lib/ui/totals/totals_screen.dart
+++ b/lib/ui/totals/totals_screen.dart
@@ -13,8 +13,10 @@ import '../../domain/projection/jurisdiction_projection.dart';
 import '../../domain/repository/flight_read_repository.dart';
 import '../../domain/totals/totals_summary.dart';
 import '../aerodromes/aerodromes_screen.dart';
+import '../currency/sample_currency_data.dart' show sampleCurrencyLicences;
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
+import '../widgets/jurisdiction_dropdown.dart';
 import 'sample_totals_data.dart';
 import 'widgets/totals_bar_chart.dart';
 import 'widgets/totals_row.dart';
@@ -27,14 +29,66 @@ const _jurisdictionLabels = {
   'us.faa.part61': 'FAA Part 61',
 };
 
-/// #85: totals and summary view — five sub-tabs over one flight set, all
-/// rendered under the pilot's **primary** jurisdiction only (CLAUDE.md's
-/// multi-jurisdiction UX rule). Total time of flight, aircraft hours and
-/// take-off/landing counts are jurisdiction-agnostic facts computed directly
-/// off `Flight`/`PilotCapacity`; PIC/dual/night/instrument/cross-country go
-/// through the existing `JurisdictionProjection` unchanged. Runs against
-/// `sample_totals_data.dart`'s fixture, the same convention Currency and the
-/// entry form already use pending #56's live repository wiring.
+/// Function-tab rows, per jurisdiction — EASA and FAA pilot function time
+/// are genuinely different regulatory concepts (`pic`/`picus`/`spic`/
+/// `copilot`/`dual`/`instructor` vs `actingPic`/`loggedPic`/`dualReceived`/
+/// `sic`), not aliases of each other, so this can't be one shared row list
+/// the way `_jurisdictionLabels` is. `easaPilotFunctionTime`/
+/// `faaPilotFunctionTime` (`lib/domain/primitives/`) are each other's only
+/// source of truth for their own key names.
+///
+/// FAA's own `solo` quantity is deliberately excluded — it's the same raw
+/// fact (`PilotCapacity.soleOccupant`) `soloTime()` already renders under
+/// "Other arrangements" below for every jurisdiction; repeating it here
+/// would double it up, not add information.
+const _functionRowsByJurisdiction = {
+  'eu.easa.part-fcl': [
+    ('pic', 'PIC'),
+    ('picus', 'PICUS'),
+    ('spic', 'SPIC'),
+    ('copilot', 'Co-pilot'),
+    ('dual', 'Dual'),
+    ('instructor', 'Instructor'),
+  ],
+  'us.faa.part61': [
+    ('actingPic', 'Acting PIC'),
+    ('loggedPic', 'Logged PIC'),
+    ('dualReceived', 'Dual received'),
+    ('sic', 'SIC'),
+  ],
+};
+
+/// Conditions-tab rows, per jurisdiction — EASA logs IFR as one column
+/// (`easa_instrument_time.dart`'s `ifr`); FAA has no such concept at all and
+/// splits actual/simulated instrument time instead
+/// (`faa_instrument_time.dart`). `crossCountry` and night both exist under
+/// both jurisdictions, but night's own key name still differs
+/// (`night` vs `nightFlightTime`).
+const _conditionRowsByJurisdiction = {
+  'eu.easa.part-fcl': [
+    ('night', 'Night'),
+    ('ifr', 'IFR'),
+    ('crossCountry', 'Cross-country'),
+  ],
+  'us.faa.part61': [
+    ('nightFlightTime', 'Night'),
+    ('actualInstrument', 'Actual instrument'),
+    ('simulatedInstrument', 'Simulated instrument'),
+    ('crossCountry', 'Cross-country'),
+  ],
+};
+
+/// #85: totals and summary view — five sub-tabs over one flight set,
+/// defaulting to the pilot's **primary** jurisdiction with an explicit,
+/// always-visible dropdown to view the same figures under any other held
+/// licence instead (CLAUDE.md's multi-jurisdiction UX rule — a switch, never
+/// a silent toggle). Total time of flight, aircraft hours and take-off/
+/// landing counts are jurisdiction-agnostic facts computed directly off
+/// `Flight`/`PilotCapacity`; PIC/dual/night/instrument/cross-country go
+/// through the existing `JurisdictionProjection`, one instance per held
+/// licence so switching jurisdictions is a lookup, not a reload. Runs
+/// against `sample_totals_data.dart`'s fixture, the same convention Currency
+/// and the entry form already use pending #56's live repository wiring.
 class TotalsScreen extends StatefulWidget {
   const TotalsScreen({super.key});
 
@@ -46,9 +100,15 @@ class _TotalsScreenState extends State<TotalsScreen> {
   int _tabIndex = 0;
   Granularity _granularity = Granularity.year;
 
+  /// Defaults to the pilot's primary licence — CLAUDE.md: Totals *defaults*
+  /// to primary, but an explicit, visible dropdown (never a silent toggle)
+  /// lets the pilot view the same figures under any other held licence.
+  late String _selectedJurisdictionId =
+      samplePilotProfile.primaryJurisdictionId;
+
   List<FlightRecord>? _flights;
   AerodromeDirectory? _aerodromes;
-  JurisdictionProjection? _projection;
+  Map<String, JurisdictionProjection>? _projections;
   late final CalendarDate _today;
 
   @override
@@ -78,18 +138,23 @@ class _TotalsScreenState extends State<TotalsScreen> {
       parseJurisdictionProfileYaml(results[1]),
     ]);
     final aerodromes = AerodromeDirectory.fromOurAirportsCsv(results[2]);
-    final projection = JurisdictionProjection(
-      registry: registry,
-      primitives: defaultPrimitives,
-      aerodromes: aerodromes,
-      jurisdictionId: samplePilotProfile.primaryJurisdictionId,
-    );
+    // One projection per held licence, not just the primary one, so
+    // switching the dropdown is a cheap lookup rather than a reload.
+    final projections = {
+      for (final licence in sampleCurrencyLicences)
+        licence.jurisdictionId: JurisdictionProjection(
+          registry: registry,
+          primitives: defaultPrimitives,
+          aerodromes: aerodromes,
+          jurisdictionId: licence.jurisdictionId,
+        ),
+    };
     final flights = sampleTotalsFlights(_today);
     if (!mounted) return;
     setState(() {
       _flights = flights;
       _aerodromes = aerodromes;
-      _projection = projection;
+      _projections = projections;
     });
   }
 
@@ -97,10 +162,11 @@ class _TotalsScreenState extends State<TotalsScreen> {
   Widget build(BuildContext context) {
     final flights = _flights;
     final aerodromes = _aerodromes;
-    final projection = _projection;
-    if (flights == null || aerodromes == null || projection == null) {
+    final projections = _projections;
+    if (flights == null || aerodromes == null || projections == null) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
+    final projection = projections[_selectedJurisdictionId]!;
 
     return Scaffold(
       body: CustomScrollView(
@@ -111,10 +177,9 @@ class _TotalsScreenState extends State<TotalsScreen> {
               child: Column(
                 children: [
                   _Header(
-                    jurisdictionLabel:
-                        _jurisdictionLabels[samplePilotProfile
-                            .primaryJurisdictionId] ??
-                        samplePilotProfile.primaryJurisdictionId,
+                    selectedJurisdictionId: _selectedJurisdictionId,
+                    onJurisdictionChanged: (id) =>
+                        setState(() => _selectedJurisdictionId = id),
                   ),
                   _MainTabs(
                     selected: _tabIndex,
@@ -146,14 +211,20 @@ class _TotalsScreenState extends State<TotalsScreen> {
 }
 
 class _Header extends StatelessWidget {
-  const _Header({required this.jurisdictionLabel});
+  const _Header({
+    required this.selectedJurisdictionId,
+    required this.onJurisdictionChanged,
+  });
 
-  final String jurisdictionLabel;
+  final String selectedJurisdictionId;
+  final ValueChanged<String> onJurisdictionChanged;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final ink = context.inkTiers;
+    final isPrimary =
+        selectedJurisdictionId == samplePilotProfile.primaryJurisdictionId;
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
       child: Column(
@@ -192,10 +263,32 @@ class _Header extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 4),
-          Text(
-            'Derived under $jurisdictionLabel — your primary licence',
-            style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+          const SizedBox(height: 8),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                'Derived under ',
+                style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+              ),
+              JurisdictionDropdown<String>(
+                value: selectedJurisdictionId,
+                label:
+                    _jurisdictionLabels[selectedJurisdictionId] ??
+                    selectedJurisdictionId,
+                options: {
+                  for (final licence in sampleCurrencyLicences)
+                    licence.jurisdictionId:
+                        _jurisdictionLabels[licence.jurisdictionId] ??
+                        licence.jurisdictionId,
+                },
+                onChanged: onJurisdictionChanged,
+              ),
+              Text(
+                isPrimary ? ' — primary licence' : ' — secondary licence',
+                style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+              ),
+            ],
           ),
         ],
       ),
@@ -551,16 +644,10 @@ class _FunctionTab extends StatelessWidget {
     final result = projection.projectAggregate([
       for (final record in flights) (record.flight, record.aircraft),
     ]);
-    const functionQuantityNames = [
-      'pic',
-      'picus',
-      'spic',
-      'copilot',
-      'dual',
-      'instructor',
-    ];
+    final rows =
+        _functionRowsByJurisdiction[projection.jurisdictionId] ?? const [];
     final total = FlightDuration.sum([
-      for (final name in functionQuantityNames)
+      for (final name in rows.map((r) => r.$1))
         if (result[name] case final quantity? when quantity.creditable)
           quantity.value,
     ]);
@@ -576,14 +663,7 @@ class _FunctionTab extends StatelessWidget {
           label: 'PILOT FUNCTION TIME',
           trailing: total.toHoursMinutes(),
         ),
-        for (final name in const [
-          ('pic', 'PIC'),
-          ('picus', 'PICUS'),
-          ('spic', 'SPIC'),
-          ('copilot', 'Co-pilot'),
-          ('dual', 'Dual'),
-          ('instructor', 'Instructor'),
-        ])
+        for (final name in rows)
           if (result[name.$1] != null) ...[
             const _TabDivider(),
             TotalsRow(label: name.$2, value: valueOf(name.$1)),
@@ -622,6 +702,8 @@ class _ConditionsTab extends StatelessWidget {
     final result = projection.projectAggregate([
       for (final record in flights) (record.flight, record.aircraft),
     ]);
+    final rows =
+        _conditionRowsByJurisdiction[projection.jurisdictionId] ?? const [];
 
     String valueOf(String name) =>
         (result[name]?.value ?? FlightDuration.zero).toHoursMinutes();
@@ -631,13 +713,7 @@ class _ConditionsTab extends StatelessWidget {
       children: [
         const _TabDivider(),
         const TotalsSectionHeader(label: 'OPERATIONAL CONDITION TIME'),
-        for (final name in const [
-          ('night', 'Night'),
-          ('ifr', 'IFR'),
-          ('actualInstrument', 'Actual instrument'),
-          ('simulatedInstrument', 'Simulated instrument'),
-          ('crossCountry', 'Cross-country'),
-        ])
+        for (final name in rows)
           if (result[name.$1] != null) ...[
             const _TabDivider(),
             TotalsRow(label: name.$2, value: valueOf(name.$1)),

--- a/lib/ui/widgets/jurisdiction_dropdown.dart
+++ b/lib/ui/widgets/jurisdiction_dropdown.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+/// A pill-styled dropdown for picking a jurisdiction — shared by Currency
+/// (an optional filter, `T = String?` where `null` means "Both") and Totals
+/// (`T = String`, always exactly one held licence, no "Both").
+///
+/// Always renders [label] as its own trigger text, so a selection is a
+/// visible, chosen state rather than a silent default — CLAUDE.md's
+/// Multi-jurisdiction UX section requires exactly this: "never a global
+/// toggle that silently changes what the numbers mean."
+///
+/// A dropdown, not the pill switches used elsewhere in this app (Totals'
+/// granularity switch, Aerodromes' Map/List, Settings' Theme/Time-display):
+/// those all pick from a small fixed set that will never grow, where a
+/// dropdown's extra tap would be friction for no reason. A jurisdiction list
+/// grows as licences are added (CLAUDE.md's jurisdiction registry is
+/// explicitly open-ended), so this needs to scale past two or three options
+/// without redesigning the control.
+class JurisdictionDropdown<T> extends StatelessWidget {
+  const JurisdictionDropdown({
+    super.key,
+    required this.value,
+    required this.label,
+    required this.options,
+    required this.onChanged,
+  });
+
+  final T value;
+  final String label;
+
+  /// Menu items in display order, value to label.
+  final Map<T, String> options;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return PopupMenuButton<T>(
+      initialValue: value,
+      onSelected: onChanged,
+      position: PopupMenuPosition.under,
+      itemBuilder: (context) => [
+        for (final entry in options.entries)
+          PopupMenuItem<T>(value: entry.key, child: Text(entry.value)),
+      ],
+      child: Container(
+        height: 30,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        decoration: BoxDecoration(
+          color: scheme.surface,
+          border: Border.all(color: scheme.outlineVariant),
+          borderRadius: BorderRadius.circular(15),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: scheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 2),
+            Icon(Icons.arrow_drop_down, size: 18, color: scheme.primary),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/domain/aerodromes/aerodrome_summary_test.dart
+++ b/test/domain/aerodromes/aerodrome_summary_test.dart
@@ -270,4 +270,68 @@ void main() {
       );
     });
   });
+
+  group('totalDistanceFlownNm', () {
+    test('sums leg-by-leg distance across every flight', () {
+      final directory = _directory();
+      final egka = directory.byIcao('EGKA')!;
+      final eghh = directory.byIcao('EGHH')!;
+      final lfat = directory.byIcao('LFAT')!;
+
+      final flights = [
+        _record(
+          'f1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            route: ['EGKA', 'EGHH', 'EGKA'],
+          ),
+        ),
+        _record(
+          'f2',
+          _flight(
+            date: const CalendarDate(2026, 1, 2),
+            route: ['EGKA', 'LFAT'],
+          ),
+        ),
+      ];
+
+      final expected =
+          greatCircleDistanceNm(egka.position, eghh.position) * 2 +
+          greatCircleDistanceNm(egka.position, lfat.position);
+
+      expect(
+        totalDistanceFlownNm(flights, directory),
+        closeTo(expected, 0.001),
+      );
+    });
+
+    test('skips a leg whose aerodrome does not resolve', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(
+            date: const CalendarDate(2026, 1, 1),
+            route: ['EGKA', 'PRIVATE-STRIP', 'EGKA'],
+          ),
+        ),
+      ];
+
+      expect(totalDistanceFlownNm(flights, _directory()), 0);
+    });
+
+    test('a single-aerodrome route (no legs) contributes nothing', () {
+      final flights = [
+        _record(
+          'f1',
+          _flight(date: const CalendarDate(2026, 1, 1), route: ['EGKA']),
+        ),
+      ];
+
+      expect(totalDistanceFlownNm(flights, _directory()), 0);
+    });
+
+    test('an empty flight set flies zero distance', () {
+      expect(totalDistanceFlownNm(const [], _directory()), 0);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- New shared `JurisdictionDropdown` widget — a dropdown rather than a pill switch, since the jurisdiction registry is explicitly open-ended and a dropdown scales past two or three options without a redesign.
- **Currency**: an optional Both/EASA/FAA filter (default Both), satisfying #62's own acceptance criteria ("jurisdiction filter, with the option to view both at once").
- **Totals**: an explicit dropdown to view the same figures under any held licence, defaulting to primary. Confirmed against CLAUDE.md's existing "never a silent toggle that silently changes what the numbers mean" rule before building — CLAUDE.md is updated to describe the new convention (a visible, chosen dropdown satisfies the same principle a pill switch would have violated).
- **Real bug fix, found during on-device verification of the above**: EASA and FAA's pilot-function-time and operational-condition-time primitives use entirely different quantity key names (`pic`/`picus`/`spic`/`copilot`/`dual`/`instructor` vs `actingPic`/`loggedPic`/`dualReceived`/`sic`; `night`/`ifr` vs `nightFlightTime`/`actualInstrument`/`simulatedInstrument`). Totals' Function/Conditions tabs previously only ever worked because the screen could only ever show the primary jurisdiction — switching to FAA showed all zeros. Fixed with per-jurisdiction row configuration so each renders its own real concepts and labels.
- **Currency empty state** (#62): a zero-flights pilot now sees a friendly empty state instead of a wall of unsatisfied-looking requirement rows.
- **Aerodromes total distance flown** (#88): new `totalDistanceFlownNm`, summing every flight's route leg-by-leg via the existing `greatCircleDistanceNm` primitive (an honest lower bound — a leg whose aerodrome doesn't resolve is skipped, never guessed).

## Test plan
- [x] `flutter test` — 629 tests pass, including 4 new `totalDistanceFlownNm` cases.
- [x] `dart run tool/check_domain_coverage.dart` — 95.8% on `lib/domain/` (threshold 90%).
- [x] `flutter analyze --fatal-infos`, `check_layering`, `check_domain_types`, `check_currency_rules`, `check_schema_snapshot` all clean.
- [x] On-device (Android emulator, dark mode): Currency filter (Both/EASA-only/FAA-only) and empty state; Totals dropdown switching between EASA and FAA with Function/Conditions tabs showing correct jurisdiction-specific figures in both directions, confirmed no regression on the EASA (primary) path; Aerodromes' new distance row.
- [x] Caught and fixed a real layout bug during verification: the Currency empty state wasn't wrapped in `SafeArea`, so its header overlapped the status bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)