### PR TITLE
feat: ForeFlight exporter with FAA-projected derived values (#70)

### DIFF
--- a/lib/io/foreflight/foreflight_aircraft_exporter.dart
+++ b/lib/io/foreflight/foreflight_aircraft_exporter.dart
@@ -1,0 +1,129 @@
+import '../../domain/model/aircraft.dart';
+
+const _easaJurisdictionId = 'eu.easa.part-fcl';
+const _faaJurisdictionId = 'us.faa.part61';
+
+/// Reverse of `foreflight_aircraft_mapper.dart`'s `_engineTypes` map.
+/// [EngineType.none] has no ForeFlight string — the import side only ever
+/// produces it as a fallback for an unrecognised value, so there is nothing
+/// authentic to write back.
+const Map<EngineType, String> _engineTypeStrings = {
+  EngineType.piston: 'Piston',
+  EngineType.turboprop: 'Turboprop',
+  EngineType.turbojet: 'Turbojet',
+  EngineType.turbofan: 'Turbofan',
+  EngineType.electric: 'Electric',
+};
+
+bool _hasQualification(
+  Aircraft aircraft,
+  String jurisdictionId,
+  AircraftQualification qualification,
+) =>
+    aircraft.requiredQualifications[jurisdictionId]?.contains(qualification) ??
+    false;
+
+/// Reverse of `foreflight_aircraft_mapper.dart`'s `_isTailwheel`/
+/// `_isRetractable` string parsing — either jurisdiction recording tailwheel
+/// is enough evidence to write it back; retractable gear has no FAA
+/// qualification value in this app's model at all (`§61.31(e)`'s complex
+/// endorsement folds it in with flaps and a controllable-pitch prop instead
+/// of tracking it alone), so only the EASA flag is checked for it.
+String _gearType(Aircraft aircraft) {
+  final tailwheel =
+      _hasQualification(
+        aircraft,
+        _faaJurisdictionId,
+        AircraftQualification.faaTailwheel,
+      ) ||
+      _hasQualification(
+        aircraft,
+        _easaJurisdictionId,
+        AircraftQualification.easaTailwheel,
+      );
+  final retractable = _hasQualification(
+    aircraft,
+    _easaJurisdictionId,
+    AircraftQualification.easaRetractableUndercarriage,
+  );
+
+  return switch ((tailwheel, retractable)) {
+    (true, true) => 'retractable_tailwheel',
+    (true, false) => 'fixed_tailwheel',
+    (false, true) => 'retractable_tricycle',
+    (false, false) => 'fixed_tricycle',
+  };
+}
+
+/// Reverse of `foreflight_aircraft_mapper.dart`'s `_parseAircraftClass` —
+/// only reconstructed precisely enough for the import side's own
+/// `startsWith`/`contains` checks to recover [Aircraft.category],
+/// [Aircraft.engineCount] and [Aircraft.operatingSurface] correctly; the
+/// exact string ForeFlight itself would have generated for helicopters,
+/// gliders and lighter-than-air categories is not otherwise reconstructed
+/// (this app has no more detail than the bare category for those).
+String? _aircraftClass(Aircraft aircraft) {
+  final surface = switch (aircraft.operatingSurface) {
+    OperatingSurface.amphibian => 'amphibian',
+    OperatingSurface.sea => 'sea',
+    OperatingSurface.land => 'land',
+  };
+  final engineArity = aircraft.engineCount > 1
+      ? 'multi_engine'
+      : 'single_engine';
+
+  return switch (aircraft.category) {
+    AircraftCategory.aeroplane => 'airplane_${engineArity}_$surface',
+    AircraftCategory.helicopter => 'helicopter',
+    AircraftCategory.glider => 'glider',
+    AircraftCategory.poweredLift => 'powered_lift',
+    AircraftCategory.airship => 'lighter_than_air_airship',
+    AircraftCategory.balloon => 'lighter_than_air_balloon',
+    // touringMotorGlider/poweredParachute: no ForeFlight aircraftClass
+    // string is known to correspond to either — left blank rather than
+    // guessing one that its own importer wouldn't recognise anyway.
+    AircraftCategory.touringMotorGlider ||
+    AircraftCategory.poweredParachute => null,
+  };
+}
+
+/// Maps [aircraft] to one row of ForeFlight's aircraft-table columns
+/// (`AircraftID`..`pressurized (FAA)`), the reverse of
+/// `foreflight_aircraft_mapper.dart`'s `mapForeFlightAircraft`.
+///
+/// `Year`, `taa (FAA)` and `pressurized (FAA)` are always blank — this
+/// app's [Aircraft] carries no year-built field, and the import side's own
+/// dartdoc already documents `taa`/`pressurized` as having no canonical
+/// equivalent to read back from. `equipType (FAA)` is always `aircraft`:
+/// this app never creates an [Aircraft] record for a simulator (FSTD
+/// sessions are a separate, unbuilt form — CLAUDE.md), so there is never a
+/// `ftd` row to write.
+Map<String, String> exportForeFlightAircraftRow(Aircraft aircraft) => {
+  'AircraftID': aircraft.registration,
+  'TypeCode': aircraft.icaoTypeDesignator ?? '',
+  'Year': '',
+  'Make': aircraft.manufacturer,
+  'Model': aircraft.model,
+  'GearType': _gearType(aircraft),
+  'EngineType': _engineTypeStrings[aircraft.engineType] ?? '',
+  'equipType (FAA)': 'aircraft',
+  'aircraftClass (FAA)': _aircraftClass(aircraft) ?? '',
+  'complexAircraft (FAA)':
+      _hasQualification(
+        aircraft,
+        _faaJurisdictionId,
+        AircraftQualification.faaComplex,
+      )
+      ? 'TRUE'
+      : '',
+  'taa (FAA)': '',
+  'highPerformance (FAA)':
+      _hasQualification(
+        aircraft,
+        _faaJurisdictionId,
+        AircraftQualification.faaHighPerformance,
+      )
+      ? 'TRUE'
+      : '',
+  'pressurized (FAA)': '',
+};

--- a/lib/io/foreflight/foreflight_exporter.dart
+++ b/lib/io/foreflight/foreflight_exporter.dart
@@ -1,0 +1,172 @@
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/calendar_date.dart';
+import '../../domain/projection/projection.dart';
+import '../../domain/repository/flight_read_repository.dart';
+import 'foreflight_aircraft_exporter.dart';
+import 'foreflight_flight_exporter.dart';
+
+/// Column order for ForeFlight's aircraft table — load-bearing (#70).
+/// Verified against a real ForeFlight export during #69's development.
+const _aircraftHeader = [
+  'AircraftID',
+  'TypeCode',
+  'Year',
+  'Make',
+  'Model',
+  'GearType',
+  'EngineType',
+  'equipType (FAA)',
+  'aircraftClass (FAA)',
+  'complexAircraft (FAA)',
+  'taa (FAA)',
+  'highPerformance (FAA)',
+  'pressurized (FAA)',
+];
+
+/// Column order for ForeFlight's flights table — load-bearing (#70).
+/// Verified against a real ForeFlight export during #69's development.
+/// Deliberately omits any `[Type]Label` custom field column: those are
+/// per-ForeFlight-account definitions this app has no schema for, not a
+/// fixed part of the format.
+const _flightHeader = [
+  'Date',
+  'AircraftID',
+  'From',
+  'To',
+  'Route',
+  'TimeOut',
+  'TimeOff',
+  'TimeOn',
+  'TimeIn',
+  'OnDuty',
+  'OffDuty',
+  'TotalTime',
+  'PIC',
+  'SIC',
+  'Night',
+  'Solo',
+  'CrossCountry',
+  'PICUS',
+  'MultiPilot',
+  'IFR',
+  'Examiner',
+  'NVG',
+  'NVG Ops',
+  'Distance',
+  'ActualInstrument',
+  'SimulatedInstrument',
+  'HobbsStart',
+  'HobbsEnd',
+  'TachStart',
+  'TachEnd',
+  'Holds',
+  'Approach1',
+  'Approach2',
+  'Approach3',
+  'Approach4',
+  'Approach5',
+  'Approach6',
+  'DualGiven',
+  'DualReceived',
+  'SimulatedFlight',
+  'GroundTraining',
+  'GroundTrainingGiven',
+  'InstructorName',
+  'InstructorComments',
+  'Person1',
+  'Person2',
+  'Person3',
+  'Person4',
+  'Person5',
+  'Person6',
+  'PilotComments',
+  'Flight Review (FAA)',
+  'IPC (FAA)',
+  'Checkride (FAA)',
+  'FAA 61.58 (FAA)',
+  'NVG Proficiency (FAA)',
+  'Takeoff Day',
+  'Takeoff Day Towered',
+  'Landing Full-Stop Day',
+  'Landing Full-Stop Day Towered',
+  'DayTakeoffs',
+  'DayLandingsFullStop',
+  'NightTakeoffs',
+  'NightLandingsFullStop',
+  'AllLandings',
+];
+
+String _csvField(String value) {
+  if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+    return '"${value.replaceAll('"', '""')}"';
+  }
+  return value;
+}
+
+String _csvRow(List<String> header, Map<String, String> values) =>
+    header.map((column) => _csvField(values[column] ?? '')).join(',');
+
+/// Builds a ForeFlight `logbook_template.csv` export from [flights],
+/// deriving jurisdiction-dependent figures via [faaProjection] (#70).
+/// Column order and header names exactly match a real ForeFlight export —
+/// required for the file to be accepted back into ForeFlight itself, not
+/// just this app's own importer.
+///
+/// [flights] is exactly what the caller wants exported — this function
+/// does no date-range filtering of its own. #70's mandatory range
+/// selection is the caller's job (via `FlightQuery.from`/`to` against
+/// `FlightReadRepository`), the same division of responsibility the import
+/// adapters use for resolving aircraft: pure transformation here, I/O and
+/// selection above it.
+///
+/// Aircraft are listed once each, in order of first appearance among
+/// [flights], deduplicated by registration.
+String exportForeFlightCsv({
+  required List<FlightRecord> flights,
+  required Projection faaProjection,
+}) {
+  final buffer = StringBuffer();
+  buffer.writeln(
+    'ForeFlight Logbook Import,This row is required for importing into '
+    'ForeFlight. Do not delete or modify.',
+  );
+  buffer.writeln();
+
+  final aircraftByRegistration = <String, Aircraft>{
+    for (final record in flights) record.aircraft.registration: record.aircraft,
+  };
+
+  buffer.writeln('Aircraft Table');
+  buffer.writeln(_aircraftHeader.join(','));
+  for (final aircraft in aircraftByRegistration.values) {
+    buffer.writeln(
+      _csvRow(_aircraftHeader, exportForeFlightAircraftRow(aircraft)),
+    );
+  }
+  buffer.writeln();
+
+  // Trailing space matches a real ForeFlight export's own marker exactly
+  // — `foreflight_tables.dart`'s import-side parser tolerates either, but
+  // this file also needs to satisfy ForeFlight's own importer, not just
+  // this app's.
+  buffer.writeln('Flights Table ');
+  buffer.writeln(_flightHeader.join(','));
+  for (final record in flights) {
+    final row = exportForeFlightFlightRow(
+      flight: record.flight,
+      aircraft: record.aircraft,
+      faaProjection: faaProjection,
+    );
+    buffer.writeln(_csvRow(_flightHeader, row));
+  }
+
+  return buffer.toString();
+}
+
+/// The filename #70 requires: the export range embedded so a pilot (or a
+/// future overlap check) can see at a glance what a file covers without
+/// opening it — e.g. `logbook_template_2026-01-01_to_2026-06-30.csv`.
+String foreFlightExportFilename({
+  required CalendarDate from,
+  required CalendarDate to,
+}) => 'logbook_template_${from}_to_$to.csv';

--- a/lib/io/foreflight/foreflight_flight_exporter.dart
+++ b/lib/io/foreflight/foreflight_flight_exporter.dart
@@ -1,0 +1,198 @@
+import '../../domain/model/aircraft.dart';
+import '../../domain/model/flight.dart';
+import '../../domain/model/flight_duration.dart';
+import '../../domain/model/flight_times.dart';
+import '../../domain/model/instructor_presence.dart';
+import '../../domain/model/pilot_capacity.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/projection/projection.dart';
+import '../../domain/projection/projection_result.dart';
+
+String _twoDigits(int value) => value.toString().padLeft(2, '0');
+
+String _formatDate(UtcInstant instant) {
+  final utc = instant.asUtcDateTime;
+  return '${utc.year.toString().padLeft(4, '0')}-'
+      '${_twoDigits(utc.month)}-${_twoDigits(utc.day)}';
+}
+
+String _formatTime(UtcInstant instant) {
+  final utc = instant.asUtcDateTime;
+  return '${_twoDigits(utc.hour)}:${_twoDigits(utc.minute)}';
+}
+
+String _formatDuration(FlightDuration duration) =>
+    duration.inMinutes == 0 ? '0:00' : duration.toHoursMinutes();
+
+FlightDuration _quantity(ProjectionResult result, String name) =>
+    result[name]?.value ?? FlightDuration.zero;
+
+/// Reverse of `foreflight_flight_mapper.dart`'s approach-type keyword
+/// classification. [ApproachType.backCourse] has no import-side keyword at
+/// all (its own switch never checks for one) — `LOC BC` is written back as
+/// the closest honest label, but re-importing it will classify it as a
+/// plain [ApproachType.loc], the same known, one-way gap the import side
+/// already documents for values it cannot recognise.
+String _approachTypeLabel(ApproachType type) => switch (type) {
+  ApproachType.ils => 'ILS',
+  ApproachType.rnav => 'RNAV',
+  ApproachType.gps => 'GPS',
+  ApproachType.vor => 'VOR',
+  ApproachType.loc => 'LOC',
+  ApproachType.ndb => 'NDB',
+  ApproachType.backCourse => 'LOC BC',
+  ApproachType.lda => 'LDA',
+  ApproachType.sdf => 'SDF',
+  ApproachType.tacan => 'TACAN',
+  ApproachType.par => 'PAR',
+  ApproachType.asr => 'ASR',
+  ApproachType.mls => 'MLS',
+};
+
+/// Formats one [Approach] as ForeFlight's `count;description;runway;
+/// aerodrome;;[CIRCLE]` cell — the reverse of
+/// `foreflight_flight_mapper.dart`'s `_parseApproach`. Never emits the
+/// trailing `CIRCLE` marker: this app has no "circling approach" fact to
+/// read it back from.
+String _formatApproach(Approach approach) =>
+    '${approach.count};${_approachTypeLabel(approach.type)} RWY '
+    '${approach.runway};${approach.runway};${approach.aerodromeIcao};;';
+
+const _approachColumns = [
+  'Approach1',
+  'Approach2',
+  'Approach3',
+  'Approach4',
+  'Approach5',
+  'Approach6',
+];
+
+/// Maps one [flight] flown in [aircraft] to a row of ForeFlight's flights
+/// table columns, computing every jurisdiction-dependent figure (PIC, SIC,
+/// solo, night, cross-country, actual/simulated instrument, dual received)
+/// via [faaProjection] — #70's own instruction, since ForeFlight's schema
+/// is FAA-shaped and has no EASA equivalents for most of these.
+///
+/// Everything else here is a raw [PilotCapacity]/[Flight] fact read
+/// directly, not projected — `DualGiven`, `Examiner`, `MultiPilot`, `PICUS`
+/// and `IFR` all have a single, jurisdiction-independent meaning already
+/// (whether this pilot instructed, was examined, flew a multi-pilot
+/// operation, claimed PICUS, or filed an IFR plan), so there is no
+/// projection to run for them — the whole block time is attributed to
+/// whichever of these flags is set, the same simplifying assumption the
+/// import side made in reverse (`foreflight_flight_mapper.dart`'s own
+/// dartdoc on `_classifyCapacity` and `ifrFlightPlanFiled` inference).
+///
+/// Columns with nothing to read this app's model for at all (`OnDuty`,
+/// `HobbsStart`/`End`, `TachStart`/`End`, `NVG`, `Distance`,
+/// `GroundTraining`, `Person1`-`6`, the `(FAA)` alternative-compliance
+/// columns, `Takeoff Day`/`Landing Full-Stop Day` and their towered
+/// variants) are always left blank — never fabricated.
+Map<String, String> exportForeFlightFlightRow({
+  required Flight flight,
+  required Aircraft aircraft,
+  required Projection faaProjection,
+}) {
+  final capacity = flight.capacity;
+  final blockTime = flight.blockTime;
+  final result = faaProjection.project(flight, aircraft);
+
+  final route = flight.route;
+  final intermediateStops = route.length > 2
+      ? route.sublist(1, route.length - 1).join(' ')
+      : '';
+
+  final dayTakeoffs =
+      flight.takeoffs.dayFullStop + flight.takeoffs.dayTouchAndGo;
+  final nightTakeoffs =
+      flight.takeoffs.nightFullStop + flight.takeoffs.nightTouchAndGo;
+  final allLandings =
+      flight.landings.dayFullStop +
+      flight.landings.dayTouchAndGo +
+      flight.landings.nightFullStop +
+      flight.landings.nightTouchAndGo;
+
+  final instructor = capacity.instructor;
+  final examinerPresent =
+      instructor?.capacity == InstructorCapacity.flightExaminer;
+
+  final row = <String, String>{
+    'Date': _formatDate(flight.offBlocks),
+    'AircraftID': flight.aircraftRegistration,
+    'From': route.isNotEmpty ? route.first : '',
+    'To': route.length > 1 ? route.last : '',
+    'Route': intermediateStops,
+    'TimeOut': _formatTime(flight.offBlocks),
+    'TimeOff': flight.takeoff != null ? _formatTime(flight.takeoff!) : '',
+    'TimeOn': flight.landing != null ? _formatTime(flight.landing!) : '',
+    'TimeIn': _formatTime(flight.onBlocks),
+    'OnDuty': '',
+    'OffDuty': '',
+    'TotalTime': _formatDuration(blockTime),
+    'PIC': _formatDuration(_quantity(result, 'loggedPic')),
+    'SIC': _formatDuration(_quantity(result, 'sic')),
+    'Night': _formatDuration(_quantity(result, 'nightFlightTime')),
+    'Solo': _formatDuration(_quantity(result, 'solo')),
+    'CrossCountry': _formatDuration(_quantity(result, 'crossCountry')),
+    'PICUS': _formatDuration(
+      capacity.picusClaimed ? blockTime : FlightDuration.zero,
+    ),
+    'MultiPilot': _formatDuration(
+      capacity.multiPilotOperation ? blockTime : FlightDuration.zero,
+    ),
+    'IFR': _formatDuration(
+      flight.ifrFlightPlanFiled ? blockTime : FlightDuration.zero,
+    ),
+    'Examiner': _formatDuration(
+      examinerPresent ? blockTime : FlightDuration.zero,
+    ),
+    'NVG': '',
+    'NVG Ops': '',
+    'Distance': '',
+    'ActualInstrument': _formatDuration(_quantity(result, 'actualInstrument')),
+    'SimulatedInstrument': _formatDuration(
+      _quantity(result, 'simulatedInstrument'),
+    ),
+    'HobbsStart': '',
+    'HobbsEnd': '',
+    'TachStart': '',
+    'TachEnd': '',
+    'Holds': flight.holdingProceduresCount.toString(),
+    for (var i = 0; i < _approachColumns.length; i++)
+      _approachColumns[i]: i < flight.approaches.length
+          ? _formatApproach(flight.approaches[i])
+          : '',
+    'DualGiven': _formatDuration(
+      capacity.actingAsInstructor ? blockTime : FlightDuration.zero,
+    ),
+    'DualReceived': _formatDuration(_quantity(result, 'dualReceived')),
+    'SimulatedFlight': '',
+    'GroundTraining': '',
+    'GroundTrainingGiven': '',
+    'InstructorName': instructor?.name ?? '',
+    'InstructorComments': '',
+    'Person1': '',
+    'Person2': '',
+    'Person3': '',
+    'Person4': '',
+    'Person5': '',
+    'Person6': '',
+    'PilotComments': flight.remarks,
+    'Flight Review (FAA)': '',
+    'IPC (FAA)': '',
+    'Checkride (FAA)': '',
+    'FAA 61.58 (FAA)': '',
+    'NVG Proficiency (FAA)': '',
+    'Takeoff Day': '',
+    'Takeoff Day Towered': '',
+    'Landing Full-Stop Day': '',
+    'Landing Full-Stop Day Towered': '',
+    'DayTakeoffs': dayTakeoffs.toString(),
+    'DayLandingsFullStop': flight.landings.dayFullStop.toString(),
+    'NightTakeoffs': nightTakeoffs.toString(),
+    'NightLandingsFullStop': flight.landings.nightFullStop.toString(),
+    'AllLandings': allLandings.toString(),
+  };
+
+  return row;
+}

--- a/test/io/foreflight/foreflight_exporter_test.dart
+++ b/test/io/foreflight/foreflight_exporter_test.dart
@@ -1,0 +1,255 @@
+import 'dart:io';
+
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_profile.dart';
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/primitives/default_primitives.dart';
+import 'package:easa_digital_log/domain/projection/jurisdiction_projection.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/io/foreflight/foreflight_adapter.dart';
+import 'package:easa_digital_log/io/foreflight/foreflight_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Exercises the ForeFlight exporter (#70) against a real ForeFlight
+/// importer (#69) round trip — the acceptance criterion is equivalence,
+/// not a snapshot of the CSV text, so these tests re-import what they
+/// export and compare the resulting domain objects rather than strings.
+void main() {
+  final registry = JurisdictionRegistry(
+    ['assets/jurisdictions/us.faa.part61.yaml'].map(
+      (path) => parseJurisdictionProfileYaml(File(path).readAsStringSync()),
+    ),
+  );
+  final faaProjection = JurisdictionProjection(
+    registry: registry,
+    primitives: defaultPrimitives,
+    aerodromes: AerodromeDirectory(const []),
+    jurisdictionId: 'us.faa.part61',
+  );
+
+  const aircraft = Aircraft(
+    registration: 'N100AB',
+    manufacturer: 'Cessna',
+    model: 'C172P Skyhawk',
+    icaoTypeDesignator: 'C172',
+    category: AircraftCategory.aeroplane,
+    engineType: EngineType.piston,
+    engineCount: 1,
+    operatingSurface: OperatingSurface.land,
+    requiresMultiCrew: false,
+  );
+
+  test('a plain solo PIC flight round-trips through export then re-import', () {
+    final offBlocks = UtcInstant.utc(2026, 3, 15, 14, 0);
+    final onBlocks = offBlocks.add(const Duration(minutes: 90));
+    final flight = Flight(
+      aircraftRegistration: 'N100AB',
+      route: const ['KABC', 'KDEF'],
+      prePlannedNavigation: false,
+      offBlocks: offBlocks,
+      onBlocks: onBlocks,
+      takeoff: offBlocks.add(const Duration(minutes: 2)),
+      landing: onBlocks.subtract(const Duration(minutes: 2)),
+      capacity: const PilotCapacity(
+        commandAuthority: true,
+        soleManipulator: true,
+        soleOccupant: true,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+      ),
+      carryingPassengers: false,
+      takeoffs: const CircuitCounts(dayFullStop: 1),
+      landings: const CircuitCounts(dayFullStop: 1),
+      ifrFlightPlanFiled: true,
+      actualInstrumentTime: const FlightDuration(30),
+      simulatedInstrumentTime: FlightDuration.zero,
+      approaches: const [
+        Approach(type: ApproachType.ils, aerodromeIcao: 'KDEF', runway: '27'),
+      ],
+      holdingProceduresCount: 1,
+      trackingPerformed: false,
+      remarks: 'Great flight, no issues',
+    );
+
+    final csv = exportForeFlightCsv(
+      flights: [FlightRecord(id: 'f1', flight: flight, aircraft: aircraft)],
+      faaProjection: faaProjection,
+    );
+
+    final result = ForeFlightAdapter().parse({
+      ForeFlightAdapter.logbookKey: csv,
+    });
+
+    expect(result.errors, isEmpty);
+    expect(result.rows, hasLength(1));
+    final reimported = result.rows.single.flight;
+    final reimportedAircraft = result.rows.single.aircraft;
+
+    expect(reimportedAircraft, aircraft);
+
+    expect(reimported.aircraftRegistration, flight.aircraftRegistration);
+    expect(reimported.route, flight.route);
+    expect(reimported.offBlocks, flight.offBlocks);
+    expect(reimported.onBlocks, flight.onBlocks);
+    expect(reimported.takeoff, flight.takeoff);
+    expect(reimported.landing, flight.landing);
+    expect(reimported.capacity.commandAuthority, isTrue);
+    expect(reimported.capacity.soleManipulator, isTrue);
+    expect(reimported.capacity.soleOccupant, isTrue);
+    expect(reimported.takeoffs, flight.takeoffs);
+    expect(reimported.landings, flight.landings);
+    expect(reimported.ifrFlightPlanFiled, isTrue);
+    expect(reimported.actualInstrumentTime, flight.actualInstrumentTime);
+    expect(reimported.simulatedInstrumentTime, flight.simulatedInstrumentTime);
+    expect(reimported.approaches, flight.approaches);
+    expect(reimported.holdingProceduresCount, flight.holdingProceduresCount);
+    // PilotComments is not one of foreflight_flight_mapper.dart's own
+    // `_mappedColumns` — round-tripping it lands in unmappedFields, the
+    // same place a real vendor field the importer doesn't recognise
+    // would, not back in Flight.remarks directly.
+    expect(
+      result.rows.single.unmappedFields['PilotComments'],
+      'Great flight, no issues',
+    );
+  });
+
+  test('a flight with no optional data round-trips with every optional field '
+      'blank, not fabricated', () {
+    final offBlocks = UtcInstant.utc(2026, 4, 1, 9, 0);
+    final onBlocks = offBlocks.add(const Duration(minutes: 45));
+    final flight = Flight(
+      aircraftRegistration: 'N100AB',
+      route: const ['KABC', 'KABC'],
+      prePlannedNavigation: false,
+      offBlocks: offBlocks,
+      onBlocks: onBlocks,
+      capacity: const PilotCapacity(
+        commandAuthority: true,
+        soleManipulator: true,
+        soleOccupant: true,
+        multiPilotOperation: false,
+        additionalCrewRequiredByRule: false,
+        actingAsInstructor: false,
+        actingAsExaminer: false,
+        picusClaimed: false,
+        picInterventionNotRequired: false,
+      ),
+      carryingPassengers: false,
+      takeoffs: const CircuitCounts(dayFullStop: 1),
+      landings: const CircuitCounts(dayFullStop: 1),
+      ifrFlightPlanFiled: false,
+      actualInstrumentTime: FlightDuration.zero,
+      simulatedInstrumentTime: FlightDuration.zero,
+      approaches: const [],
+      holdingProceduresCount: 0,
+      trackingPerformed: false,
+      remarks: '',
+    );
+
+    final csv = exportForeFlightCsv(
+      flights: [FlightRecord(id: 'f1', flight: flight, aircraft: aircraft)],
+      faaProjection: faaProjection,
+    );
+
+    final result = ForeFlightAdapter().parse({
+      ForeFlightAdapter.logbookKey: csv,
+    });
+
+    expect(result.errors, isEmpty);
+    final reimported = result.rows.single.flight;
+    expect(reimported.takeoff, isNull);
+    expect(reimported.landing, isNull);
+    expect(reimported.approaches, isEmpty);
+    expect(reimported.holdingProceduresCount, 0);
+    expect(reimported.ifrFlightPlanFiled, isFalse);
+  });
+
+  test(
+    'column order and header names match a real ForeFlight export exactly',
+    () {
+      final offBlocks = UtcInstant.utc(2026, 1, 1, 10, 0);
+      final flight = Flight(
+        aircraftRegistration: 'N100AB',
+        route: const ['KABC', 'KDEF'],
+        prePlannedNavigation: false,
+        offBlocks: offBlocks,
+        onBlocks: offBlocks.add(const Duration(minutes: 30)),
+        capacity: const PilotCapacity(
+          commandAuthority: true,
+          soleManipulator: true,
+          soleOccupant: true,
+          multiPilotOperation: false,
+          additionalCrewRequiredByRule: false,
+          actingAsInstructor: false,
+          actingAsExaminer: false,
+          picusClaimed: false,
+          picInterventionNotRequired: false,
+        ),
+        carryingPassengers: false,
+        takeoffs: const CircuitCounts(dayFullStop: 1),
+        landings: const CircuitCounts(dayFullStop: 1),
+        ifrFlightPlanFiled: false,
+        actualInstrumentTime: FlightDuration.zero,
+        simulatedInstrumentTime: FlightDuration.zero,
+        approaches: const [],
+        holdingProceduresCount: 0,
+        trackingPerformed: false,
+        remarks: '',
+      );
+
+      final csv = exportForeFlightCsv(
+        flights: [FlightRecord(id: 'f1', flight: flight, aircraft: aircraft)],
+        faaProjection: faaProjection,
+      );
+      final lines = csv.split('\n');
+
+      expect(
+        lines[0],
+        'ForeFlight Logbook Import,This row is required for importing into '
+        'ForeFlight. Do not delete or modify.',
+      );
+      expect(lines[2], 'Aircraft Table');
+      expect(
+        lines[3],
+        'AircraftID,TypeCode,Year,Make,Model,GearType,EngineType,'
+        'equipType (FAA),aircraftClass (FAA),complexAircraft (FAA),taa (FAA),'
+        'highPerformance (FAA),pressurized (FAA)',
+      );
+      expect(lines[6], 'Flights Table ');
+      expect(
+        lines[7],
+        'Date,AircraftID,From,To,Route,TimeOut,TimeOff,TimeOn,TimeIn,OnDuty,'
+        'OffDuty,TotalTime,PIC,SIC,Night,Solo,CrossCountry,PICUS,MultiPilot,'
+        'IFR,Examiner,NVG,NVG Ops,Distance,ActualInstrument,'
+        'SimulatedInstrument,HobbsStart,HobbsEnd,TachStart,TachEnd,Holds,'
+        'Approach1,Approach2,Approach3,Approach4,Approach5,Approach6,'
+        'DualGiven,DualReceived,SimulatedFlight,GroundTraining,'
+        'GroundTrainingGiven,InstructorName,InstructorComments,Person1,'
+        'Person2,Person3,Person4,Person5,Person6,PilotComments,'
+        'Flight Review (FAA),IPC (FAA),Checkride (FAA),FAA 61.58 (FAA),'
+        'NVG Proficiency (FAA),Takeoff Day,Takeoff Day Towered,'
+        'Landing Full-Stop Day,Landing Full-Stop Day Towered,DayTakeoffs,'
+        'DayLandingsFullStop,NightTakeoffs,NightLandingsFullStop,AllLandings',
+      );
+    },
+  );
+
+  test('the export filename embeds the requested date range', () {
+    final name = foreFlightExportFilename(
+      from: const CalendarDate(2026, 1, 1),
+      to: const CalendarDate(2026, 6, 30),
+    );
+
+    expect(name, 'logbook_template_2026-01-01_to_2026-06-30.csv');
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `exportForeFlightCsv` (`lib/io/foreflight/foreflight_exporter.dart`), producing a `logbook_template.csv`-shaped export whose column order and header names exactly match a real ForeFlight file — verified against the real export reviewed during #69's development. This matters because the goal is round-tripping through ForeFlight itself, not just this app's own importer.
- Jurisdiction-dependent figures (PIC, SIC, solo, night, cross-country, actual/simulated instrument, dual received) are computed via a caller-supplied FAA `Projection`, per #70's own instruction — ForeFlight's schema is FAA-shaped and has no EASA equivalents for most of these.
- Everything else (`DualGiven`, `Examiner`, `MultiPilot`, `PICUS`, `IFR`) is read directly off raw `PilotCapacity`/`Flight` facts rather than projected, since those already have one jurisdiction-independent meaning (whether this pilot instructed, was examined, flew multi-pilot, claimed PICUS, or filed an IFR plan) — no projection needed. Columns this app has no fact for at all (Hobbs/Tach, NVG, Distance, the `(FAA)` alternative-compliance columns, `Person1`-`6`, ...) are always left blank, never fabricated.
- Date-range selection and scoping are the caller's job, via `FlightQuery` against `FlightReadRepository` — the same separation of pure transformation from I/O the import adapters already use. `foreFlightExportFilename` embeds the requested range per #70's filename requirement.

## Scope note
#70's "a record of what has previously been exported, to warn about overlap" criterion needs a persistent store (a new repository interface + drift migration) — a separable unit of work, not something this PR's pure `lib/io/` exporter can own. Deliberately left for a follow-up issue, the same scoping split #75 used for its own preview/bulk-action dependency on #73.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 790/790 passing
- [x] Round-trip tests: export a flight, re-import it through the existing `ForeFlightAdapter` (#69), assert equivalence on every field the format is designed to preserve — including a "no optional data" case proving blanks aren't fabricated
- [x] Literal header/column-order test against the real ForeFlight header strings
- [x] Filename test
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_no_networking.dart` / `check_schema_snapshot.dart` — all clean
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 96.2% (threshold 90%)
- [x] `dart run tool/check_io_vendor_leak.dart` — no vendor identifier outside `lib/io/`
- [x] Formatting verified against CI-pinned Flutter 3.44.0's `dart format`

Progresses #70 (see scope note above for what's left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)