### PR TITLE
Canonical import model and adapter interface (#68)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,9 @@ jobs:
       - name: Check no networking (#67)
         run: dart run tool/check_no_networking.dart
 
+      - name: Check io/ vendor leakage (#68)
+        run: dart run tool/check_io_vendor_leak.dart
+
       - name: Test
         run: flutter test --coverage
 

--- a/lib/io/canonical_import_row.dart
+++ b/lib/io/canonical_import_row.dart
@@ -1,0 +1,73 @@
+import '../domain/model/aircraft.dart';
+import '../domain/model/flight.dart';
+
+/// One flight parsed out of a vendor import file, mapped onto this app's own
+/// domain model — [Flight] and [Aircraft] *are* the "canonical internal
+/// model" CLAUDE.md's Import/export section requires every adapter to
+/// produce (#68). There is no separate, parallel import-only model: raw
+/// facts are raw facts regardless of where they came from, and duplicating
+/// [Flight]'s field set in a second type would just be two places to keep in
+/// sync. This class is the thin envelope an adapter wraps a mapped flight in
+/// — the metadata needed to review and write it, not a reinterpretation of
+/// it.
+class CanonicalImportRow {
+  const CanonicalImportRow({
+    required this.sourceRowNumber,
+    required this.flight,
+    required this.aircraft,
+    this.unmappedFields = const {},
+    this.reviewNotes = const [],
+  });
+
+  /// 1-based position in the source file. The preview step (#73) and any
+  /// per-row error report point back to this, not a database id — nothing
+  /// has been written yet when this row is produced.
+  final int sourceRowNumber;
+
+  final Flight flight;
+
+  /// Not yet resolved against `AircraftRepository`. **Adapters have no
+  /// knowledge of the database** (this issue's own acceptance criterion) —
+  /// turning this into a stored aircraft id (reusing an existing
+  /// registration or creating a new record) is the import pipeline's job,
+  /// the same way `NewFlightScreen._resolveAircraftId` already does it for
+  /// a hand-entered flight.
+  final Aircraft aircraft;
+
+  /// Vendor fields with no home on [Flight] or [Aircraft] — preserved
+  /// verbatim as `column label -> raw value`, so [mergeUnmappedFieldsIntoRemarks]
+  /// can fold them into [Flight.remarks] rather than dropping them.
+  /// CLAUDE.md: "Silently dropping a field the user has been maintaining
+  /// for a decade is the worst possible import outcome."
+  final Map<String, String> unmappedFields;
+
+  /// Plain-language notes about a row this adapter could not map with full
+  /// confidence — a default it had to guess at, an ambiguous type
+  /// designator, anything the preview step (#73) should surface before the
+  /// pilot commits to importing it. Never used to *block* the import, the
+  /// same non-blocking spirit as #105's qualification-gap warning.
+  final List<String> reviewNotes;
+}
+
+/// Folds [unmappedFields] into [remarks] as human-readable `label: value`
+/// lines, preserving whatever the vendor tracked that this app has no raw
+/// fact for. CLAUDE.md is explicit that dropping it silently is the worst
+/// possible import outcome — this is the one place that promise is kept.
+///
+/// A no-op (returns [remarks] unchanged) when there is nothing to fold in,
+/// or when every unmapped value is blank — a vendor's own CSV frequently
+/// carries an empty column for every row, and an empty column contributes
+/// nothing worth preserving.
+String mergeUnmappedFieldsIntoRemarks(
+  String remarks,
+  Map<String, String> unmappedFields,
+) {
+  final lines = [
+    for (final entry in unmappedFields.entries)
+      if (entry.value.trim().isNotEmpty) '${entry.key}: ${entry.value.trim()}',
+  ];
+  if (lines.isEmpty) return remarks;
+
+  final appended = lines.join('; ');
+  return remarks.isEmpty ? appended : '$remarks — $appended';
+}

--- a/lib/io/import_adapter.dart
+++ b/lib/io/import_adapter.dart
@@ -1,0 +1,47 @@
+import 'canonical_import_row.dart';
+
+/// One source row an [ImportAdapter] could not turn into a
+/// [CanonicalImportRow] — #74's own home for *why* a row wasn't imported,
+/// not just that it wasn't. [rowNumber] is 1-based, matching
+/// [CanonicalImportRow.sourceRowNumber] so a report can point back to the
+/// exact line in the file the pilot opened it from.
+class ImportRowError {
+  const ImportRowError({required this.rowNumber, required this.message});
+
+  final int rowNumber;
+  final String message;
+
+  @override
+  String toString() => 'row $rowNumber: $message';
+}
+
+/// Everything one call to [ImportAdapter.parse] produced: every row it
+/// could map, and every row it couldn't, with why. Never partial for one
+/// row — a row that fails validation is entirely in [errors], never
+/// half-populated in [rows] (#74: "per-row validation with no silent
+/// coercion").
+class ImportParseResult {
+  const ImportParseResult({required this.rows, required this.errors});
+
+  final List<CanonicalImportRow> rows;
+  final List<ImportRowError> errors;
+
+  bool get hasErrors => errors.isNotEmpty;
+}
+
+/// What every vendor-specific importer (#69 ForeFlight, #71 Garmin, #72
+/// generic CSV) implements.
+///
+/// Pure and synchronous on purpose: an adapter **has no knowledge of the
+/// database** (this issue's own acceptance criterion) — it turns file
+/// content into an [ImportParseResult] and nothing else. Resolving an
+/// aircraft registration to a stored id, detecting duplicates (#75), and
+/// actually writing anything are the import pipeline's job, layered on top
+/// of this, never the adapter's own.
+abstract class ImportAdapter {
+  /// A short, human-readable name for this format, shown in the import
+  /// picker UI — e.g. "ForeFlight (logbook_template.csv)".
+  String get displayName;
+
+  ImportParseResult parse(String source);
+}

--- a/lib/io/supported_import_formats.dart
+++ b/lib/io/supported_import_formats.dart
@@ -1,0 +1,11 @@
+/// A short, human-readable summary of which vendor formats import supports
+/// — the one place outside an adapter's own file that names a vendor by
+/// name is allowed to live, so a screen that just wants to *say* what's
+/// supported (Settings' placeholder row, before #69/#71/#72 exist) doesn't
+/// have to spell out "ForeFlight or Garmin" itself (#68: "never let a
+/// vendor's field naming past `io/`").
+///
+/// Update this alongside `ImportAdapter.displayName` as adapters are added
+/// — there is no registry yet listing them for this to read live, since
+/// none exist.
+const String supportedImportFormatsLabel = 'ForeFlight or Garmin CSV';

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -12,6 +12,7 @@ import '../../domain/totals/totals_summary.dart';
 import '../aircraft/aircraft_list_screen.dart';
 import '../currency/rule_asset_paths.dart';
 import '../currency/sample_currency_data.dart';
+import '../../io/supported_import_formats.dart';
 import '../preferences/app_preferences.dart';
 import '../providers/aircraft_providers.dart';
 import '../theme/app_colors.dart';
@@ -137,7 +138,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 const _InertRow(
                   title: 'Import',
                   subtitle:
-                      'ForeFlight or Garmin CSV · preview before applying',
+                      '$supportedImportFormatsLabel · preview before applying',
                 ),
                 const _Divider(),
                 // `exportDatabaseBackup`/`isBackupOverdue`

--- a/test/io/canonical_import_row_test.dart
+++ b/test/io/canonical_import_row_test.dart
@@ -1,0 +1,117 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/io/canonical_import_row.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _aircraft = Aircraft(
+  registration: 'N12345',
+  manufacturer: 'Cessna',
+  model: '172',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight({String remarks = ''}) {
+  final off = UtcInstant.utc(2026, 1, 1, 9);
+  return Flight(
+    aircraftRegistration: _aircraft.registration,
+    route: const ['KABC', 'KABC'],
+    prePlannedNavigation: false,
+    offBlocks: off,
+    onBlocks: off.add(const Duration(hours: 1)),
+    capacity: _capacity,
+    carryingPassengers: false,
+    takeoffs: const CircuitCounts(dayFullStop: 1),
+    landings: const CircuitCounts(dayFullStop: 1),
+    ifrFlightPlanFiled: false,
+    actualInstrumentTime: FlightDuration.zero,
+    simulatedInstrumentTime: FlightDuration.zero,
+    approaches: const [],
+    holdingProceduresCount: 0,
+    trackingPerformed: false,
+    remarks: remarks,
+  );
+}
+
+void main() {
+  group('mergeUnmappedFieldsIntoRemarks', () {
+    test('is a no-op with no unmapped fields', () {
+      expect(
+        mergeUnmappedFieldsIntoRemarks('Local flight', {}),
+        'Local flight',
+      );
+    });
+
+    test('is a no-op when every unmapped value is blank', () {
+      expect(
+        mergeUnmappedFieldsIntoRemarks('Local flight', {
+          'Pilot Comments': '',
+          'Instructor Comments': '   ',
+        }),
+        'Local flight',
+      );
+    });
+
+    test('appends a single field to existing remarks', () {
+      expect(
+        mergeUnmappedFieldsIntoRemarks('Local flight', {
+          'Pilot Comments': 'Great weather',
+        }),
+        'Local flight — Pilot Comments: Great weather',
+      );
+    });
+
+    test('appends without a leading separator when remarks were empty', () {
+      expect(
+        mergeUnmappedFieldsIntoRemarks('', {'Pilot Comments': 'Great weather'}),
+        'Pilot Comments: Great weather',
+      );
+    });
+
+    test('joins several unmapped fields and drops the blank ones', () {
+      expect(
+        mergeUnmappedFieldsIntoRemarks('', {
+          'Pilot Comments': 'Great weather',
+          'Instructor Comments': '',
+          'Route': 'Direct',
+        }),
+        'Pilot Comments: Great weather; Route: Direct',
+      );
+    });
+  });
+
+  test('CanonicalImportRow carries a full Flight and Aircraft unmodified', () {
+    final flight = _flight(remarks: 'Great weather');
+    final row = CanonicalImportRow(
+      sourceRowNumber: 3,
+      flight: flight,
+      aircraft: _aircraft,
+      unmappedFields: const {'Route': 'Direct'},
+      reviewNotes: const ['Approach count guessed from a blank column'],
+    );
+
+    expect(row.sourceRowNumber, 3);
+    expect(row.flight, flight);
+    expect(row.aircraft, _aircraft);
+    expect(row.unmappedFields, {'Route': 'Direct'});
+    expect(row.reviewNotes, ['Approach count guessed from a blank column']);
+  });
+}

--- a/test/io/import_adapter_test.dart
+++ b/test/io/import_adapter_test.dart
@@ -1,0 +1,138 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/io/canonical_import_row.dart';
+import 'package:easa_digital_log/io/import_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+/// A minimal, in-memory adapter over a trivial `registration,route,remarks`
+/// CSV — not a real vendor format (that's #69/#71/#72's job), just enough
+/// to prove [ImportAdapter] is actually usable end to end: parse to
+/// canonical rows, report a per-row error without touching the rows
+/// already parsed, and never reach for a database.
+class _TestFixtureAdapter implements ImportAdapter {
+  @override
+  String get displayName => 'Test fixture';
+
+  @override
+  ImportParseResult parse(String source) {
+    final rows = <CanonicalImportRow>[];
+    final errors = <ImportRowError>[];
+    final lines = source.split('\n').where((l) => l.trim().isNotEmpty).toList();
+
+    for (var i = 0; i < lines.length; i++) {
+      final rowNumber = i + 1;
+      final fields = lines[i].split(',');
+      if (fields.length < 2) {
+        errors.add(
+          ImportRowError(
+            rowNumber: rowNumber,
+            message: 'expected at least 2 columns, found ${fields.length}',
+          ),
+        );
+        continue;
+      }
+
+      final registration = fields[0];
+      final route = fields[1].split('-');
+      final off = UtcInstant.utc(2026, 1, 1, 9);
+
+      rows.add(
+        CanonicalImportRow(
+          sourceRowNumber: rowNumber,
+          aircraft: Aircraft(
+            registration: registration,
+            manufacturer: 'Unknown',
+            model: 'Unknown',
+            category: AircraftCategory.aeroplane,
+            engineType: EngineType.piston,
+            engineCount: 1,
+            operatingSurface: OperatingSurface.land,
+            requiresMultiCrew: false,
+          ),
+          flight: Flight(
+            aircraftRegistration: registration,
+            route: route,
+            prePlannedNavigation: false,
+            offBlocks: off,
+            onBlocks: off.add(const Duration(hours: 1)),
+            capacity: _capacity,
+            carryingPassengers: false,
+            takeoffs: const CircuitCounts(dayFullStop: 1),
+            landings: const CircuitCounts(dayFullStop: 1),
+            ifrFlightPlanFiled: false,
+            actualInstrumentTime: FlightDuration.zero,
+            simulatedInstrumentTime: FlightDuration.zero,
+            approaches: const [],
+            holdingProceduresCount: 0,
+            trackingPerformed: false,
+            remarks: '',
+          ),
+          unmappedFields: fields.length > 2 ? {'extra': fields[2]} : const {},
+        ),
+      );
+    }
+
+    return ImportParseResult(rows: rows, errors: errors);
+  }
+}
+
+void main() {
+  test('a working adapter maps every clean row to a canonical row', () {
+    final result = _TestFixtureAdapter().parse(
+      'N12345,KABC-KDEF\nN67890,KGHI-KGHI',
+    );
+
+    expect(result.rows, hasLength(2));
+    expect(result.errors, isEmpty);
+    expect(result.hasErrors, isFalse);
+    expect(result.rows[0].flight.route, ['KABC', 'KDEF']);
+    expect(result.rows[0].aircraft.registration, 'N12345');
+  });
+
+  test(
+    'a malformed row becomes an error, and does not block the rows around it',
+    () {
+      final result = _TestFixtureAdapter().parse(
+        'N12345,KABC-KDEF\nmalformed\nN67890,KGHI-KGHI',
+      );
+
+      expect(result.rows, hasLength(2));
+      expect(result.hasErrors, isTrue);
+      expect(result.errors.single.rowNumber, 2);
+      expect(result.errors.single.message, contains('2 columns'));
+      // Row numbers stay 1-based against the source file, not against the
+      // successfully-parsed subset — row 3 in the file, not row 2 of rows.
+      expect(result.rows[1].sourceRowNumber, 3);
+    },
+  );
+
+  test('unmapped vendor fields survive onto the canonical row, not lost', () {
+    final result = _TestFixtureAdapter().parse(
+      'N12345,KABC-KDEF,some vendor note',
+    );
+
+    expect(result.rows.single.unmappedFields, {'extra': 'some vendor note'});
+    expect(
+      mergeUnmappedFieldsIntoRemarks(
+        result.rows.single.flight.remarks,
+        result.rows.single.unmappedFields,
+      ),
+      'extra: some vendor note',
+    );
+  });
+}

--- a/test/tool/check_io_vendor_leak_test.dart
+++ b/test/tool/check_io_vendor_leak_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/check_io_vendor_leak.dart';
+
+void main() {
+  group('findVendorLeaks', () {
+    test('flags a vendor identifier in lib/data/', () {
+      const source = 'class ForeFlightRow {}\n';
+      final leaks = findVendorLeaks('lib/data/thing.dart', source);
+
+      expect(leaks, hasLength(1));
+      expect(leaks.single.vendorName, 'ForeFlight');
+      expect(leaks.single.line, 1);
+    });
+
+    test('flags a vendor identifier in lib/ui/', () {
+      const source = "const label = 'Imported from Garmin Pilot';\n";
+      final leaks = findVendorLeaks('lib/ui/settings/thing.dart', source);
+
+      expect(leaks, hasLength(1));
+      expect(leaks.single.vendorName, 'Garmin');
+    });
+
+    test('allows the same name inside lib/io/', () {
+      const source = 'class ForeFlightAdapter {}\n';
+      expect(
+        findVendorLeaks('lib/io/foreflight/adapter.dart', source),
+        isEmpty,
+      );
+    });
+
+    test('ignores a comment explaining a design decision by vendor name', () {
+      const source = '''
+// ForeFlight and Garmin both export a single "PIC" figure per flight.
+class Aircraft {}
+''';
+      expect(
+        findVendorLeaks('lib/domain/model/aircraft.dart', source),
+        isEmpty,
+      );
+    });
+
+    test('is case-sensitive to the vendor\'s own capitalisation', () {
+      const source = "const x = 'foreflightless';\n";
+      expect(findVendorLeaks('lib/ui/thing.dart', source), isEmpty);
+    });
+
+    test('flags a compound identifier a real adapter would plausibly use '
+        '(regression: a `\\b`-bounded match let ForeFlightRow slip past, '
+        'since Dart identifiers concatenate words with no separator)', () {
+      const source = 'class ForeFlightRow {}\nclass GarminCsvRow {}\n';
+      final leaks = findVendorLeaks('lib/data/thing.dart', source);
+
+      expect(leaks, hasLength(2));
+      expect(leaks.map((l) => l.vendorName), ['ForeFlight', 'Garmin']);
+    });
+
+    test('every real lib/ file is clean', () {
+      // Pins today's clean state, the same shape as
+      // check_no_networking_test.dart's own real-tree assertion — a future
+      // accidental leak fails this test immediately, not just the next CI
+      // run.
+      final leaks = <VendorLeak>[];
+      for (final entity in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.freezed.dart') ||
+            entity.path.endsWith('.g.dart')) {
+          continue;
+        }
+        leaks.addAll(findVendorLeaks(entity.path, entity.readAsStringSync()));
+      }
+      expect(leaks, isEmpty);
+    });
+  });
+}

--- a/tool/check_io_vendor_leak.dart
+++ b/tool/check_io_vendor_leak.dart
@@ -1,0 +1,130 @@
+/// #68: CLAUDE.md's Import/export section — "never let a vendor's field
+/// naming leak past `io/`" — enforced as a build guard rather than a review
+/// habit. A vendor-specific identifier (a ForeFlight/Garmin type, constant
+/// or column name) has no business appearing in `domain/`, `data/` or
+/// `ui/`: those layers see [CanonicalImportRow]/[Flight]/[Aircraft], never
+/// a vendor's own shape.
+///
+/// Matches syntactically rather than depending on `package:analyzer` (see
+/// ADR-0001), the same trade-off `check_layering.dart` documents: comments
+/// are stripped first (this project's own docs and dartdocs legitimately
+/// *explain* a design decision by naming ForeFlight/Garmin — see
+/// `Aircraft`'s own dartdoc — and that is not a leak), but a vendor name
+/// inside a string literal — a user-facing label like `'Imported from
+/// ForeFlight'` — still counts as a violation. That is a deliberate,
+/// accepted over-report: the fix is to hoist the label into `lib/io/` as a
+/// named constant the UI imports, not to special-case string literals here
+/// and risk a real leak slipping through disguised as one.
+///
+/// Run: `dart run tool/check_io_vendor_leak.dart`
+library;
+
+import 'dart:io';
+
+import 'dart_source.dart';
+
+/// Vendor names banned outside [_ioSegment]. Deliberately narrow and
+/// name-based rather than "every vendor CSV import concept" — a generic
+/// term like `logbook` or `csv` is not a leak, a proper noun naming one
+/// specific format is. Extend this list as new vendors are added (#69
+/// ForeFlight, #71 Garmin), never widen the matching strategy to guess at
+/// vendors not yet named here.
+const List<String> bannedVendorNames = <String>['ForeFlight', 'Garmin'];
+
+/// Path segment marking the exempt tree — vendor-specific code is exactly
+/// what lives here.
+const String _ioSegment = 'io';
+
+const String _sourceTarget = 'lib';
+
+/// A banned vendor name found outside `lib/io/`.
+class VendorLeak {
+  const VendorLeak({
+    required this.filePath,
+    required this.line,
+    required this.vendorName,
+  });
+
+  final String filePath;
+  final int line;
+  final String vendorName;
+
+  @override
+  String toString() => '$filePath:$line  names "$vendorName"';
+}
+
+/// Whether [filePath] sits inside the exempt `lib/io/` tree.
+bool _isExempt(String filePath) {
+  final segments = filePath.replaceAll(r'\', '/').split('/');
+  return segments.contains(_ioSegment);
+}
+
+/// Returns every banned vendor name [source] mentions, outside comments.
+///
+/// A plain, case-sensitive substring match against each name's own
+/// proper-noun capitalisation — deliberately *not* bounded by `\b` on
+/// either side. Dart identifiers concatenate words with no separator
+/// (`ForeFlightAdapter`, `GarminCsvRow`), so a trailing `\b` would let
+/// exactly the class names a real adapter uses slip past a check meant to
+/// catch them. `foreflight` lowercased inside a sentence explaining *why*
+/// a rule exists still reads differently from `ForeFlight` used as an
+/// identifier or a label, and case sensitivity alone draws that line.
+List<VendorLeak> findVendorLeaks(String filePath, String source) {
+  filePath = filePath.replaceAll(r'\', '/');
+  if (_isExempt(filePath)) return const [];
+
+  final stripped = stripComments(source);
+  final leaks = <VendorLeak>[];
+
+  for (final vendorName in bannedVendorNames) {
+    final pattern = RegExp(RegExp.escape(vendorName));
+    for (final match in pattern.allMatches(stripped)) {
+      final line =
+          '\n'.allMatches(stripped.substring(0, match.start)).length + 1;
+      leaks.add(
+        VendorLeak(filePath: filePath, line: line, vendorName: vendorName),
+      );
+    }
+  }
+
+  return leaks;
+}
+
+void main() {
+  final directory = Directory(_sourceTarget);
+  if (!directory.existsSync()) {
+    stdout.writeln(
+      'check_io_vendor_leak: $_sourceTarget does not exist yet — nothing to check.',
+    );
+    exit(0);
+  }
+
+  final leaks = <VendorLeak>[];
+  for (final entity in directory.listSync(recursive: true)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) continue;
+    if (entity.path.endsWith('.freezed.dart') ||
+        entity.path.endsWith('.g.dart')) {
+      continue;
+    }
+    leaks.addAll(findVendorLeaks(entity.path, entity.readAsStringSync()));
+  }
+
+  if (leaks.isEmpty) {
+    stdout.writeln(
+      'check_io_vendor_leak: no vendor-specific identifier outside lib/io/.',
+    );
+    exit(0);
+  }
+
+  stderr.writeln('check_io_vendor_leak: ${leaks.length} leak(s):');
+  for (final leak in leaks) {
+    stderr.writeln('  $leak');
+  }
+  stderr.writeln('');
+  stderr.writeln(
+    'CLAUDE.md: "Never let a vendor\'s field naming past io/." Map into '
+    'CanonicalImportRow/Flight/Aircraft inside lib/io/ and have the rest of '
+    'the app read that instead.',
+  );
+  exit(1);
+}

--- a/tool/pre_commit.ps1
+++ b/tool/pre_commit.ps1
@@ -32,5 +32,9 @@ Write-Host "pre-commit: checking for networking (#67)..."
 dart run tool/check_no_networking.dart
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+Write-Host "pre-commit: checking io/ vendor leakage (#68)..."
+dart run tool/check_io_vendor_leak.dart
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
 Write-Host "pre-commit: all checks passed."
 exit 0


### PR DESCRIPTION
## Summary
- **`CanonicalImportRow`** (`lib/io/canonical_import_row.dart`) wraps the existing `Flight`/`Aircraft` domain model rather than duplicating their field set in a parallel type — CLAUDE.md's "adapters map into the canonical internal model" already means `Flight`/`Aircraft` themselves. The envelope adds only what an adapter needs beyond the raw facts: `sourceRowNumber`, `unmappedFields` (preserved verbatim, never dropped — CLAUDE.md: "silently dropping a field the user has been maintaining for a decade is the worst possible import outcome"), and non-blocking `reviewNotes`.
- **`mergeUnmappedFieldsIntoRemarks`** folds preserved vendor fields into `Flight.remarks` as `label: value` lines.
- **`ImportAdapter`** (`lib/io/import_adapter.dart`) is pure and synchronous by design: `parse(String) -> ImportParseResult`, no database access, no async I/O — resolving an aircraft to a stored id, duplicate detection (#75), and actually writing anything are the pipeline's job layered on top, never the adapter's.
- **`tool/check_io_vendor_leak.dart`** enforces "never let a vendor's field naming leak past `io/`" as a build guard (wired into CI and pre-commit), the same syntactic-matching approach as `check_layering.dart`/`check_no_networking.dart`. It caught a real pre-existing case immediately: Settings' "Import" placeholder row named ForeFlight/Garmin directly in a UI string — hoisted into `lib/io/supported_import_formats.dart`.
- Verified against the exact Dart SDK CI uses (3.44.0/Dart 3.12.0) after last time's formatter-version mismatch.

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` — 751 tests passing
- [x] `dart run tool/check_io_vendor_leak.dart`, `check_layering.dart`, `check_domain_types.dart`, `check_currency_rules.dart`, `check_no_networking.dart` all clean
- [x] `dart run tool/check_domain_coverage.dart` — 96.1%
- [x] `dart run tool/check_schema_snapshot.dart` — up to date
- [x] `dart format --set-exit-if-changed .` clean against CI's pinned SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)