### PR TITLE
feat: duplicate detection for import (#75)

### DIFF
--- a/lib/io/duplicate_matcher.dart
+++ b/lib/io/duplicate_matcher.dart
@@ -1,0 +1,187 @@
+import '../domain/model/flight.dart';
+import '../domain/model/utc_instant.dart';
+import '../domain/repository/flight_read_repository.dart';
+import 'canonical_import_row.dart';
+
+/// How confident [findDuplicate] is that a candidate flight is the same
+/// real flight as an existing one.
+enum DuplicateConfidence {
+  /// Same aircraft, identical route (every leg, in order) and identical
+  /// block times to the minute. About as certain as two independently
+  /// recorded flights can be.
+  exact,
+
+  /// Same aircraft, same departure and destination, and block times within
+  /// the matcher's tolerance — plausibly the same flight recorded slightly
+  /// differently by two sources (rounding, a dropped intermediate stop),
+  /// but not identical enough to auto-skip without a look.
+  likely,
+}
+
+/// One candidate duplicate found for an incoming flight, naming which
+/// already-stored flight it plausibly repeats and why. Never used to *skip*
+/// an import on its own (#75's own acceptance criteria: a per-row
+/// skip/import choice, not a silent drop) — the preview step (#73) is
+/// responsible for surfacing this to the pilot and defaulting the checkbox,
+/// never for acting on it unattended.
+class DuplicateMatch {
+  const DuplicateMatch({
+    required this.confidence,
+    required this.existingFlightId,
+    required this.reason,
+  });
+
+  /// [FlightRecord.id] of the existing flight this candidate plausibly
+  /// repeats — a draft or a committed flight; the caller decides which
+  /// pools to check by what it puts in [findDuplicate]'s `existingFlights`.
+  final String existingFlightId;
+
+  final DuplicateConfidence confidence;
+
+  /// Plain-language explanation for the preview UI — CLAUDE.md's "never
+  /// showing a red or green pill" spirit applied to duplicates: a pilot
+  /// deciding whether to skip a row needs to know *why* it was flagged, not
+  /// just that it was.
+  final String reason;
+}
+
+/// Default tolerance for [DuplicateConfidence.likely] — wide enough to
+/// absorb rounding and cross-vendor drift (a source logging to the nearest
+/// minute versus one logging to the second, or a decimal-hours vendor
+/// rounding a total differently), narrow enough that two genuinely distinct
+/// same-day repeat flights (#75's own worked example: "two identical
+/// circuits an hour apart") never collide with it.
+const Duration _defaultTolerance = Duration(minutes: 5);
+
+String _normalize(String value) => value.trim().toUpperCase();
+
+bool _sameAircraft(Flight a, Flight b) =>
+    _normalize(a.aircraftRegistration) == _normalize(b.aircraftRegistration);
+
+bool _sameFullRoute(Flight a, Flight b) {
+  if (a.route.length != b.route.length) return false;
+  for (var i = 0; i < a.route.length; i++) {
+    if (_normalize(a.route[i]) != _normalize(b.route[i])) return false;
+  }
+  return true;
+}
+
+bool _sameDepartureAndDestination(Flight a, Flight b) {
+  if (a.route.isEmpty || b.route.isEmpty) return false;
+  return _normalize(a.route.first) == _normalize(b.route.first) &&
+      _normalize(a.route.last) == _normalize(b.route.last);
+}
+
+Duration _absoluteDifference(UtcInstant a, UtcInstant b) {
+  final diff = a.difference(b);
+  return diff.isNegative ? -diff : diff;
+}
+
+/// [DuplicateConfidence.exact] outranks [DuplicateConfidence.likely]
+/// regardless of time difference — a closer-in-time `likely` match is still
+/// a worse candidate than a byte-identical `exact` one.
+int _confidenceRank(DuplicateConfidence confidence) =>
+    confidence == DuplicateConfidence.exact ? 0 : 1;
+
+/// Finds the best candidate duplicate for [candidate] among
+/// [existingFlights] (typically a caller's combined drafts + committed
+/// flights, pre-filtered to roughly the imported date range for
+/// performance — this function does no filtering of its own), or `null`
+/// when nothing plausibly matches.
+///
+/// Matching is keyed on aircraft, route and block times — #75's own
+/// acceptance criteria — deliberately *not* on a separate "date" field
+/// (`Flight` has none; a date is `offBlocks`'s UTC calendar date). Comparing
+/// `offBlocks`/`onBlocks` directly, rather than pre-filtering by calendar
+/// date, means a flight that crosses midnight Zulu and gets attributed to
+/// different nominal dates by two sources still matches correctly.
+///
+/// [tolerance] governs [DuplicateConfidence.likely] only — [exact] always
+/// requires identical route and block times, since "identical apart from
+/// rounding" is exactly what [likely] is for.
+DuplicateMatch? findDuplicate({
+  required Flight candidate,
+  required List<FlightRecord> existingFlights,
+  Duration tolerance = _defaultTolerance,
+}) {
+  FlightRecord? bestMatch;
+  DuplicateConfidence? bestConfidence;
+  Duration? bestDistance;
+
+  for (final existing in existingFlights) {
+    final other = existing.flight;
+    if (!_sameAircraft(candidate, other)) continue;
+
+    final offBlocksDiff = _absoluteDifference(
+      candidate.offBlocks,
+      other.offBlocks,
+    );
+    final onBlocksDiff = _absoluteDifference(
+      candidate.onBlocks,
+      other.onBlocks,
+    );
+
+    DuplicateConfidence? confidence;
+    if (_sameFullRoute(candidate, other) &&
+        offBlocksDiff == Duration.zero &&
+        onBlocksDiff == Duration.zero) {
+      confidence = DuplicateConfidence.exact;
+    } else if (_sameDepartureAndDestination(candidate, other) &&
+        offBlocksDiff <= tolerance &&
+        onBlocksDiff <= tolerance) {
+      confidence = DuplicateConfidence.likely;
+    }
+    if (confidence == null) continue;
+
+    final distance = offBlocksDiff + onBlocksDiff;
+    final isBetter =
+        bestConfidence == null ||
+        _confidenceRank(confidence) < _confidenceRank(bestConfidence) ||
+        (_confidenceRank(confidence) == _confidenceRank(bestConfidence) &&
+            distance < bestDistance!);
+    if (isBetter) {
+      bestMatch = existing;
+      bestConfidence = confidence;
+      bestDistance = distance;
+    }
+  }
+
+  if (bestMatch == null || bestConfidence == null) return null;
+
+  final reason = bestConfidence == DuplicateConfidence.exact
+      ? 'Same aircraft, route and block times as a flight already in your '
+            'logbook.'
+      : 'Same aircraft and departure/destination as a flight already in '
+            'your logbook, with block times within '
+            '${tolerance.inMinutes} minute(s) — likely the same flight, '
+            'recorded slightly differently. Compare before deciding.';
+
+  return DuplicateMatch(
+    confidence: bestConfidence,
+    existingFlightId: bestMatch.id,
+    reason: reason,
+  );
+}
+
+/// Runs [findDuplicate] for every row in [incoming] against the same
+/// [existingFlights] pool, returning one result per row in the same order
+/// — so a preview screen (#73) can zip `incoming` against the result to
+/// pair each row with its verdict (`null` meaning "looks new").
+///
+/// This is the shape #75's "bulk actions for a wholly overlapping range"
+/// criterion is built on: a preview screen offering "skip all duplicates"
+/// is just filtering this list for non-null entries, not additional
+/// matching logic — there is nothing file-level to detect here beyond what
+/// each row's own match already says.
+List<DuplicateMatch?> findDuplicates({
+  required List<CanonicalImportRow> incoming,
+  required List<FlightRecord> existingFlights,
+  Duration tolerance = _defaultTolerance,
+}) => [
+  for (final row in incoming)
+    findDuplicate(
+      candidate: row.flight,
+      existingFlights: existingFlights,
+      tolerance: tolerance,
+    ),
+];

--- a/test/io/duplicate_matcher_test.dart
+++ b/test/io/duplicate_matcher_test.dart
@@ -1,0 +1,301 @@
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/io/canonical_import_row.dart';
+import 'package:easa_digital_log/io/duplicate_matcher.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({
+  String registration = 'N100AB',
+  List<String> route = const ['KABC', 'KDEF'],
+  required UtcInstant offBlocks,
+  required UtcInstant onBlocks,
+}) => Flight(
+  aircraftRegistration: registration,
+  route: route,
+  prePlannedNavigation: false,
+  offBlocks: offBlocks,
+  onBlocks: onBlocks,
+  capacity: _capacity,
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+FlightRecord _record(String id, Flight flight) => FlightRecord(
+  id: id,
+  flight: flight,
+  aircraft: Aircraft(
+    registration: flight.aircraftRegistration,
+    manufacturer: 'Unknown',
+    model: 'Unknown',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 1,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+  ),
+);
+
+final _base = UtcInstant.utc(2026, 1, 1, 10, 0);
+
+void main() {
+  test('identical aircraft, route and block times is an exact duplicate', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final candidate = _flight(
+      offBlocks: _base,
+      onBlocks: _base.add(const Duration(minutes: 90)),
+    );
+
+    final match = findDuplicate(
+      candidate: candidate,
+      existingFlights: [existing],
+    );
+
+    expect(match?.confidence, DuplicateConfidence.exact);
+    expect(match?.existingFlightId, 'e1');
+  });
+
+  test('the same flight logged a couple of minutes apart (rounding) is a '
+      'likely duplicate, not exact', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final candidate = _flight(
+      offBlocks: _base.add(const Duration(minutes: 2)),
+      onBlocks: _base.add(const Duration(minutes: 92)),
+    );
+
+    final match = findDuplicate(
+      candidate: candidate,
+      existingFlights: [existing],
+    );
+
+    expect(match?.confidence, DuplicateConfidence.likely);
+    expect(match?.existingFlightId, 'e1');
+  });
+
+  test('two identical circuits an hour apart are genuinely distinct flights, '
+      'not duplicates', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final candidate = _flight(
+      offBlocks: _base.add(const Duration(hours: 1)),
+      onBlocks: _base.add(const Duration(hours: 1, minutes: 90)),
+    );
+
+    final match = findDuplicate(
+      candidate: candidate,
+      existingFlights: [existing],
+    );
+
+    expect(match, isNull);
+  });
+
+  test('a different aircraft flying the same route at the same time is not '
+      'a duplicate', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        registration: 'N100AB',
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final candidate = _flight(
+      registration: 'N999ZZ',
+      offBlocks: _base,
+      onBlocks: _base.add(const Duration(minutes: 90)),
+    );
+
+    final match = findDuplicate(
+      candidate: candidate,
+      existingFlights: [existing],
+    );
+
+    expect(match, isNull);
+  });
+
+  test('the same aircraft at the same time but a different destination is '
+      'not a duplicate', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        route: const ['KABC', 'KDEF'],
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final candidate = _flight(
+      route: const ['KABC', 'KXYZ'],
+      offBlocks: _base,
+      onBlocks: _base.add(const Duration(minutes: 90)),
+    );
+
+    final match = findDuplicate(
+      candidate: candidate,
+      existingFlights: [existing],
+    );
+
+    expect(match, isNull);
+  });
+
+  test('the tolerance boundary is inclusive at 5 minutes and exclusive just '
+      'past it', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+
+    final atBoundary = _flight(
+      offBlocks: _base.add(const Duration(minutes: 5)),
+      onBlocks: _base.add(const Duration(minutes: 95)),
+    );
+    expect(
+      findDuplicate(
+        candidate: atBoundary,
+        existingFlights: [existing],
+      )?.confidence,
+      DuplicateConfidence.likely,
+    );
+
+    final pastBoundary = _flight(
+      offBlocks: _base.add(const Duration(minutes: 6)),
+      onBlocks: _base.add(const Duration(minutes: 96)),
+    );
+    expect(
+      findDuplicate(candidate: pastBoundary, existingFlights: [existing]),
+      isNull,
+    );
+  });
+
+  test(
+    'aircraft registration matching is case- and whitespace-insensitive',
+    () {
+      final existing = _record(
+        'e1',
+        _flight(
+          registration: 'N100AB',
+          offBlocks: _base,
+          onBlocks: _base.add(const Duration(minutes: 90)),
+        ),
+      );
+      final candidate = _flight(
+        registration: ' n100ab ',
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      );
+
+      final match = findDuplicate(
+        candidate: candidate,
+        existingFlights: [existing],
+      );
+
+      expect(match?.confidence, DuplicateConfidence.exact);
+    },
+  );
+
+  test('an exact match is preferred over a closer-in-list likely match', () {
+    final likelyButFirst = _record(
+      'likely',
+      _flight(
+        offBlocks: _base.add(const Duration(minutes: 1)),
+        onBlocks: _base.add(const Duration(minutes: 91)),
+      ),
+    );
+    final exactButSecond = _record(
+      'exact',
+      _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final candidate = _flight(
+      offBlocks: _base,
+      onBlocks: _base.add(const Duration(minutes: 90)),
+    );
+
+    final match = findDuplicate(
+      candidate: candidate,
+      existingFlights: [likelyButFirst, exactButSecond],
+    );
+
+    expect(match?.confidence, DuplicateConfidence.exact);
+    expect(match?.existingFlightId, 'exact');
+  });
+
+  test('findDuplicates maps every row to its own verdict, in order', () {
+    final existing = _record(
+      'e1',
+      _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+    );
+    final duplicateRow = CanonicalImportRow(
+      sourceRowNumber: 2,
+      flight: _flight(
+        offBlocks: _base,
+        onBlocks: _base.add(const Duration(minutes: 90)),
+      ),
+      aircraft: existing.aircraft,
+    );
+    final newRow = CanonicalImportRow(
+      sourceRowNumber: 3,
+      flight: _flight(
+        offBlocks: _base.add(const Duration(hours: 1)),
+        onBlocks: _base.add(const Duration(hours: 1, minutes: 90)),
+      ),
+      aircraft: existing.aircraft,
+    );
+
+    final matches = findDuplicates(
+      incoming: [duplicateRow, newRow],
+      existingFlights: [existing],
+    );
+
+    expect(matches, hasLength(2));
+    expect(matches[0]?.confidence, DuplicateConfidence.exact);
+    expect(matches[1], isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `findDuplicate`/`findDuplicates` in `lib/io/duplicate_matcher.dart` — a pure matcher comparing an incoming `Flight` against a pool of existing `FlightRecord`s (drafts and/or committed; the caller decides which pools to include) on aircraft registration, route and block times.
- Two confidence tiers: `exact` requires identical aircraft, full route and byte-identical block times; `likely` requires only matching departure/destination and block times within a tolerance (default 5 minutes), absorbing the kind of rounding drift you'd see between two sources logging the same flight.
- Deliberately keyed off `offBlocks`/`onBlocks` directly rather than a separate calendar-date field (`Flight` has none) — a flight crossing midnight Zulu still matches correctly regardless of which nominal date two sources attribute it to.
- The matcher only classifies — it never skips a row itself. Acting on a match (defaulting a preview checkbox, offering a "skip all duplicates" bulk action for a wholly overlapping re-import) is #73's transactional-import-pipeline job, not yet built; this supplies the per-row verdict that pipeline will consume.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 786/786 passing
- [x] New tests cover: exact duplicates, near-duplicates from rounding, the tolerance boundary (inclusive/exclusive), a different aircraft, a different destination, case-insensitive registration matching, exact-preferred-over-likely tie-breaking, and the issue's own worked counter-example — two identical circuits an hour apart are genuinely distinct flights, not duplicates
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_no_networking.dart` / `check_schema_snapshot.dart` — all clean
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 96.2% (threshold 90%)
- [x] `dart run tool/check_io_vendor_leak.dart` — no vendor identifier outside `lib/io/`
- [x] Formatting verified against CI-pinned Flutter 3.44.0's `dart format`

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)