### PR TITLE
feat: ForeFlight logbook_template.csv importer (#69)

### DIFF
--- a/lib/io/foreflight/foreflight_adapter.dart
+++ b/lib/io/foreflight/foreflight_adapter.dart
@@ -1,0 +1,77 @@
+import '../canonical_import_row.dart';
+import '../import_adapter.dart';
+import 'foreflight_aircraft_mapper.dart';
+import 'foreflight_flight_mapper.dart';
+import 'foreflight_tables.dart';
+
+/// Imports ForeFlight's `logbook_template.csv` export (#69) — a single CSV
+/// containing two embedded tables (Aircraft, then Flights) plus typed
+/// custom fields in the form `[Type]FieldName`.
+///
+/// [parse] throws [FormatException] if [source] doesn't have that basic
+/// shape at all (no "Aircraft Table"/"Flights Table" markers) — a whole-file
+/// problem, not a per-row one, so it isn't folded into
+/// [ImportParseResult.errors] the way a malformed individual row is.
+///
+/// ForeFlight's own PIC/SIC/dual-time columns are *derived* quantities, not
+/// this app's raw facts (CLAUDE.md rule 1) — reconstructing
+/// [PilotCapacity] from them is an inherently lossy reverse projection.
+/// See `foreflight_flight_mapper.dart`'s own dartdoc for exactly which
+/// judgement calls that makes and why every one of them appends a
+/// [CanonicalImportRow.reviewNotes] entry rather than staying silent.
+class ForeFlightAdapter implements ImportAdapter {
+  @override
+  String get displayName => 'ForeFlight (logbook_template.csv)';
+
+  @override
+  ImportParseResult parse(String source) {
+    final tables = parseForeFlightTables(source);
+
+    final aircraftByRegistration = <String, ForeFlightAircraftMapping>{};
+    for (final row in tables.aircraftRows) {
+      final registration = row['AircraftID'] ?? '';
+      if (registration.isEmpty) continue;
+      final mapping = mapForeFlightAircraft(row);
+      if (mapping != null) aircraftByRegistration[registration] = mapping;
+    }
+
+    final rows = <CanonicalImportRow>[];
+    final errors = <ImportRowError>[];
+
+    for (var i = 0; i < tables.flightRows.length; i++) {
+      final row = tables.flightRows[i];
+      final sourceRowNumber = tables.flightDataStartLine + i;
+      final aircraftMapping = aircraftByRegistration[row['AircraftID'] ?? ''];
+
+      final mapped = mapForeFlightFlight(
+        row: row,
+        aircraft: aircraftMapping?.aircraft,
+      );
+
+      if (mapped.error != null) {
+        errors.add(
+          ImportRowError(rowNumber: sourceRowNumber, message: mapped.error!),
+        );
+        continue;
+      }
+
+      rows.add(
+        CanonicalImportRow(
+          sourceRowNumber: sourceRowNumber,
+          flight: mapped.flight!,
+          aircraft: aircraftMapping!.aircraft,
+          unmappedFields: mapped.unmappedFields,
+          // Aircraft-level review notes (e.g. an engine count that had to
+          // be defaulted) apply once per aircraft, not once per flight —
+          // repeating them on every one of that aircraft's rows would
+          // drown out the flight-specific ones. They're available via
+          // `mapForeFlightAircraft` directly for a caller that wants an
+          // aircraft-level report instead.
+          reviewNotes: mapped.reviewNotes,
+        ),
+      );
+    }
+
+    return ImportParseResult(rows: rows, errors: errors);
+  }
+}

--- a/lib/io/foreflight/foreflight_aircraft_mapper.dart
+++ b/lib/io/foreflight/foreflight_aircraft_mapper.dart
@@ -1,0 +1,183 @@
+import '../../domain/model/aircraft.dart';
+
+/// One aircraft-table row mapped to this app's own [Aircraft] model, plus
+/// any notes about assumptions the mapping had to make.
+class ForeFlightAircraftMapping {
+  const ForeFlightAircraftMapping({
+    required this.aircraft,
+    this.reviewNotes = const [],
+  });
+
+  final Aircraft aircraft;
+  final List<String> reviewNotes;
+}
+
+const _easaJurisdictionId = 'eu.easa.part-fcl';
+const _faaJurisdictionId = 'us.faa.part61';
+
+/// Maps ForeFlight's `EngineType` column. Blank or unrecognised values fall
+/// back to [EngineType.none] with a review note — never guessed as piston,
+/// the common case, since a wrong engine type feeds directly into the EASA
+/// class-rating suffix.
+const Map<String, EngineType> _engineTypes = {
+  'Piston': EngineType.piston,
+  'Turboprop': EngineType.turboprop,
+  'Turbojet': EngineType.turbojet,
+  'Turbofan': EngineType.turbofan,
+  'Electric': EngineType.electric,
+};
+
+/// Maps a ForeFlight `aircraftClass (FAA)` value (e.g.
+/// `airplane_single_engine_land`) to this app's [AircraftCategory] and
+/// [OperatingSurface] — the one column that carries both facts in a single
+/// underscore-joined string.
+class _ParsedAircraftClass {
+  const _ParsedAircraftClass({
+    required this.category,
+    required this.operatingSurface,
+    required this.isMultiEngine,
+  });
+
+  final AircraftCategory category;
+  final OperatingSurface operatingSurface;
+  final bool isMultiEngine;
+}
+
+_ParsedAircraftClass? _parseAircraftClass(String value) {
+  final category = switch (value) {
+    _ when value.startsWith('airplane_') => AircraftCategory.aeroplane,
+    _ when value.startsWith('helicopter') => AircraftCategory.helicopter,
+    _ when value.startsWith('glider') => AircraftCategory.glider,
+    _ when value.startsWith('powered_lift') => AircraftCategory.poweredLift,
+    _ when value.startsWith('lighter_than_air_airship') =>
+      AircraftCategory.airship,
+    _ when value.startsWith('lighter_than_air_balloon') =>
+      AircraftCategory.balloon,
+    _ => null,
+  };
+  if (category == null) return null;
+
+  final operatingSurface = value.contains('amphibian')
+      ? OperatingSurface.amphibian
+      : value.contains('_sea')
+      ? OperatingSurface.sea
+      : OperatingSurface.land;
+
+  return _ParsedAircraftClass(
+    category: category,
+    operatingSurface: operatingSurface,
+    isMultiEngine: value.contains('multi_engine'),
+  );
+}
+
+/// Whether ForeFlight's `GearType` column names a tailwheel arrangement —
+/// `fixed_tailwheel` is the only value observed to; anything else (fixed or
+/// retractable tricycle, floats) is not.
+bool _isTailwheel(String gearType) => gearType.contains('tailwheel');
+
+bool _isRetractable(String gearType) => gearType.startsWith('retractable');
+
+/// Maps one aircraft-table [row] to a real [Aircraft], or returns `null`
+/// when it has no canonical equivalent to map to at all:
+///
+/// - `equipType (FAA)` of `ftd` — a flight training device session, not an
+///   aircraft. FSTD sessions are a separate form CLAUDE.md defers entirely
+///   (`#58`'s dartdoc: "a different form, not built") — importing one as a
+///   regular flight against a fabricated `Aircraft` would misrepresent
+///   simulator time as aircraft time, a data-integrity violation this
+///   adapter refuses to make.
+/// - No `Make`/`Model` at all — ForeFlight's own aircraft table routinely
+///   carries placeholder rows (a bare tail number with every other field
+///   blank) for entries the pilot never filled in; there is nothing here
+///   to construct a valid [Aircraft] from.
+///
+/// The caller (the flight mapper) is responsible for turning a `null` here
+/// into a per-row [ImportRowError] for whichever flights reference this
+/// registration — the gap is real and belongs in front of the pilot, not
+/// silently dropped.
+ForeFlightAircraftMapping? mapForeFlightAircraft(Map<String, String> row) {
+  final registration = row['AircraftID'] ?? '';
+  if (registration.isEmpty) return null;
+  if (row['equipType (FAA)'] == 'ftd') return null;
+
+  final manufacturer = row['Make'] ?? '';
+  final model = row['Model'] ?? '';
+  if (manufacturer.isEmpty && model.isEmpty) return null;
+
+  final notes = <String>[];
+
+  final parsedClass = _parseAircraftClass(row['aircraftClass (FAA)'] ?? '');
+  final category = parsedClass?.category ?? AircraftCategory.aeroplane;
+  if (parsedClass == null) {
+    notes.add(
+      'aircraftClass (FAA) was blank or unrecognised — category defaulted '
+      'to aeroplane, verify.',
+    );
+  }
+  final operatingSurface =
+      parsedClass?.operatingSurface ?? OperatingSurface.land;
+
+  final engineTypeRaw = row['EngineType'] ?? '';
+  final engineType = _engineTypes[engineTypeRaw];
+  if (engineType == null && engineTypeRaw.isNotEmpty) {
+    notes.add(
+      'EngineType "$engineTypeRaw" was not recognised — defaulted to none.',
+    );
+  }
+
+  final engineCount = parsedClass?.isMultiEngine == true ? 2 : 1;
+  if (parsedClass == null) {
+    notes.add('Engine count defaulted to 1 — aircraftClass did not say.');
+  }
+
+  final gearType = row['GearType'] ?? '';
+  final requiredQualifications = <String, Set<AircraftQualification>>{};
+
+  final faaQualifications = <AircraftQualification>{
+    if (row['complexAircraft (FAA)'] == 'TRUE')
+      AircraftQualification.faaComplex,
+    if (row['highPerformance (FAA)'] == 'TRUE')
+      AircraftQualification.faaHighPerformance,
+    if (_isTailwheel(gearType)) AircraftQualification.faaTailwheel,
+  };
+  if (faaQualifications.isNotEmpty) {
+    requiredQualifications[_faaJurisdictionId] = faaQualifications;
+  }
+
+  final easaQualifications = <AircraftQualification>{
+    if (_isTailwheel(gearType)) AircraftQualification.easaTailwheel,
+    if (_isRetractable(gearType))
+      AircraftQualification.easaRetractableUndercarriage,
+  };
+  if (easaQualifications.isNotEmpty) {
+    requiredQualifications[_easaJurisdictionId] = easaQualifications;
+  }
+
+  for (final column in ['taa (FAA)', 'pressurized (FAA)']) {
+    if (row[column] == 'TRUE') {
+      notes.add(
+        '$column is set but has no equivalent AircraftQualification — not '
+        'recorded. Set it up manually in Aircraft management if it should '
+        'gate a qualification.',
+      );
+    }
+  }
+
+  return ForeFlightAircraftMapping(
+    aircraft: Aircraft(
+      registration: registration,
+      manufacturer: manufacturer,
+      model: model,
+      icaoTypeDesignator: (row['TypeCode'] ?? '').isEmpty
+          ? null
+          : row['TypeCode'],
+      category: category,
+      engineType: engineType ?? EngineType.none,
+      engineCount: engineCount,
+      operatingSurface: operatingSurface,
+      requiresMultiCrew: false,
+      requiredQualifications: requiredQualifications,
+    ),
+    reviewNotes: notes,
+  );
+}

--- a/lib/io/foreflight/foreflight_flight_mapper.dart
+++ b/lib/io/foreflight/foreflight_flight_mapper.dart
@@ -1,0 +1,503 @@
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/flight.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/instructor_presence.dart';
+import '../../domain/model/pilot_capacity.dart';
+import '../../domain/model/utc_instant.dart';
+
+/// Either a mapped [CanonicalImportRow]-shaped `(flight, unmappedFields,
+/// reviewNotes)` triple, or an [error] naming why the row could not be
+/// mapped at all. Kept as a plain result object rather than throwing —
+/// #74's "no silent coercion" applies to malformed rows the same way it
+/// applies to the adapter's caller, and a thrown exception mid-file would
+/// abort every row after it rather than reporting this one row's problem
+/// and continuing.
+class ForeFlightFlightMapping {
+  const ForeFlightFlightMapping.mapped({
+    required this.flight,
+    this.unmappedFields = const {},
+    this.reviewNotes = const [],
+  }) : error = null;
+
+  const ForeFlightFlightMapping.error(this.error)
+    : flight = null,
+      unmappedFields = const {},
+      reviewNotes = const [];
+
+  final Flight? flight;
+  final String? error;
+  final Map<String, String> unmappedFields;
+  final List<String> reviewNotes;
+}
+
+/// ForeFlight logs `TimeOut`/`TimeIn`/`TimeOff`/`TimeOn` in Zulu by default
+/// — the same convention CLAUDE.md rule 3 requires this app to store in.
+/// There is no per-row zone marker to confirm that from the file alone;
+/// this is a documented assumption, not a fact this adapter can verify.
+/// If a pilot's ForeFlight account was ever configured to export local
+/// time instead, every imported time would be silently wrong by that
+/// offset — worth a one-time check against a known flight before trusting
+/// a full import.
+UtcInstant? _parseDateTime(String date, String time) {
+  if (date.isEmpty || time.isEmpty) return null;
+  final dateParts = date.split('-');
+  final timeParts = time.split(':');
+  if (dateParts.length != 3 || timeParts.length != 2) return null;
+  final year = int.tryParse(dateParts[0]);
+  final month = int.tryParse(dateParts[1]);
+  final day = int.tryParse(dateParts[2]);
+  final hour = int.tryParse(timeParts[0]);
+  final minute = int.tryParse(timeParts[1]);
+  if (year == null ||
+      month == null ||
+      day == null ||
+      hour == null ||
+      minute == null) {
+    return null;
+  }
+  return UtcInstant.utc(year, month, day, hour, minute);
+}
+
+FlightDuration _duration(Map<String, String> row, String column) {
+  final raw = row[column] ?? '';
+  if (raw.isEmpty) return FlightDuration.zero;
+  try {
+    return FlightDuration.parseHoursMinutes(raw);
+  } on FormatException {
+    return FlightDuration.zero;
+  }
+}
+
+int _count(Map<String, String> row, String column) =>
+    int.tryParse(row[column] ?? '') ?? 0;
+
+/// Splits ForeFlight's `From`/`Route`/`To` columns into [Flight.route].
+/// `Route` holds any intermediate stops as whitespace-separated
+/// identifiers (irregular spacing observed in real exports, hence
+/// splitting on any run of whitespace rather than a single space).
+List<String> _route(Map<String, String> row) {
+  final from = row['From'] ?? '';
+  final to = row['To'] ?? '';
+  final intermediate = (row['Route'] ?? '')
+      .split(RegExp(r'\s+'))
+      .where((s) => s.isNotEmpty);
+  return [if (from.isNotEmpty) from, ...intermediate, if (to.isNotEmpty) to];
+}
+
+/// ForeFlight gives four counts (`DayTakeoffs`, `NightTakeoffs`,
+/// `DayLandingsFullStop`, `NightLandingsFullStop`, `AllLandings`) rather
+/// than this app's own four-way full-stop/touch-and-go split by day and
+/// night — CLAUDE.md rule 2's own list names that split as one of the
+/// facts a vendor import routinely can't reconstruct cleanly.
+///
+/// Takeoffs map directly — ForeFlight has no touch-and-go concept for a
+/// takeoff (a takeoff is a takeoff regardless of what preceded it), so
+/// `DayTakeoffs`/`NightTakeoffs` go straight into the full-stop slots with
+/// no ambiguity to flag.
+///
+/// Landings are genuinely ambiguous: `AllLandings` minus the full-stop
+/// counts is the touch-and-go count, but ForeFlight does not say how many
+/// of those were flown at night. The whole remainder is assigned to the
+/// day bucket — the far more common case — and the row is flagged for
+/// review whenever that remainder is nonzero, so a pilot with real night
+/// touch-and-goes catches the miscount rather than trusting a silent
+/// guess.
+({CircuitCounts takeoffs, CircuitCounts landings, String? note}) _circuitCounts(
+  Map<String, String> row,
+) {
+  final dayTakeoffs = _count(row, 'DayTakeoffs');
+  final nightTakeoffs = _count(row, 'NightTakeoffs');
+  final dayFullStop = _count(row, 'DayLandingsFullStop');
+  final nightFullStop = _count(row, 'NightLandingsFullStop');
+  final allLandings = _count(row, 'AllLandings');
+
+  final touchAndGo = allLandings - (dayFullStop + nightFullStop);
+  final dayTouchAndGo = touchAndGo > 0 ? touchAndGo : 0;
+
+  return (
+    takeoffs: CircuitCounts(
+      dayFullStop: dayTakeoffs,
+      nightFullStop: nightTakeoffs,
+    ),
+    landings: CircuitCounts(
+      dayFullStop: dayFullStop,
+      nightFullStop: nightFullStop,
+      dayTouchAndGo: dayTouchAndGo,
+    ),
+    note: dayTouchAndGo > 0
+        ? '$dayTouchAndGo touch-and-go landing(s) counted from AllLandings '
+              "minus the full-stop counts — ForeFlight doesn't say whether "
+              'they were flown by day or night; assigned to day, verify.'
+        : null,
+  );
+}
+
+/// Parses one `Approach1`..`Approach6` cell, formatted
+/// `count;description;runway;aerodrome;;[CIRCLE]` — e.g.
+/// `1;LOC RWY 27;27;LIMG;;` or `1;RNP A;13;LOAV;;CIRCLE`. Returns `null`
+/// for a blank cell; the caller adds a review note for a cell that isn't
+/// blank but doesn't parse, rather than dropping it silently.
+({Approach? approach, String? unparsed}) _parseApproach(String cell) {
+  if (cell.trim().isEmpty) return (approach: null, unparsed: null);
+
+  final parts = cell.split(';');
+  if (parts.length < 4) return (approach: null, unparsed: cell);
+
+  final count = int.tryParse(parts[0]) ?? 1;
+  final description = parts[1].toUpperCase();
+  final runway = parts[2];
+  final aerodrome = parts[3];
+  if (aerodrome.isEmpty) return (approach: null, unparsed: cell);
+
+  final type = switch (description) {
+    _ when description.contains('ILS') => ApproachType.ils,
+    _ when description.contains('RNAV') => ApproachType.rnav,
+    _ when description.contains('RNP') => ApproachType.rnav,
+    _ when description.contains('GNSS') => ApproachType.rnav,
+    _ when description.contains('GPS') => ApproachType.gps,
+    _ when description.contains('VOR') => ApproachType.vor,
+    _ when description.contains('NDB') => ApproachType.ndb,
+    _ when description.contains('TACAN') => ApproachType.tacan,
+    _ when description.contains('SDF') => ApproachType.sdf,
+    _ when description.contains('LDA') => ApproachType.lda,
+    _ when description.contains('MLS') => ApproachType.mls,
+    _ when description.contains('ASR') => ApproachType.asr,
+    _ when description.contains('PAR') => ApproachType.par,
+    // "LOC RWY 27" alone (no ILS prefix) is a stand-alone localizer
+    // approach — checked last since "ILS" and several others also
+    // contain runway text that could coincidentally include "LOC".
+    _ when description.contains('LOC') => ApproachType.loc,
+    _ => null,
+  };
+  if (type == null) return (approach: null, unparsed: cell);
+
+  return (
+    approach: Approach(
+      type: type,
+      aerodromeIcao: aerodrome,
+      runway: runway,
+      count: count,
+    ),
+    unparsed: null,
+  );
+}
+
+const _approachColumns = [
+  'Approach1',
+  'Approach2',
+  'Approach3',
+  'Approach4',
+  'Approach5',
+  'Approach6',
+];
+
+/// Columns folded into [PilotCapacity] or elsewhere on [Flight] directly,
+/// rather than surviving into [ForeFlightFlightMapping.unmappedFields] —
+/// listed once here so the "everything else" loop that builds
+/// unmappedFields knows what to skip.
+const _mappedColumns = {
+  'Date', 'AircraftID', 'From', 'To', 'Route',
+  'TimeOut', 'TimeOff', 'TimeOn', 'TimeIn',
+  'TotalTime', 'PIC', 'SIC', 'Solo', 'CrossCountry', 'PICUS', 'MultiPilot',
+  'IFR', 'Examiner', 'ActualInstrument', 'SimulatedInstrument',
+  'Holds', 'DualGiven', 'DualReceived', 'InstructorName',
+  'DayTakeoffs', 'DayLandingsFullStop', 'NightTakeoffs',
+  'NightLandingsFullStop', 'AllLandings',
+  // Legacy duplicates of DayTakeoffs/DayLandingsFullStop with no night
+  // counterpart — same values observed in every real row that populates
+  // both, so treated as redundant rather than unmapped.
+  'Takeoff Day', 'Takeoff Day Towered',
+  'Landing Full-Stop Day', 'Landing Full-Stop Day Towered',
+  'OnDuty', 'OffDuty', 'Night',
+  ..._approachColumns,
+};
+
+/// This pilot's [PilotCapacity] reverse-projected from ForeFlight's own
+/// derived hour columns — #69's central, "inherently lossy" problem.
+/// ForeFlight stores PIC/SIC/dual hours, not the raw command-authority/
+/// sole-manipulator/instructor-presence facts CLAUDE.md rule 2 requires;
+/// reconstructing one from the other is a best-effort classification of
+/// the common cases, never a guess dressed up as certainty — every branch
+/// that made a judgement call appends to [notes] rather than staying
+/// silent about it.
+PilotCapacity _classifyCapacity(Map<String, String> row, List<String> notes) {
+  final pic = _duration(row, 'PIC');
+  final sic = _duration(row, 'SIC');
+  final solo = _duration(row, 'Solo');
+  final picus = _duration(row, 'PICUS');
+  final multiPilot = _duration(row, 'MultiPilot');
+  final dualGiven = _duration(row, 'DualGiven');
+  final dualReceived = _duration(row, 'DualReceived');
+  final instructorName = row['InstructorName'] ?? '';
+
+  if (dualReceived.inMinutes > 0) {
+    notes.add(
+      'Logged as dual received from ForeFlight (instructor: '
+      '${instructorName.isEmpty ? "not named" : instructorName}) — EASA '
+      "SPIC vs. dual, and countersignature state, aren't recoverable from "
+      'ForeFlight\'s export and default to "not SPIC, no countersignature". '
+      'Verify against the paper/original record.',
+    );
+    return PilotCapacity(
+      commandAuthority: false,
+      soleManipulator: true,
+      soleOccupant: false,
+      multiPilotOperation: multiPilot.inMinutes > 0,
+      additionalCrewRequiredByRule: false,
+      actingAsInstructor: false,
+      actingAsExaminer: false,
+      picusClaimed: picus.inMinutes > 0,
+      picInterventionNotRequired: false,
+      instructor: InstructorPresence(
+        capacity: InstructorCapacity.flightInstructor,
+        influencedFlight: true,
+        name: instructorName.isEmpty ? null : instructorName,
+      ),
+    );
+  }
+
+  if (dualGiven.inMinutes > 0) {
+    notes.add(
+      'Logged as dual given from ForeFlight — this pilot is recorded as '
+      'the instructor. Whether the student was sole manipulator '
+      "isn't recoverable from ForeFlight's export; verify.",
+    );
+    return PilotCapacity(
+      commandAuthority: true,
+      soleManipulator: false,
+      soleOccupant: false,
+      multiPilotOperation: multiPilot.inMinutes > 0,
+      additionalCrewRequiredByRule: false,
+      actingAsInstructor: true,
+      actingAsExaminer: false,
+      picusClaimed: false,
+      picInterventionNotRequired: false,
+    );
+  }
+
+  if (picus.inMinutes > 0) {
+    notes.add(
+      'Logged as PICUS from ForeFlight — the countersignature and '
+      '"PIC intervention not required" state that make it creditable '
+      "under FCL.010 aren't recoverable from ForeFlight's export and "
+      'default to unset. Verify and countersign.',
+    );
+    return PilotCapacity(
+      commandAuthority: false,
+      soleManipulator: true,
+      soleOccupant: false,
+      multiPilotOperation: multiPilot.inMinutes > 0,
+      additionalCrewRequiredByRule: false,
+      actingAsInstructor: false,
+      actingAsExaminer: false,
+      picusClaimed: true,
+      picInterventionNotRequired: false,
+      instructor: instructorName.isEmpty
+          ? null
+          : InstructorPresence(
+              capacity: InstructorCapacity.flightInstructor,
+              influencedFlight: false,
+              name: instructorName,
+            ),
+    );
+  }
+
+  if (sic.inMinutes > 0) {
+    notes.add(
+      'Logged as SIC from ForeFlight — recorded as a multi-pilot '
+      'operation with this pilot not holding command authority; verify.',
+    );
+    return PilotCapacity(
+      commandAuthority: false,
+      soleManipulator: false,
+      soleOccupant: false,
+      multiPilotOperation: true,
+      additionalCrewRequiredByRule: true,
+      actingAsInstructor: false,
+      actingAsExaminer: false,
+      picusClaimed: false,
+      picInterventionNotRequired: false,
+    );
+  }
+
+  if (pic.inMinutes > 0) {
+    return PilotCapacity(
+      commandAuthority: true,
+      soleManipulator: true,
+      soleOccupant: solo.inMinutes > 0,
+      multiPilotOperation: multiPilot.inMinutes > 0,
+      additionalCrewRequiredByRule: false,
+      actingAsInstructor: false,
+      actingAsExaminer: false,
+      picusClaimed: false,
+      picInterventionNotRequired: false,
+    );
+  }
+
+  notes.add(
+    'None of ForeFlight\'s PIC/SIC/PICUS/dual columns were populated for '
+    "this row — pilot capacity couldn't be determined and defaults to "
+    'every flag unset. Verify.',
+  );
+  return const PilotCapacity(
+    commandAuthority: false,
+    soleManipulator: false,
+    soleOccupant: false,
+    multiPilotOperation: false,
+    additionalCrewRequiredByRule: false,
+    actingAsInstructor: false,
+    actingAsExaminer: false,
+    picusClaimed: false,
+    picInterventionNotRequired: false,
+  );
+}
+
+/// Maps one flights-table [row] to a [Flight] against the aircraft already
+/// resolved from the aircraft table ([aircraft] — `null` when the row's
+/// `AircraftID` has no canonical equivalent, per
+/// [mapForeFlightAircraft]'s own dartdoc: an FTD session, or an aircraft
+/// with no make/model on file).
+ForeFlightFlightMapping mapForeFlightFlight({
+  required Map<String, String> row,
+  required Aircraft? aircraft,
+}) {
+  final registration = row['AircraftID'] ?? '';
+  if (registration.isEmpty) {
+    return const ForeFlightFlightMapping.error(
+      'AircraftID is blank — cannot resolve which aircraft this flight was '
+      'flown in.',
+    );
+  }
+  if (aircraft == null) {
+    return ForeFlightFlightMapping.error(
+      'AircraftID "$registration" is either a flight training device '
+      '(FSTD sessions are not yet supported by this app — CLAUDE.md '
+      'defers them to a separate form) or has no make/model on file in '
+      "ForeFlight's own aircraft table. Add it under Aircraft management "
+      'and re-import, or skip this row.',
+    );
+  }
+
+  final offBlocks = _parseDateTime(row['Date'] ?? '', row['TimeOut'] ?? '');
+  var onBlocks = _parseDateTime(row['Date'] ?? '', row['TimeIn'] ?? '');
+  if (offBlocks == null || onBlocks == null) {
+    return const ForeFlightFlightMapping.error(
+      'Date, TimeOut or TimeIn is missing or unparseable — every flight '
+      'needs both block times.',
+    );
+  }
+  // A flight landing after midnight Zulu has an earlier time-of-day than
+  // it departed with; ForeFlight's Date column names the departure date
+  // only, so the day rolls over here rather than misreading the block
+  // time as negative.
+  if (onBlocks < offBlocks) onBlocks = onBlocks.add(const Duration(days: 1));
+
+  final takeoff = _parseDateTime(row['Date'] ?? '', row['TimeOff'] ?? '');
+  var landing = _parseDateTime(row['Date'] ?? '', row['TimeOn'] ?? '');
+  if (takeoff != null && landing != null && landing < takeoff) {
+    landing = landing.add(const Duration(days: 1));
+  }
+
+  final route = _route(row);
+  if (route.length < 2) {
+    return const ForeFlightFlightMapping.error(
+      'From and To are both blank — every flight needs at least a '
+      'departure and destination.',
+    );
+  }
+
+  final notes = <String>[];
+  final circuits = _circuitCounts(row);
+  if (circuits.note != null) notes.add(circuits.note!);
+
+  // Scoped to ForeFlight actually having logged cross-country hours, not
+  // merely "the route touches two different aerodromes" — the ordinary
+  // case for most flights, and flagging every one of them would drown out
+  // the genuinely useful notes in a full import.
+  final crossCountry = _duration(row, 'CrossCountry');
+  if (crossCountry.inMinutes > 0) {
+    notes.add(
+      "ForeFlight's CrossCountry column measures its own (FAA-style, "
+      "distance-based) definition, not EASA's FCL.010 pre-planned-"
+      'navigation test — prePlannedNavigation is left false. Set it '
+      'manually if this flight qualifies.',
+    );
+  }
+
+  final ifrHours = _duration(row, 'IFR');
+  final ifrFlightPlanFiled = ifrHours.inMinutes > 0;
+  if (ifrFlightPlanFiled) {
+    notes.add(
+      'ifrFlightPlanFiled inferred from ForeFlight logging IFR time on '
+      'this flight — verify.',
+    );
+  }
+
+  final approaches = <Approach>[];
+  for (final column in _approachColumns) {
+    final parsed = _parseApproach(row[column] ?? '');
+    if (parsed.approach != null) approaches.add(parsed.approach!);
+    if (parsed.unparsed != null) {
+      notes.add(
+        '$column ("${parsed.unparsed}") could not be parsed — dropped.',
+      );
+    }
+  }
+
+  final unmappedFields = <String, String>{};
+  for (final entry in row.entries) {
+    if (_mappedColumns.contains(entry.key)) continue;
+    if (entry.key.isEmpty || entry.value.isEmpty) continue;
+    unmappedFields[entry.key] = entry.value;
+  }
+
+  // The one custom field this adapter gives specific meaning to, rather
+  // than leaving as an opaque preserved string: ForeFlight's own
+  // `[Text]Safety pilot` field records the *other* pilot's name on a
+  // simulated-instrument flight — `Flight.otherPilotName` and
+  // `PilotCapacity.otherPilotRole` exist for exactly this
+  // (`§61.51(b)(1)(v)`). Any other `[Type]Label` custom field falls
+  // through to the generic unmappedFields loop above, preserved verbatim
+  // rather than interpreted.
+  String? otherPilotName;
+  var capacity = _classifyCapacity(row, notes);
+  for (final key in row.keys.where((k) => k.startsWith('['))) {
+    final match = RegExp(r'^\[(\w+)\](.+)$').firstMatch(key);
+    if (match == null) continue;
+    final label = match.group(2)!.trim();
+    final value = row[key] ?? '';
+    if (label.toLowerCase() == 'safety pilot' && value.trim().isNotEmpty) {
+      otherPilotName = value.trim();
+      capacity = capacity.copyWith(otherPilotRole: OtherPilotRole.safetyPilot);
+      unmappedFields.remove(key);
+    }
+  }
+
+  final flight = Flight(
+    aircraftRegistration: registration,
+    route: route,
+    prePlannedNavigation: false,
+    offBlocks: offBlocks,
+    onBlocks: onBlocks,
+    takeoff: takeoff,
+    landing: landing,
+    capacity: capacity,
+    otherPilotName: otherPilotName,
+    carryingPassengers: false,
+    takeoffs: circuits.takeoffs,
+    landings: circuits.landings,
+    ifrFlightPlanFiled: ifrFlightPlanFiled,
+    actualInstrumentTime: _duration(row, 'ActualInstrument'),
+    simulatedInstrumentTime: _duration(row, 'SimulatedInstrument'),
+    approaches: approaches,
+    holdingProceduresCount: _count(row, 'Holds'),
+    trackingPerformed: false,
+    remarks: '',
+  );
+
+  return ForeFlightFlightMapping.mapped(
+    flight: flight,
+    unmappedFields: unmappedFields,
+    reviewNotes: notes,
+  );
+}

--- a/lib/io/foreflight/foreflight_tables.dart
+++ b/lib/io/foreflight/foreflight_tables.dart
@@ -1,0 +1,113 @@
+import 'package:csv/csv.dart';
+
+/// The two embedded tables ForeFlight's `logbook_template.csv` always
+/// contains, in order — Aircraft, then Flights (#69) — each row already
+/// zipped against its own table's header into a `columnName -> rawValue`
+/// map. Values are plain strings, untouched; interpreting them (parsing a
+/// duration, classifying a capacity) is the mapper's job, not this file's.
+class ForeFlightTables {
+  const ForeFlightTables({
+    required this.aircraftRows,
+    required this.flightRows,
+    required this.flightDataStartLine,
+  });
+
+  final List<Map<String, String>> aircraftRows;
+  final List<Map<String, String>> flightRows;
+
+  /// 1-based position of the first row in [flightRows] within the
+  /// *decoded* file — not an index into [flightRows] itself, which knows
+  /// nothing about the aircraft table or header rows preceding it, and not
+  /// necessarily the exact line number in a text editor: `package:csv`
+  /// drops fully-blank lines (the separators between the preamble, the
+  /// aircraft table and the flights table) rather than emitting an empty
+  /// row for them, so this undercounts the true file line by however many
+  /// blank separator lines preceded it. Close enough for a pilot to find
+  /// the right row by counting, not a byte-exact file offset.
+  final int flightDataStartLine;
+}
+
+/// Marks the start of the aircraft table. ForeFlight always emits this
+/// exact text in the first cell of its own header row.
+const _aircraftTableMarker = 'Aircraft Table';
+
+/// Marks the start of the flights table. Observed with a trailing space in
+/// real exports (`'Flights Table '`) — matched by prefix, not equality, so
+/// a version without the trailing space still works.
+const _flightsTableMarkerPrefix = 'Flights Table';
+
+/// Splits [csvContent] into its two embedded tables.
+///
+/// Throws [FormatException] if either table marker is missing — a file
+/// that doesn't have this shape at all is not a ForeFlight export, and
+/// silently returning an empty result would look like "nothing to
+/// import" rather than "this isn't the right file".
+ForeFlightTables parseForeFlightTables(String csvContent) {
+  final allRows = Csv().decode(csvContent);
+
+  final aircraftMarkerIndex = allRows.indexWhere(
+    (row) =>
+        row.isNotEmpty && row.first.toString().trim() == _aircraftTableMarker,
+  );
+  if (aircraftMarkerIndex == -1) {
+    throw const FormatException(
+      'No "Aircraft Table" marker found — this does not look like a '
+      "ForeFlight logbook_template.csv export.",
+    );
+  }
+
+  final flightsMarkerIndex = allRows.indexWhere(
+    (row) =>
+        row.isNotEmpty &&
+        row.first.toString().trimRight().startsWith(_flightsTableMarkerPrefix),
+    aircraftMarkerIndex + 1,
+  );
+  if (flightsMarkerIndex == -1) {
+    throw const FormatException(
+      'No "Flights Table" marker found after the aircraft table — this '
+      "does not look like a complete ForeFlight logbook_template.csv "
+      'export.',
+    );
+  }
+
+  final aircraftHeaderRow = allRows[aircraftMarkerIndex + 1];
+  final aircraftDataRows = allRows.sublist(
+    aircraftMarkerIndex + 2,
+    flightsMarkerIndex,
+  );
+
+  final flightsHeaderRow = allRows[flightsMarkerIndex + 1];
+  final flightDataRows = allRows.sublist(flightsMarkerIndex + 2);
+
+  return ForeFlightTables(
+    aircraftRows: _zipRows(aircraftHeaderRow, aircraftDataRows),
+    flightRows: _zipRows(flightsHeaderRow, flightDataRows),
+    // +1 for 1-based, +1 to move past the flights header row itself.
+    flightDataStartLine: flightsMarkerIndex + 2 + 1,
+  );
+}
+
+bool _isBlankRow(List<dynamic> row) =>
+    row.every((cell) => cell.toString().trim().isEmpty);
+
+/// Zips each data row against [header] into a `columnName -> value` map,
+/// stopping at a blank row (both tables are padded to a shared column
+/// width with a blank separator row between them, not a fixed row count).
+List<Map<String, String>> _zipRows(
+  List<dynamic> header,
+  List<List<dynamic>> dataRows,
+) {
+  final headerNames = header.map((cell) => cell.toString().trim()).toList();
+  final rows = <Map<String, String>>[];
+
+  for (final row in dataRows) {
+    if (_isBlankRow(row)) break;
+    final map = <String, String>{};
+    for (var i = 0; i < headerNames.length; i++) {
+      map[headerNames[i]] = i < row.length ? row[i].toString().trim() : '';
+    }
+    rows.add(map);
+  }
+
+  return rows;
+}

--- a/test/io/foreflight/fixtures/logbook_template_sample.csv
+++ b/test/io/foreflight/fixtures/logbook_template_sample.csv
@@ -1,0 +1,22 @@
+ForeFlight Logbook Import,This row is required for importing into ForeFlight. Do not delete or modify.
+
+Aircraft Table
+AircraftID,TypeCode,Year,Make,Model,GearType,EngineType,equipType (FAA),aircraftClass (FAA),complexAircraft (FAA),taa (FAA),highPerformance (FAA),pressurized (FAA)
+N100AB,C172,,Cessna,C172P Skyhawk,fixed_tricycle,Piston,aircraft,airplane_single_engine_land,,,,
+N200CD,P28R,,Piper Aircraft,PA28-200 Arrow II,retractable_tricycle,Piston,aircraft,airplane_single_engine_land,TRUE,,,
+XXXX,,,,,,,aircraft,,,,,
+SIM01,P28R,,Piper Aircraft,PA28R-201 Arrow,retractable_tricycle,Piston,ftd,airplane_single_engine_land,,,,
+N300EF,SR20,,Cirrus Aircraft,SR20,fixed_tricycle,Piston,aircraft,airplane_single_engine_land,,TRUE,,
+
+Flights Table
+Date,AircraftID,From,To,Route,TimeOut,TimeOff,TimeOn,TimeIn,OnDuty,OffDuty,TotalTime,PIC,SIC,Night,Solo,CrossCountry,PICUS,MultiPilot,IFR,Examiner,NVG,NVG Ops,Distance,ActualInstrument,SimulatedInstrument,HobbsStart,HobbsEnd,TachStart,TachEnd,Holds,Approach1,Approach2,Approach3,Approach4,Approach5,Approach6,DualGiven,DualReceived,SimulatedFlight,GroundTraining,GroundTrainingGiven,InstructorName,InstructorComments,Person1,Person2,Person3,Person4,Person5,Person6,PilotComments,Flight Review (FAA),IPC (FAA),Checkride (FAA),FAA 61.58 (FAA),NVG Proficiency (FAA),Takeoff Day,Takeoff Day Towered,Landing Full-Stop Day,Landing Full-Stop Day Towered,DayTakeoffs,DayLandingsFullStop,NightTakeoffs,NightLandingsFullStop,AllLandings,[Text]Safety pilot
+2026-01-01,N100AB,KABC,KDEF,,14:00,14:02,15:28,15:30,,,1:30,1:30,0:00,,1:30,0:00,0:00,0:00,0:00,,,,,0:00,0:00,,,,,0,1;ILS RWY 27;27;KDEF;;,,,,,,0:00,0:00,,,,,,,,,,,,,,,,,,,,,,1,1,0,0,1,
+2026-01-02,N200CD,KABC,KABC,,09:00,09:05,10:25,10:30,,,1:30,0:00,0:00,,0:00,0:00,0:00,0:00,0:00,,,,,0:00,0:00,,,,,0,,,,,,,0:00,1:30,,,,Jane Instructor,,,,,,,,,,,,,,,,,,3,1,0,0,3,
+2026-01-03,N100AB,KABC,KGHI,,11:00,11:04,12:26,12:30,,,1:30,0:00,0:00,,0:00,1:30,1:30,0:00,0:00,,,,,0:00,0:00,,,,,0,,,,,,,0:00,0:00,,,,Jane Instructor,,,,,,,,,,,,,,,,,,1,1,0,0,1,
+2026-01-04,N100AB,KABC,KABC,,13:00,13:05,13:55,14:00,,,1:00,1:00,0:00,,1:00,0:00,0:00,0:00,0:00,,,,,0:00,0:00,,,,,0,,,,,,,0:00,0:00,,,,,,,,,,,,,,,,,,,,,,3,1,0,0,3,
+2026-01-05,XXXX,KABC,KABC,,08:00,08:05,08:55,09:00,,,1:00,1:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,1,1,,,1,
+2026-01-06,SIM01,,,,10:00,,,12:00,,,0:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2:00,Sam Trainer,,,,,,,,,,,,,,,,,,,,,,,
+2026-01-07,N300EF,KABC,KABC,,15:00,15:05,16:55,17:00,,,2:00,2:00,,,,,,,,,,,,,2:00,,,,,1,1;RNAV RWY 09;09;KABC;;,,,,,,,,,,,,,,,,,,,,,,,,,,,,,1,1,,,1,Alex Rivera
+2026-01-08,N100AB,KABC,KJKL,,23:50,23:55,00:15,00:20,,,0:30,0:30,,,0:30,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,1,1,1,
+2026-01-09,N200CD,KABC,KABC,,09:00,09:05,09:55,10:00,,,1:00,1:00,,,1:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"Great flight, smooth air throughout",,,,,,,,,,1,1,,,1,
+2026-01-10,N100AB,KABC,KABC,,10:00,10:05,10:55,11:00,,,1:00,1:00,,,1:00,,,,,,,,,,,,,,,0,1;VOR;09;;;,,,,,,,,,,,,,,,,,,,,,,,,,,,,,1,1,,,1,

--- a/test/io/foreflight/foreflight_adapter_test.dart
+++ b/test/io/foreflight/foreflight_adapter_test.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/io/foreflight/foreflight_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Exercises [ForeFlightAdapter] against an anonymised fixture built to
+/// mirror the real structural shape of a `logbook_template.csv` export
+/// (two embedded tables, a typed custom field, an FTD/equipType row, a
+/// blank-data placeholder aircraft, touch-and-go ambiguity, a quoted
+/// comma, an unparseable approach cell) without carrying anyone's real
+/// name or flight history — see the fixture file's own header for
+/// provenance.
+void main() {
+  late String csv;
+
+  setUpAll(() {
+    csv = File(
+      'test/io/foreflight/fixtures/logbook_template_sample.csv',
+    ).readAsStringSync();
+  });
+
+  test('maps every clean row and reports every unmappable one', () {
+    final result = ForeFlightAdapter().parse(csv);
+
+    expect(result.rows, hasLength(8));
+    expect(result.errors, hasLength(2));
+    expect(result.hasErrors, isTrue);
+  });
+
+  test('a plain solo PIC flight maps cleanly, with its approach parsed', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 11);
+
+    expect(row.flight.route, ['KABC', 'KDEF']);
+    expect(row.flight.capacity.commandAuthority, isTrue);
+    expect(row.flight.capacity.soleManipulator, isTrue);
+    expect(row.flight.capacity.soleOccupant, isTrue);
+    expect(row.flight.approaches, hasLength(1));
+    expect(row.flight.approaches.single.type, ApproachType.ils);
+    expect(row.flight.approaches.single.aerodromeIcao, 'KDEF');
+    expect(row.aircraft.registration, 'N100AB');
+    expect(row.reviewNotes, isEmpty);
+  });
+
+  test('dual received is mapped with commandAuthority false and a review '
+      'note about the SPIC/dual gap', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 12);
+
+    expect(row.flight.capacity.commandAuthority, isFalse);
+    expect(row.flight.capacity.instructor?.influencedFlight, isTrue);
+    expect(row.flight.capacity.instructor?.name, 'Jane Instructor');
+    expect(row.reviewNotes, contains(contains('SPIC vs. dual')));
+  });
+
+  test('a PICUS claim is mapped, flagged for countersignature review', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 13);
+
+    expect(row.flight.capacity.picusClaimed, isTrue);
+    expect(row.flight.capacity.commandAuthority, isFalse);
+    expect(row.reviewNotes, contains(contains('PICUS')));
+  });
+
+  test('AllLandings exceeding the full-stop counts is read as touch-and-go, '
+      'flagged for a day/night review', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 14);
+
+    expect(row.flight.landings.dayFullStop, 1);
+    expect(row.flight.landings.dayTouchAndGo, 2);
+    expect(row.flight.landings.nightTouchAndGo, 0);
+    expect(row.reviewNotes, contains(contains('touch-and-go')));
+  });
+
+  test(
+    'an aircraft row with no make/model becomes an error, never a guess',
+    () {
+      final result = ForeFlightAdapter().parse(csv);
+      final error = result.errors.firstWhere((e) => e.rowNumber == 15);
+
+      expect(error.message, contains('XXXX'));
+    },
+  );
+
+  test('a flight training device (equipType=ftd) becomes an error, never '
+      'imported as a regular aircraft flight', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final error = result.errors.firstWhere((e) => e.rowNumber == 16);
+
+    expect(error.message, contains('flight training device'));
+  });
+
+  test('the [Text]Safety pilot custom field maps to otherPilotName and '
+      'OtherPilotRole.safetyPilot, not a preserved string', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 17);
+
+    expect(row.flight.otherPilotName, 'Alex Rivera');
+    expect(row.flight.capacity.otherPilotRole, OtherPilotRole.safetyPilot);
+    expect(row.unmappedFields.containsKey('[Text]Safety pilot'), isFalse);
+  });
+
+  test('a flight crossing midnight Zulu rolls the on-blocks date forward '
+      'rather than reading as a negative block time', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 18);
+
+    expect(row.flight.offBlocks.toIso8601String(), '2026-01-08T23:50:00.000Z');
+    expect(row.flight.onBlocks.toIso8601String(), '2026-01-09T00:20:00.000Z');
+    expect(row.flight.onBlocks.difference(row.flight.offBlocks).inMinutes, 30);
+  });
+
+  test('a quoted field containing an embedded comma survives intact — proves '
+      'real CSV parsing, not a naive comma split', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 19);
+
+    expect(
+      row.unmappedFields['PilotComments'],
+      'Great flight, smooth air throughout',
+    );
+  });
+
+  test('an approach cell with no aerodrome is dropped with a review note, '
+      'not left in Flight.approaches and not failing the whole row', () {
+    final result = ForeFlightAdapter().parse(csv);
+    final row = result.rows.firstWhere((r) => r.sourceRowNumber == 20);
+
+    expect(row.flight.approaches, isEmpty);
+    expect(row.reviewNotes, contains(contains('could not be parsed')));
+  });
+
+  test(
+    'throws FormatException for a file with no ForeFlight table markers',
+    () {
+      expect(
+        () => ForeFlightAdapter().parse('just,some,csv\n1,2,3\n'),
+        throwsFormatException,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Parses ForeFlight's two-table `logbook_template.csv` export (Aircraft table, then Flights table), including typed `[Type]FieldName` custom fields, into the canonical `CanonicalImportRow` model from #68.
- Reverse-projects ForeFlight's derived PIC/SIC/dual/PICUS hour columns back into raw `PilotCapacity` facts — the lossy direction CLAUDE.md rule 2 warns about — flagging every ambiguous case (SPIC vs. dual, a PICUS claim, touch-and-go landings inferred from `AllLandings`) with a review note instead of silently guessing.
- Rows that can't be mapped at all (an FTD/`equipType=ftd` row, or an aircraft-table entry with no make/model) become a per-row `ImportRowError` rather than a fabricated `Aircraft`.
- Test fixture is a synthetic, anonymised CSV built to mirror the structural shape of a real ForeFlight export without carrying anyone's real name or flight history.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 763/763 passing
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_no_networking.dart` / `check_schema_snapshot.dart` — all clean
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 96.1% (threshold 90%)
- [x] `dart run tool/check_io_vendor_leak.dart` — no vendor identifier outside `lib/io/`
- [x] Formatting verified against CI-pinned Flutter 3.44.0's `dart format`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)