### PR TITLE
feat: transactional import batches with undo, plus export-history ledger (#73, #70)

### DIFF
--- a/drift_schemas/drift_schema_v8.json
+++ b/drift_schemas/drift_schema_v8.json
@@ -1,0 +1,1819 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "aircraft",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "registration",
+            "getter_name": "registration",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "manufacturer",
+            "getter_name": "manufacturer",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "model",
+            "getter_name": "model",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_type_designator",
+            "getter_name": "icaoTypeDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "category",
+            "getter_name": "category",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_type",
+            "getter_name": "engineType",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "engine_count",
+            "getter_name": "engineCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "operating_surface",
+            "getter_name": "operatingSurface",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "requires_multi_crew",
+            "getter_name": "requiresMultiCrew",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"requires_multi_crew\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"requires_multi_crew\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type_rating_designator",
+            "getter_name": "typeRatingDesignator",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "archived",
+            "getter_name": "archived",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"archived\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"archived\" IN (0, 1))"
+            },
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_qualification_jurisdictions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [
+        0
+      ],
+      "type": "table",
+      "data": {
+        "name": "aircraft_required_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "aircraft_id",
+          "jurisdiction_id",
+          "qualification"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "custom_aerodromes",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icao_code",
+            "getter_name": "icaoCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iata_code",
+            "getter_name": "iataCode",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "latitude",
+            "getter_name": "latitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "longitude",
+            "getter_name": "longitude",
+            "moor_type": "double",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "elevation_ft",
+            "getter_name": "elevationFt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "iso_country",
+            "getter_name": "isoCountry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "import_batches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "source_label",
+            "getter_name": "sourceLabel",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "imported_at",
+            "getter_name": "importedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "undone_at",
+            "getter_name": "undoneAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "references": [
+        0,
+        4
+      ],
+      "type": "table",
+      "data": {
+        "name": "flights",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aircraft_id",
+            "getter_name": "aircraftId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES aircraft (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES aircraft (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "aircraft",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "pre_planned_navigation",
+            "getter_name": "prePlannedNavigation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pre_planned_navigation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pre_planned_navigation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "off_blocks",
+            "getter_name": "offBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "on_blocks",
+            "getter_name": "onBlocks",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoff",
+            "getter_name": "takeoff",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landing",
+            "getter_name": "landing",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_name",
+            "getter_name": "otherPilotName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "other_pilot_credential_number",
+            "getter_name": "otherPilotCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "carrying_passengers",
+            "getter_name": "carryingPassengers",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"carrying_passengers\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"carrying_passengers\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_full_stop",
+            "getter_name": "takeoffsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_day_touch_and_go",
+            "getter_name": "takeoffsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_full_stop",
+            "getter_name": "takeoffsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "takeoffs_night_touch_and_go",
+            "getter_name": "takeoffsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_full_stop",
+            "getter_name": "landingsDayFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_day_touch_and_go",
+            "getter_name": "landingsDayTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_full_stop",
+            "getter_name": "landingsNightFullStop",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "landings_night_touch_and_go",
+            "getter_name": "landingsNightTouchAndGo",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "ifr_flight_plan_filed",
+            "getter_name": "ifrFlightPlanFiled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"ifr_flight_plan_filed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "actual_instrument_minutes",
+            "getter_name": "actualInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "simulated_instrument_minutes",
+            "getter_name": "simulatedInstrumentMinutes",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "holding_procedures_count",
+            "getter_name": "holdingProceduresCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tracking_performed",
+            "getter_name": "trackingPerformed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"tracking_performed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"tracking_performed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "series_group_id",
+            "getter_name": "seriesGroupId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "airworthiness_basis",
+            "getter_name": "airworthinessBasis",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "remarks",
+            "getter_name": "remarks",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "alternative_compliance_events",
+            "getter_name": "alternativeComplianceEvents",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_command_authority",
+            "getter_name": "capacityCommandAuthority",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_command_authority\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_command_authority\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_manipulator",
+            "getter_name": "capacitySoleManipulator",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_manipulator\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_sole_occupant",
+            "getter_name": "capacitySoleOccupant",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_sole_occupant\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_sole_occupant\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_multi_pilot_operation",
+            "getter_name": "capacityMultiPilotOperation",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_multi_pilot_operation\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_additional_crew_required_by_rule",
+            "getter_name": "capacityAdditionalCrewRequiredByRule",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_instructor",
+            "getter_name": "capacityActingAsInstructor",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_instructor\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_acting_as_examiner",
+            "getter_name": "capacityActingAsExaminer",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_acting_as_examiner\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_picus_claimed",
+            "getter_name": "capacityPicusClaimed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_picus_claimed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_picus_claimed\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_pic_intervention_not_required",
+            "getter_name": "capacityPicInterventionNotRequired",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_manipulation_time_minutes",
+            "getter_name": "capacityManipulationTimeMinutes",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_solo_endorsement_held",
+            "getter_name": "capacitySoloEndorsementHeld",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_solo_endorsement_held\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_endorsing_instructor_name",
+            "getter_name": "capacityEndorsingInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_capacity",
+            "getter_name": "capacityInstructorCapacity",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_influenced_flight",
+            "getter_name": "capacityInstructorInfluencedFlight",
+            "moor_type": "bool",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_name",
+            "getter_name": "capacityInstructorName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_number",
+            "getter_name": "capacityInstructorCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_instructor_credential_expiry",
+            "getter_name": "capacityInstructorCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_other_pilot_role",
+            "getter_name": "capacityOtherPilotRole",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_status",
+            "getter_name": "capacityCountersignatureStatus",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_name",
+            "getter_name": "capacityCountersignatureSignatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_number",
+            "getter_name": "capacityCountersignatureSignatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signatory_credential_expiry",
+            "getter_name": "capacityCountersignatureSignatoryCredentialExpiry",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "capacity_countersignature_signed_at",
+            "getter_name": "capacityCountersignatureSignedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "committed_at",
+            "getter_name": "committedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tombstoned_at",
+            "getter_name": "tombstonedAt",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "import_batch_id",
+            "getter_name": "importBatchId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES import_batches (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES import_batches (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "import_batches",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "references": [
+        5
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_route_legs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "sequence",
+            "getter_name": "sequence",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "identifier",
+            "getter_name": "identifier",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "references": [
+        5
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_approaches",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id) ON DELETE CASCADE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id) ON DELETE CASCADE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": "cascade"
+                }
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "aerodrome_icao",
+            "getter_name": "aerodromeIcao",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "runway",
+            "getter_name": "runway",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "count",
+            "getter_name": "count",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "references": [
+        5
+      ],
+      "type": "table",
+      "data": {
+        "name": "flight_revisions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "flight_id",
+            "getter_name": "flightId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "REFERENCES flights (id)",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "REFERENCES flights (id)"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              {
+                "foreign_key": {
+                  "to": {
+                    "table": "flights",
+                    "column": "id"
+                  },
+                  "initially_deferred": false,
+                  "on_update": null,
+                  "on_delete": null
+                }
+              }
+            ]
+          },
+          {
+            "name": "recorded_at",
+            "getter_name": "recordedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "reason",
+            "getter_name": "reason",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "changed_fields",
+            "getter_name": "changedFields",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pilot_profile",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_of_birth",
+            "getter_name": "dateOfBirth",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "primary_jurisdiction_id",
+            "getter_name": "primaryJurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'eu.easa.part-fcl\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "home_base_icao",
+            "getter_name": "homeBaseIcao",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "medical_certificates",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "certificate_class",
+            "getter_name": "certificateClass",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 11,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_aircraft_qualifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "qualification",
+            "getter_name": "qualification",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "date_granted",
+            "getter_name": "dateGranted",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_name",
+            "getter_name": "signatoryName",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "signatory_credential_number",
+            "getter_name": "signatoryCredentialNumber",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "held_ratings",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "kind",
+            "getter_name": "kind",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "designator",
+            "getter_name": "designator",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "jurisdiction_id",
+            "getter_name": "jurisdictionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "issue_date",
+            "getter_name": "issueDate",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "expiry_date",
+            "getter_name": "expiryDate",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "language_proficiency_level",
+            "getter_name": "languageProficiencyLevel",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 13,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "export_records",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "format",
+            "getter_name": "format",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "range_from",
+            "getter_name": "rangeFrom",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "range_to",
+            "getter_name": "rangeTo",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "exported_at",
+            "getter_name": "exportedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "aircraft",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft\" (\"id\" TEXT NOT NULL, \"registration\" TEXT NOT NULL UNIQUE, \"manufacturer\" TEXT NOT NULL, \"model\" TEXT NOT NULL, \"icao_type_designator\" TEXT NULL, \"category\" TEXT NOT NULL, \"engine_type\" TEXT NOT NULL, \"engine_count\" INTEGER NOT NULL, \"operating_surface\" TEXT NOT NULL, \"requires_multi_crew\" INTEGER NOT NULL CHECK (\"requires_multi_crew\" IN (0, 1)), \"type_rating_designator\" TEXT NULL, \"archived\" INTEGER NOT NULL DEFAULT 0 CHECK (\"archived\" IN (0, 1)), PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_qualification_jurisdictions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_qualification_jurisdictions\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "aircraft_required_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"aircraft_required_qualifications\" (\"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id) ON DELETE CASCADE, \"jurisdiction_id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, PRIMARY KEY (\"aircraft_id\", \"jurisdiction_id\", \"qualification\"));"
+        }
+      ]
+    },
+    {
+      "name": "custom_aerodromes",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"custom_aerodromes\" (\"id\" TEXT NOT NULL, \"icao_code\" TEXT NULL, \"iata_code\" TEXT NULL, \"name\" TEXT NOT NULL, \"latitude\" REAL NOT NULL, \"longitude\" REAL NOT NULL, \"elevation_ft\" INTEGER NULL, \"iso_country\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "import_batches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"import_batches\" (\"id\" TEXT NOT NULL, \"source_label\" TEXT NOT NULL, \"imported_at\" INTEGER NOT NULL, \"undone_at\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flights",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flights\" (\"id\" TEXT NOT NULL, \"aircraft_id\" TEXT NOT NULL REFERENCES aircraft (id), \"pre_planned_navigation\" INTEGER NOT NULL CHECK (\"pre_planned_navigation\" IN (0, 1)), \"off_blocks\" INTEGER NOT NULL, \"on_blocks\" INTEGER NOT NULL, \"takeoff\" INTEGER NULL, \"landing\" INTEGER NULL, \"other_pilot_name\" TEXT NULL, \"other_pilot_credential_number\" TEXT NULL, \"carrying_passengers\" INTEGER NOT NULL CHECK (\"carrying_passengers\" IN (0, 1)), \"takeoffs_day_full_stop\" INTEGER NOT NULL, \"takeoffs_day_touch_and_go\" INTEGER NOT NULL, \"takeoffs_night_full_stop\" INTEGER NOT NULL, \"takeoffs_night_touch_and_go\" INTEGER NOT NULL, \"landings_day_full_stop\" INTEGER NOT NULL, \"landings_day_touch_and_go\" INTEGER NOT NULL, \"landings_night_full_stop\" INTEGER NOT NULL, \"landings_night_touch_and_go\" INTEGER NOT NULL, \"ifr_flight_plan_filed\" INTEGER NOT NULL CHECK (\"ifr_flight_plan_filed\" IN (0, 1)), \"actual_instrument_minutes\" INTEGER NOT NULL, \"simulated_instrument_minutes\" INTEGER NOT NULL, \"holding_procedures_count\" INTEGER NOT NULL, \"tracking_performed\" INTEGER NOT NULL CHECK (\"tracking_performed\" IN (0, 1)), \"series_group_id\" TEXT NULL, \"airworthiness_basis\" TEXT NULL, \"remarks\" TEXT NOT NULL, \"alternative_compliance_events\" TEXT NOT NULL DEFAULT '', \"capacity_command_authority\" INTEGER NOT NULL CHECK (\"capacity_command_authority\" IN (0, 1)), \"capacity_sole_manipulator\" INTEGER NOT NULL CHECK (\"capacity_sole_manipulator\" IN (0, 1)), \"capacity_sole_occupant\" INTEGER NOT NULL CHECK (\"capacity_sole_occupant\" IN (0, 1)), \"capacity_multi_pilot_operation\" INTEGER NOT NULL CHECK (\"capacity_multi_pilot_operation\" IN (0, 1)), \"capacity_additional_crew_required_by_rule\" INTEGER NOT NULL CHECK (\"capacity_additional_crew_required_by_rule\" IN (0, 1)), \"capacity_acting_as_instructor\" INTEGER NOT NULL CHECK (\"capacity_acting_as_instructor\" IN (0, 1)), \"capacity_acting_as_examiner\" INTEGER NOT NULL CHECK (\"capacity_acting_as_examiner\" IN (0, 1)), \"capacity_picus_claimed\" INTEGER NOT NULL CHECK (\"capacity_picus_claimed\" IN (0, 1)), \"capacity_pic_intervention_not_required\" INTEGER NOT NULL CHECK (\"capacity_pic_intervention_not_required\" IN (0, 1)), \"capacity_manipulation_time_minutes\" INTEGER NULL, \"capacity_solo_endorsement_held\" INTEGER NULL CHECK (\"capacity_solo_endorsement_held\" IN (0, 1)), \"capacity_endorsing_instructor_name\" TEXT NULL, \"capacity_instructor_capacity\" TEXT NULL, \"capacity_instructor_influenced_flight\" INTEGER NULL CHECK (\"capacity_instructor_influenced_flight\" IN (0, 1)), \"capacity_instructor_name\" TEXT NULL, \"capacity_instructor_credential_number\" TEXT NULL, \"capacity_instructor_credential_expiry\" TEXT NULL, \"capacity_other_pilot_role\" TEXT NULL, \"capacity_countersignature_status\" TEXT NULL, \"capacity_countersignature_signatory_name\" TEXT NULL, \"capacity_countersignature_signatory_credential_number\" TEXT NULL, \"capacity_countersignature_signatory_credential_expiry\" TEXT NULL, \"capacity_countersignature_signed_at\" INTEGER NULL, \"committed_at\" INTEGER NULL, \"tombstoned_at\" INTEGER NULL, \"import_batch_id\" TEXT NULL REFERENCES import_batches (id), PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_route_legs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_route_legs\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"sequence\" INTEGER NOT NULL, \"identifier\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_approaches",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_approaches\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id) ON DELETE CASCADE, \"type\" TEXT NOT NULL, \"aerodrome_icao\" TEXT NOT NULL, \"runway\" TEXT NOT NULL, \"count\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "flight_revisions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"flight_revisions\" (\"id\" TEXT NOT NULL, \"flight_id\" TEXT NOT NULL REFERENCES flights (id), \"recorded_at\" INTEGER NOT NULL, \"kind\" TEXT NOT NULL, \"reason\" TEXT NULL, \"changed_fields\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pilot_profile",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pilot_profile\" (\"id\" TEXT NOT NULL, \"date_of_birth\" TEXT NOT NULL, \"primary_jurisdiction_id\" TEXT NOT NULL DEFAULT 'eu.easa.part-fcl', \"home_base_icao\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "medical_certificates",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"medical_certificates\" (\"id\" TEXT NOT NULL, \"certificate_class\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_aircraft_qualifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_aircraft_qualifications\" (\"id\" TEXT NOT NULL, \"qualification\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"date_granted\" TEXT NOT NULL, \"signatory_name\" TEXT NULL, \"signatory_credential_number\" TEXT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "held_ratings",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"held_ratings\" (\"id\" TEXT NOT NULL, \"kind\" TEXT NOT NULL, \"designator\" TEXT NOT NULL, \"jurisdiction_id\" TEXT NOT NULL, \"issue_date\" TEXT NOT NULL, \"expiry_date\" TEXT NULL, \"language_proficiency_level\" INTEGER NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    },
+    {
+      "name": "export_records",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"export_records\" (\"id\" TEXT NOT NULL, \"format\" TEXT NOT NULL, \"range_from\" TEXT NOT NULL, \"range_to\" TEXT NOT NULL, \"exported_at\" INTEGER NOT NULL, PRIMARY KEY (\"id\"));"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -6,8 +6,10 @@ import 'package:drift/native.dart';
 import 'open_with_backup.dart';
 import 'tables/aircraft_tables.dart';
 import 'tables/custom_aerodrome_table.dart';
+import 'tables/export_record_table.dart';
 import 'tables/flight_tables.dart';
 import 'tables/held_qualification_tables.dart';
+import 'tables/import_batch_table.dart';
 import 'tables/pilot_record_tables.dart';
 
 part 'database.g.dart';
@@ -26,13 +28,15 @@ part 'database.g.dart';
     MedicalCertificatesTable,
     HeldAircraftQualificationsTable,
     HeldRatingsTable,
+    ImportBatchesTable,
+    ExportRecordsTable,
   ],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase(super.executor);
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   // SQLite does not enforce foreign keys — including this schema's
   // `onDelete: KeyAction.cascade` on the flight/aircraft child tables —
@@ -103,6 +107,15 @@ class AppDatabase extends _$AppDatabase {
       // backfills every existing aircraft row to "not archived".
       if (from < 7) {
         await m.addColumn(aircraftsTable, aircraftsTable.archived);
+      }
+      // #73: adds import_batches and export_records (folded in from #70's
+      // own leftover "warn about overlap" criterion), plus importBatchId
+      // on flights. import_batches must exist before the column that
+      // references it is added.
+      if (from < 8) {
+        await m.createTable(importBatchesTable);
+        await m.createTable(exportRecordsTable);
+        await m.addColumn(flightsTable, flightsTable.importBatchId);
       }
     },
     beforeOpen: (details) async {

--- a/lib/data/mappers/flight_mapper.dart
+++ b/lib/data/mappers/flight_mapper.dart
@@ -16,6 +16,7 @@ FlightRow flightToRow(
   required String aircraftId,
   int? committedAt,
   int? tombstonedAt,
+  String? importBatchId,
 }) {
   final capacity = flight.capacity;
   final instructor = capacity.instructor;
@@ -82,6 +83,7 @@ FlightRow flightToRow(
         : _epoch(countersignature!.signedAt!),
     committedAt: committedAt,
     tombstonedAt: tombstonedAt,
+    importBatchId: importBatchId,
   );
 }
 

--- a/lib/data/repositories/export_record_repository_drift.dart
+++ b/lib/data/repositories/export_record_repository_drift.dart
@@ -1,0 +1,66 @@
+import 'package:drift/drift.dart';
+
+import '../../domain/model/calendar_date.dart';
+import '../../domain/model/utc_instant.dart';
+import '../../domain/repository/export_record_repository.dart';
+import '../database.dart';
+import '../ulid.dart';
+
+class DriftExportRecordRepository implements ExportRecordRepository {
+  DriftExportRecordRepository(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<void> recordExport({
+    required String format,
+    required CalendarDate from,
+    required CalendarDate to,
+  }) async {
+    await _db
+        .into(_db.exportRecordsTable)
+        .insert(
+          ExportRecordRow(
+            id: generateUlid(),
+            format: format,
+            rangeFrom: from.toString(),
+            rangeTo: to.toString(),
+            exportedAt: DateTime.now().toUtc().millisecondsSinceEpoch,
+          ),
+        );
+  }
+
+  @override
+  Future<List<ExportRecord>> findOverlapping({
+    required String format,
+    required CalendarDate from,
+    required CalendarDate to,
+  }) async {
+    final rows =
+        await (_db.select(_db.exportRecordsTable)
+              ..where((t) => t.format.equals(format))
+              ..orderBy([(t) => OrderingTerm.desc(t.exportedAt)]))
+            .get();
+
+    final overlapping = <ExportRecord>[];
+    for (final row in rows) {
+      final rowFrom = CalendarDate.parse(row.rangeFrom);
+      final rowTo = CalendarDate.parse(row.rangeTo);
+      // Two ranges overlap iff each starts on or before the other ends.
+      if (from <= rowTo && rowFrom <= to) {
+        overlapping.add(
+          ExportRecord(
+            id: row.id,
+            format: row.format,
+            from: rowFrom,
+            to: rowTo,
+            exportedAt: UtcInstant.fromDateTime(
+              DateTime.fromMillisecondsSinceEpoch(row.exportedAt, isUtc: true),
+            ),
+          ),
+        );
+      }
+    }
+    return overlapping;
+  }
+}

--- a/lib/data/repositories/flight_repository_drift.dart
+++ b/lib/data/repositories/flight_repository_drift.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:drift/drift.dart';
 
 import '../../domain/model/flight.dart';
+import '../../domain/model/utc_instant.dart';
 import '../../domain/repository/flight_repository.dart';
 import '../database.dart';
 import '../mappers/flight_mapper.dart';
@@ -14,12 +15,23 @@ class DriftFlightRepository implements FlightRepository {
   final AppDatabase _db;
 
   @override
-  Future<String> createDraft(Flight flight, {required String aircraftId}) {
+  Future<String> createDraft(
+    Flight flight, {
+    required String aircraftId,
+    String? importBatchId,
+  }) {
     final id = generateUlid();
     return _db.transaction(() async {
       await _db
           .into(_db.flightsTable)
-          .insert(flightToRow(flight, id: id, aircraftId: aircraftId));
+          .insert(
+            flightToRow(
+              flight,
+              id: id,
+              aircraftId: aircraftId,
+              importBatchId: importBatchId,
+            ),
+          );
       await _writeChildren(id, flight);
       return id;
     });
@@ -39,7 +51,12 @@ class DriftFlightRepository implements FlightRepository {
       await (_db.update(
         _db.flightsTable,
       )..where((t) => t.id.equals(flightId))).write(
-        flightToRow(flight, id: flightId, aircraftId: current.aircraftId),
+        flightToRow(
+          flight,
+          id: flightId,
+          aircraftId: current.aircraftId,
+          importBatchId: current.importBatchId,
+        ),
       );
       await _replaceChildren(flightId, flight);
     });
@@ -130,6 +147,7 @@ class DriftFlightRepository implements FlightRepository {
         aircraftId: current.aircraftId,
         committedAt: current.committedAt,
         tombstonedAt: current.tombstonedAt,
+        importBatchId: current.importBatchId,
       );
       final changed = _diffRows(current, newRow);
       changed.addAll(await _diffChildren(flightId, flight));
@@ -275,6 +293,110 @@ class DriftFlightRepository implements FlightRepository {
           .write(const FlightsTableCompanion(tombstonedAt: Value(null)));
     });
   }
+
+  @override
+  Future<String> applyImportBatch({
+    required String sourceLabel,
+    required List<ImportBatchFlight> flights,
+  }) {
+    final batchId = generateUlid();
+    return _db.transaction(() async {
+      await _db
+          .into(_db.importBatchesTable)
+          .insert(
+            ImportBatchRow(
+              id: batchId,
+              sourceLabel: sourceLabel,
+              importedAt: DateTime.now().toUtc().millisecondsSinceEpoch,
+            ),
+          );
+      for (final entry in flights) {
+        await createDraft(
+          entry.flight,
+          aircraftId: entry.aircraftId,
+          importBatchId: batchId,
+        );
+      }
+      return batchId;
+    });
+  }
+
+  @override
+  Future<List<ImportBatchSummary>> listImportBatches() async {
+    final batchRows = await (_db.select(
+      _db.importBatchesTable,
+    )..orderBy([(t) => OrderingTerm.desc(t.importedAt)])).get();
+
+    final summaries = <ImportBatchSummary>[];
+    for (final batch in batchRows) {
+      final flightCount = await (_db.select(
+        _db.flightsTable,
+      )..where((t) => t.importBatchId.equals(batch.id))).get();
+      summaries.add(
+        ImportBatchSummary(
+          id: batch.id,
+          sourceLabel: batch.sourceLabel,
+          importedAt: _fromEpoch(batch.importedAt),
+          flightCount: flightCount.length,
+          undoneAt: batch.undoneAt == null ? null : _fromEpoch(batch.undoneAt!),
+        ),
+      );
+    }
+    return summaries;
+  }
+
+  @override
+  Future<ImportUndoResult> undoImportBatch(String batchId, {String? reason}) {
+    return _db.transaction(() async {
+      final batch = await (_db.select(
+        _db.importBatchesTable,
+      )..where((t) => t.id.equals(batchId))).getSingleOrNull();
+      if (batch == null) {
+        throw StateError('No import batch with id $batchId');
+      }
+      if (batch.undoneAt != null) {
+        throw StateError('Import batch $batchId is already undone');
+      }
+
+      final batchFlights = await (_db.select(
+        _db.flightsTable,
+      )..where((t) => t.importBatchId.equals(batchId))).get();
+
+      var deletedDrafts = 0;
+      var tombstonedCommitted = 0;
+      for (final flight in batchFlights) {
+        if (flight.committedAt == null) {
+          await deleteDraft(flight.id);
+          deletedDrafts++;
+        } else if (flight.tombstonedAt == null) {
+          await tombstone(
+            flight.id,
+            reason: reason ?? 'Import batch $batchId undone',
+          );
+          tombstonedCommitted++;
+        }
+        // A flight already tombstoned independently before this undo ran
+        // is left exactly as it is — it isn't this undo's to report.
+      }
+
+      await (_db.update(
+        _db.importBatchesTable,
+      )..where((t) => t.id.equals(batchId))).write(
+        ImportBatchesTableCompanion(
+          undoneAt: Value(DateTime.now().toUtc().millisecondsSinceEpoch),
+        ),
+      );
+
+      return ImportUndoResult(
+        deletedDraftCount: deletedDrafts,
+        tombstonedCommittedCount: tombstonedCommitted,
+      );
+    });
+  }
+
+  UtcInstant _fromEpoch(int epochMs) => UtcInstant.fromDateTime(
+    DateTime.fromMillisecondsSinceEpoch(epochMs, isUtc: true),
+  );
 
   /// Guarantees each flight's revision chain has strictly increasing
   /// `recordedAt` values, regardless of wall-clock resolution — two edits

--- a/lib/data/tables/export_record_table.dart
+++ b/lib/data/tables/export_record_table.dart
@@ -1,0 +1,29 @@
+import 'package:drift/drift.dart';
+
+/// One row per completed export — folded into #73 from #70's own leftover
+/// acceptance criterion: "a record of what has previously been exported, to
+/// warn about overlap." `rangeFrom`/`rangeTo` are `CalendarDate.toString()`
+/// (`YYYY-MM-DD`), not epoch millis — an export range is a calendar
+/// concept, never an instant (rule 3 is about stored *times*; a date range
+/// selection is deliberately compared as dates, not as UTC instants, so a
+/// pilot picking "January" means the same thing regardless of what hour
+/// they happen to run the export).
+@DataClassName('ExportRecordRow')
+class ExportRecordsTable extends Table {
+  @override
+  String get tableName => 'export_records';
+
+  TextColumn get id => text()();
+
+  /// A human-readable label for what was exported, e.g. the exporter's own
+  /// format name — supplied by the caller, never hardcoded here (see
+  /// `import_batch_table.dart`'s identical note).
+  TextColumn get format => text()();
+
+  TextColumn get rangeFrom => text()();
+  TextColumn get rangeTo => text()();
+  IntColumn get exportedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/data/tables/flight_tables.dart
+++ b/lib/data/tables/flight_tables.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 
 import 'aircraft_tables.dart';
+import 'import_batch_table.dart';
 
 /// One row per flight, current state only. `committedAt`/`tombstonedAt`
 /// double as both the state flag and the instant of that state change — see
@@ -85,6 +86,14 @@ class FlightsTable extends Table {
 
   IntColumn get committedAt => integer().nullable()();
   IntColumn get tombstonedAt => integer().nullable()();
+
+  /// The import batch this flight was created by (#73), if any — null for
+  /// a flight entered by hand. Kept even after `undoImportBatch` tombstones
+  /// this flight (a committed flight can't be deleted — rule 4), so its
+  /// provenance survives the undo; only a still-draft flight's row (and
+  /// this reference along with it) actually disappears on undo.
+  TextColumn get importBatchId =>
+      text().nullable().references(ImportBatchesTable, #id)();
 
   @override
   Set<Column> get primaryKey => {id};

--- a/lib/data/tables/import_batch_table.dart
+++ b/lib/data/tables/import_batch_table.dart
@@ -1,0 +1,32 @@
+import 'package:drift/drift.dart';
+
+/// One row per import applied through `FlightRepository.applyImportBatch`
+/// (#73) — CLAUDE.md's "every import is a transaction ... recorded as a
+/// batch, undoable even after restart". Survives independently of the
+/// flights it created: once every draft in a batch has been deleted by
+/// `undoImportBatch`, this row is the only remaining record that the
+/// import ever happened.
+///
+/// `undoneAt` is the whole batch's own undo marker, set once regardless of
+/// how many of its flights were drafts (deleted) versus already committed
+/// (tombstoned) — the per-flight outcome lives on those flights themselves
+/// (`FlightsTable.tombstonedAt`, or gone entirely), not duplicated here.
+@DataClassName('ImportBatchRow')
+class ImportBatchesTable extends Table {
+  @override
+  String get tableName => 'import_batches';
+
+  TextColumn get id => text()();
+
+  /// A human-readable label for what was imported, e.g. an
+  /// `ImportAdapter.displayName` — never a vendor identifier hardcoded in
+  /// this file (`tool/check_io_vendor_leak.dart` only exempts `lib/io/`),
+  /// always supplied by the caller.
+  TextColumn get sourceLabel => text()();
+
+  IntColumn get importedAt => integer()();
+  IntColumn get undoneAt => integer().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/domain/repository/export_record_repository.dart
+++ b/lib/domain/repository/export_record_repository.dart
@@ -1,0 +1,47 @@
+import '../model/calendar_date.dart';
+import '../model/utc_instant.dart';
+
+/// One completed export — folded into #73 from #70's own leftover
+/// acceptance criterion: "a record of what has previously been exported,
+/// to warn about overlap." [from]/[to] are the requested export range, not
+/// the range of flights it actually contained.
+class ExportRecord {
+  const ExportRecord({
+    required this.id,
+    required this.format,
+    required this.from,
+    required this.to,
+    required this.exportedAt,
+  });
+
+  final String id;
+  final String format;
+  final CalendarDate from;
+  final CalendarDate to;
+  final UtcInstant exportedAt;
+}
+
+/// Tracks previous exports so a future one can warn about overlap — #70:
+/// "Importing the same file twice into ForeFlight creates duplicates, so
+/// exports must be range-scoped." A pilot re-exporting a range they've
+/// already exported (and likely already imported into the vendor app)
+/// needs to be told that before doing it again, not left to notice only
+/// once the vendor app shows duplicates.
+abstract class ExportRecordRepository {
+  /// Records that an export of [format] covering [from]..[to] just
+  /// happened.
+  Future<void> recordExport({
+    required String format,
+    required CalendarDate from,
+    required CalendarDate to,
+  });
+
+  /// Every previously recorded export of [format] whose range overlaps
+  /// [from]..[to], most recent first. Empty when nothing overlaps — never
+  /// used to block an export, only to warn before one.
+  Future<List<ExportRecord>> findOverlapping({
+    required String format,
+    required CalendarDate from,
+    required CalendarDate to,
+  });
+}

--- a/lib/domain/repository/flight_repository.dart
+++ b/lib/domain/repository/flight_repository.dart
@@ -1,4 +1,51 @@
 import '../model/flight.dart';
+import '../model/utc_instant.dart';
+
+/// One flight to create as part of an import batch (#73), already resolved
+/// to a stored aircraft id — the same precondition [FlightRepository.createDraft]
+/// has for its own `aircraftId`.
+typedef ImportBatchFlight = ({Flight flight, String aircraftId});
+
+/// One recorded import batch (#73), independent of whichever of its
+/// flights still exist — a batch whose every flight was a draft and has
+/// since been undone still has this record, since [FlightRepository.undoImportBatch]
+/// deletes flights, never the batch itself.
+///
+/// [flightCount] reflects the *current* number of flights still tagged
+/// with this batch, not the size at import time — a fully-undone
+/// all-drafts batch reads 0, a partially-undone batch reads however many
+/// tombstoned survivors remain. That's deliberate: after undo, "how many
+/// flights does this batch still account for" is the more useful question
+/// than "how many did it originally create."
+class ImportBatchSummary {
+  const ImportBatchSummary({
+    required this.id,
+    required this.sourceLabel,
+    required this.importedAt,
+    required this.flightCount,
+    this.undoneAt,
+  });
+
+  final String id;
+  final String sourceLabel;
+  final UtcInstant importedAt;
+  final int flightCount;
+  final UtcInstant? undoneAt;
+
+  bool get isUndone => undoneAt != null;
+}
+
+/// What [FlightRepository.undoImportBatch] actually did, split by outcome —
+/// #73's own "reporting the split to the user" acceptance criterion.
+class ImportUndoResult {
+  const ImportUndoResult({
+    required this.deletedDraftCount,
+    required this.tombstonedCommittedCount,
+  });
+
+  final int deletedDraftCount;
+  final int tombstonedCommittedCount;
+}
 
 /// Write access to flights, enforcing the draft/committed/tombstoned state
 /// machine (ADR-0003, CLAUDE.md rule 4). The only interface allowed to
@@ -10,8 +57,14 @@ import '../model/flight.dart';
 abstract class FlightRepository {
   /// Creates a new draft flight against [aircraftId] (an id returned by
   /// `AircraftRepository.upsert`, not [Flight.aircraftRegistration]).
-  /// Returns the new flight's generated id.
-  Future<String> createDraft(Flight flight, {required String aircraftId});
+  /// [importBatchId] tags it as belonging to an import batch (#73); null
+  /// for a flight entered by hand, which is every caller but
+  /// [applyImportBatch] itself. Returns the new flight's generated id.
+  Future<String> createDraft(
+    Flight flight, {
+    required String aircraftId,
+    String? importBatchId,
+  });
 
   /// Overwrites a draft flight in place. Throws [StateError] if [flightId]
   /// names a committed flight.
@@ -42,4 +95,24 @@ abstract class FlightRepository {
   /// Reverses [tombstone], recording a `restore` revision. Throws
   /// [StateError] if [flightId] is not currently tombstoned.
   Future<void> restore(String flightId, {String? reason});
+
+  /// Creates every one of [flights] as a new draft, tagged as one import
+  /// batch (#73) — CLAUDE.md's "every import is a transaction ... and must
+  /// never partially apply". All-or-nothing: if any row fails, nothing
+  /// among [flights] is written and no batch is recorded. Returns the new
+  /// batch's id.
+  Future<String> applyImportBatch({
+    required String sourceLabel,
+    required List<ImportBatchFlight> flights,
+  });
+
+  /// Every recorded import batch, most recent first.
+  Future<List<ImportBatchSummary>> listImportBatches();
+
+  /// Undoes [batchId]: deletes every flight in it still a draft
+  /// ([deleteDraft]'s own clean-delete guarantee), tombstones every one
+  /// already committed (rule 4: a committed flight is never hard-deleted),
+  /// and marks the batch undone. Throws [StateError] if [batchId] is
+  /// unknown or already undone.
+  Future<ImportUndoResult> undoImportBatch(String batchId, {String? reason});
 }

--- a/lib/io/import_pipeline.dart
+++ b/lib/io/import_pipeline.dart
@@ -1,0 +1,95 @@
+import '../data/repositories/aircraft_repository.dart';
+import '../domain/repository/flight_read_repository.dart';
+import '../domain/repository/flight_repository.dart';
+import 'canonical_import_row.dart';
+import 'duplicate_matcher.dart';
+import 'import_adapter.dart';
+
+/// One [CanonicalImportRow] paired with its duplicate verdict (#75), if
+/// any. Nothing here writes anything — #73's "preview step": a caller can
+/// review every mapped row (and, separately, [ImportPreview.errors] for
+/// every row that couldn't be mapped at all) before ever calling
+/// [applyImport].
+class ImportPreviewRow {
+  const ImportPreviewRow({required this.row, this.duplicate});
+
+  final CanonicalImportRow row;
+  final DuplicateMatch? duplicate;
+}
+
+/// Everything a preview screen (not yet built — #73 scopes this PR to the
+/// data/orchestration layer) needs to show: every mappable row with its
+/// duplicate verdict, and every row that failed to map at all. Building
+/// this touches no database — [existingFlights] is supplied by the caller,
+/// already fetched.
+class ImportPreview {
+  const ImportPreview({required this.rows, required this.errors});
+
+  final List<ImportPreviewRow> rows;
+  final List<ImportRowError> errors;
+}
+
+/// Builds an [ImportPreview] from [parseResult], checking every mapped row
+/// for a duplicate against [existingFlights] (#75) — typically a caller's
+/// combined drafts and committed flights, the same pool
+/// `duplicate_matcher.dart`'s own dartdoc describes.
+ImportPreview buildImportPreview({
+  required ImportParseResult parseResult,
+  required List<FlightRecord> existingFlights,
+}) {
+  final matches = findDuplicates(
+    incoming: parseResult.rows,
+    existingFlights: existingFlights,
+  );
+  return ImportPreview(
+    rows: [
+      for (var i = 0; i < parseResult.rows.length; i++)
+        ImportPreviewRow(row: parseResult.rows[i], duplicate: matches[i]),
+    ],
+    errors: parseResult.errors,
+  );
+}
+
+/// Commits [rows] as one all-or-nothing import batch (#73).
+///
+/// Resolves each row's [CanonicalImportRow.aircraft] to a stored aircraft
+/// id, reusing an existing registration's id
+/// ([AircraftRepository.findIdByRegistration]) rather than overwriting it
+/// — a pilot may have corrected that aircraft's data by hand since the
+/// last import, and blindly re-upserting from a vendor CSV every time
+/// would silently clobber that. Only a registration seen for the first
+/// time gets a new [AircraftRepository.upsert] row. Each distinct
+/// registration among [rows] is resolved once, not once per flight.
+///
+/// [rows] is exactly what should be imported — a caller has already
+/// dropped whatever the pilot chose to skip (a duplicate, or a row they
+/// didn't want) before calling this. There is no partial-skip concept
+/// inside the transaction itself: skipping happens by not including a row
+/// here, the same division of responsibility [buildImportPreview] keeps
+/// pure and this function's own transaction keeps atomic.
+Future<String> applyImport({
+  required List<CanonicalImportRow> rows,
+  required String sourceLabel,
+  required AircraftRepository aircraftRepository,
+  required FlightRepository flightRepository,
+}) async {
+  final aircraftIdByRegistration = <String, String>{};
+  final batchFlights = <ImportBatchFlight>[];
+
+  for (final row in rows) {
+    final registration = row.aircraft.registration;
+    var aircraftId = aircraftIdByRegistration[registration];
+    if (aircraftId == null) {
+      aircraftId =
+          await aircraftRepository.findIdByRegistration(registration) ??
+          await aircraftRepository.upsert(row.aircraft);
+      aircraftIdByRegistration[registration] = aircraftId;
+    }
+    batchFlights.add((flight: row.flight, aircraftId: aircraftId));
+  }
+
+  return flightRepository.applyImportBatch(
+    sourceLabel: sourceLabel,
+    flights: batchFlights,
+  );
+}

--- a/lib/ui/providers/repository_providers.dart
+++ b/lib/ui/providers/repository_providers.dart
@@ -2,12 +2,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/repositories/aircraft_repository.dart';
 import '../../data/repositories/custom_aerodrome_repository.dart';
+import '../../data/repositories/export_record_repository_drift.dart';
 import '../../data/repositories/flight_read_repository_drift.dart';
 import '../../data/repositories/flight_repository_drift.dart';
 import '../../data/repositories/held_aircraft_qualification_repository.dart';
 import '../../data/repositories/held_rating_repository.dart';
 import '../../data/repositories/medical_certificate_repository.dart';
 import '../../data/repositories/pilot_profile_repository.dart';
+import '../../domain/repository/export_record_repository.dart';
 import '../../domain/repository/flight_read_repository.dart';
 import '../../domain/repository/flight_repository.dart';
 import 'database_provider.dart';
@@ -47,4 +49,8 @@ final medicalCertificateRepositoryProvider =
 
 final customAerodromeRepositoryProvider = Provider<CustomAerodromeRepository>(
   (ref) => CustomAerodromeRepository(ref.watch(databaseProvider)),
+);
+
+final exportRecordRepositoryProvider = Provider<ExportRecordRepository>(
+  (ref) => DriftExportRecordRepository(ref.watch(databaseProvider)),
 );

--- a/test/data/database_migration_test.dart
+++ b/test/data/database_migration_test.dart
@@ -78,6 +78,71 @@ const String _createFlightsTableV1ThroughV3 = '''
   )
 ''';
 
+/// As [_createFlightsTableV1ThroughV3], plus `alternative_compliance_events`
+/// (#121's v4 addition) -- the shape a real v4-v6 database's `flights` table
+/// has. Needed by [_seedV5Database]/[_seedV6Database]: #73's own `from < 8`
+/// step touches `flights` unconditionally (adding `import_batch_id`), the
+/// same way #61's `from < 7` step touches `aircraft` unconditionally, so any
+/// fixture the migration chain runs through needs the table even when it
+/// isn't what that fixture's own test is isolating.
+const String _createFlightsTableV4ThroughV6 = '''
+  CREATE TABLE flights (
+    id TEXT NOT NULL,
+    aircraft_id TEXT NOT NULL REFERENCES aircraft (id),
+    pre_planned_navigation INTEGER NOT NULL,
+    off_blocks INTEGER NOT NULL,
+    on_blocks INTEGER NOT NULL,
+    takeoff INTEGER NULL,
+    landing INTEGER NULL,
+    other_pilot_name TEXT NULL,
+    other_pilot_credential_number TEXT NULL,
+    carrying_passengers INTEGER NOT NULL,
+    takeoffs_day_full_stop INTEGER NOT NULL,
+    takeoffs_day_touch_and_go INTEGER NOT NULL,
+    takeoffs_night_full_stop INTEGER NOT NULL,
+    takeoffs_night_touch_and_go INTEGER NOT NULL,
+    landings_day_full_stop INTEGER NOT NULL,
+    landings_day_touch_and_go INTEGER NOT NULL,
+    landings_night_full_stop INTEGER NOT NULL,
+    landings_night_touch_and_go INTEGER NOT NULL,
+    ifr_flight_plan_filed INTEGER NOT NULL,
+    actual_instrument_minutes INTEGER NOT NULL,
+    simulated_instrument_minutes INTEGER NOT NULL,
+    holding_procedures_count INTEGER NOT NULL,
+    tracking_performed INTEGER NOT NULL,
+    series_group_id TEXT NULL,
+    airworthiness_basis TEXT NULL,
+    remarks TEXT NOT NULL,
+    alternative_compliance_events TEXT NOT NULL DEFAULT '',
+    capacity_command_authority INTEGER NOT NULL,
+    capacity_sole_manipulator INTEGER NOT NULL,
+    capacity_sole_occupant INTEGER NOT NULL,
+    capacity_multi_pilot_operation INTEGER NOT NULL,
+    capacity_additional_crew_required_by_rule INTEGER NOT NULL,
+    capacity_acting_as_instructor INTEGER NOT NULL,
+    capacity_acting_as_examiner INTEGER NOT NULL,
+    capacity_picus_claimed INTEGER NOT NULL,
+    capacity_pic_intervention_not_required INTEGER NOT NULL,
+    capacity_manipulation_time_minutes INTEGER NULL,
+    capacity_solo_endorsement_held INTEGER NULL,
+    capacity_endorsing_instructor_name TEXT NULL,
+    capacity_instructor_capacity TEXT NULL,
+    capacity_instructor_influenced_flight INTEGER NULL,
+    capacity_instructor_name TEXT NULL,
+    capacity_instructor_credential_number TEXT NULL,
+    capacity_instructor_credential_expiry TEXT NULL,
+    capacity_other_pilot_role TEXT NULL,
+    capacity_countersignature_status TEXT NULL,
+    capacity_countersignature_signatory_name TEXT NULL,
+    capacity_countersignature_signatory_credential_number TEXT NULL,
+    capacity_countersignature_signatory_credential_expiry TEXT NULL,
+    capacity_countersignature_signed_at INTEGER NULL,
+    committed_at INTEGER NULL,
+    tombstoned_at INTEGER NULL,
+    PRIMARY KEY (id)
+  )
+''';
+
 /// The `aircraft` table's shape from v1 through v6 -- unchanged until #61
 /// (v7) adds `archived`. Column names mirror
 /// `lib/data/tables/aircraft_tables.dart`'s drift-generated snake_case.
@@ -271,8 +336,9 @@ void _seedV3Database(String path) {
 /// test here, the same way [_seedV3Database] isolates v3->v4. Proves the new
 /// step adds `home_base_icao` and backfills it to null rather than guessing a
 /// value, and leaves the pre-existing `primary_jurisdiction_id` untouched.
-/// Still carries `aircraft` (empty) — #61's `from < 7` step alters it
-/// regardless of starting version, same reasoning as `_seedV2Database`'s.
+/// Still carries `aircraft` (empty) and `flights` (empty) — #61's
+/// `from < 7` step and #73's `from < 8` step each alter one of those
+/// unconditionally, same reasoning as `_seedV2Database`'s.
 void _seedV5Database(String path) {
   final db = sqlite3.sqlite3.open(path);
   try {
@@ -290,6 +356,7 @@ void _seedV5Database(String path) {
       ['singleton', '1990-01-01', 'us.faa.part61'],
     );
     db.execute(_createAircraftTableV1ThroughV6);
+    db.execute(_createFlightsTableV4ThroughV6);
     db.execute('PRAGMA user_version = 5');
   } finally {
     db.close();
@@ -298,7 +365,9 @@ void _seedV5Database(String path) {
 
 /// As [_seedV5Database], but at v6 with `home_base_icao` already present —
 /// isolates the v6->v7 step under test here: #61's `archived` column on
-/// `aircraft`, backfilled to `false` for a pre-existing registration.
+/// `aircraft`, backfilled to `false` for a pre-existing registration. Still
+/// carries `flights` (empty) for #73's `from < 8` step, same reasoning as
+/// [_seedV5Database]'s.
 void _seedV6Database(String path) {
   final db = sqlite3.sqlite3.open(path);
   try {
@@ -333,6 +402,7 @@ void _seedV6Database(String path) {
         0,
       ],
     );
+    db.execute(_createFlightsTableV4ThroughV6);
     db.execute('PRAGMA user_version = 6');
   } finally {
     db.close();

--- a/test/data/database_test.dart
+++ b/test/data/database_test.dart
@@ -3,10 +3,10 @@ import 'package:easa_digital_log/data/database.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('opens an in-memory database with all twelve tables', () async {
+  test('opens an in-memory database with all fourteen tables', () async {
     final db = AppDatabase(NativeDatabase.memory());
     addTearDown(db.close);
 
-    expect(db.allTables, hasLength(12));
+    expect(db.allTables, hasLength(14));
   });
 }

--- a/test/data/repositories/export_record_repository_test.dart
+++ b/test/data/repositories/export_record_repository_test.dart
@@ -1,0 +1,123 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/export_record_repository_drift.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late DriftExportRecordRepository exports;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    exports = DriftExportRecordRepository(db);
+  });
+
+  tearDown(() => db.close());
+
+  test('findOverlapping is empty before anything has been recorded', () async {
+    final overlapping = await exports.findOverlapping(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 1, 1),
+      to: const CalendarDate(2026, 6, 30),
+    );
+
+    expect(overlapping, isEmpty);
+  });
+
+  test('a range fully inside a previously recorded one overlaps', () async {
+    await exports.recordExport(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 1, 1),
+      to: const CalendarDate(2026, 12, 31),
+    );
+
+    final overlapping = await exports.findOverlapping(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 6, 1),
+      to: const CalendarDate(2026, 6, 30),
+    );
+
+    expect(overlapping, hasLength(1));
+    expect(overlapping.single.from, const CalendarDate(2026, 1, 1));
+    expect(overlapping.single.to, const CalendarDate(2026, 12, 31));
+  });
+
+  test('ranges that merely touch at a shared boundary day overlap', () async {
+    await exports.recordExport(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 1, 1),
+      to: const CalendarDate(2026, 6, 30),
+    );
+
+    final overlapping = await exports.findOverlapping(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 6, 30),
+      to: const CalendarDate(2026, 12, 31),
+    );
+
+    expect(overlapping, hasLength(1));
+  });
+
+  test('a range entirely before a recorded one does not overlap', () async {
+    await exports.recordExport(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 6, 1),
+      to: const CalendarDate(2026, 12, 31),
+    );
+
+    final overlapping = await exports.findOverlapping(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 1, 1),
+      to: const CalendarDate(2026, 5, 31),
+    );
+
+    expect(overlapping, isEmpty);
+  });
+
+  test('a different format never overlaps, even for the same dates', () async {
+    await exports.recordExport(
+      format: 'ForeFlight',
+      from: const CalendarDate(2026, 1, 1),
+      to: const CalendarDate(2026, 12, 31),
+    );
+
+    final overlapping = await exports.findOverlapping(
+      format: 'Garmin',
+      from: const CalendarDate(2026, 6, 1),
+      to: const CalendarDate(2026, 6, 30),
+    );
+
+    expect(overlapping, isEmpty);
+  });
+
+  test(
+    'every matching overlap is returned, not just the closest one',
+    () async {
+      await exports.recordExport(
+        format: 'ForeFlight',
+        from: const CalendarDate(2026, 1, 1),
+        to: const CalendarDate(2026, 3, 31),
+      );
+      await exports.recordExport(
+        format: 'ForeFlight',
+        from: const CalendarDate(2026, 4, 1),
+        to: const CalendarDate(2026, 6, 30),
+      );
+
+      final overlapping = await exports.findOverlapping(
+        format: 'ForeFlight',
+        from: const CalendarDate(2026, 1, 1),
+        to: const CalendarDate(2026, 12, 31),
+      );
+
+      expect(
+        overlapping.map((r) => r.from),
+        containsAll(<CalendarDate>[
+          const CalendarDate(2026, 1, 1),
+          const CalendarDate(2026, 4, 1),
+        ]),
+      );
+    },
+  );
+}

--- a/test/data/repositories/flight_repository_import_batch_test.dart
+++ b/test/data/repositories/flight_repository_import_batch_test.dart
@@ -1,0 +1,218 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/aircraft_repository.dart';
+import 'package:easa_digital_log/data/repositories/flight_repository_drift.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({int hour = 10}) => Flight(
+  aircraftRegistration: 'G-ABCD',
+  route: const ['EGKA', 'EGKB'],
+  prePlannedNavigation: false,
+  offBlocks: UtcInstant.utc(2026, 6, 1, hour),
+  onBlocks: UtcInstant.utc(2026, 6, 1, hour + 1),
+  capacity: _capacity,
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+void main() {
+  late AppDatabase db;
+  late DriftFlightRepository flights;
+  late String aircraftId;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    flights = DriftFlightRepository(db);
+    aircraftId = await AircraftRepository(db).upsert(
+      const Aircraft(
+        registration: 'G-ABCD',
+        manufacturer: 'Cessna',
+        model: '152',
+        category: AircraftCategory.aeroplane,
+        engineType: EngineType.piston,
+        engineCount: 1,
+        operatingSurface: OperatingSurface.land,
+        requiresMultiCrew: false,
+      ),
+    );
+  });
+
+  tearDown(() => db.close());
+
+  test('applyImportBatch creates every flight as a draft tagged with one new '
+      'batch id, and records the batch', () async {
+    final batchId = await flights.applyImportBatch(
+      sourceLabel: 'Test importer',
+      flights: [
+        (flight: _flight(hour: 9), aircraftId: aircraftId),
+        (flight: _flight(hour: 11), aircraftId: aircraftId),
+      ],
+    );
+
+    final drafts = await db.select(db.flightsTable).get();
+    expect(drafts, hasLength(2));
+    expect(drafts.every((row) => row.importBatchId == batchId), isTrue);
+    expect(drafts.every((row) => row.committedAt == null), isTrue);
+
+    final batches = await flights.listImportBatches();
+    expect(batches, hasLength(1));
+    expect(batches.single.id, batchId);
+    expect(batches.single.sourceLabel, 'Test importer');
+    expect(batches.single.flightCount, 2);
+    expect(batches.single.isUndone, isFalse);
+  });
+
+  test('a failure partway through applyImportBatch writes nothing at all — '
+      'not the batch row, not the flights already processed', () async {
+    final badAircraftId = 'nonexistent-aircraft-id';
+
+    await expectLater(
+      flights.applyImportBatch(
+        sourceLabel: 'Test importer',
+        flights: [
+          (flight: _flight(hour: 8), aircraftId: aircraftId),
+          (flight: _flight(hour: 9), aircraftId: aircraftId),
+          // This entry's aircraftId violates the flights.aircraft_id
+          // foreign key — the failure injected midway through the batch.
+          (flight: _flight(hour: 10), aircraftId: badAircraftId),
+          (flight: _flight(hour: 11), aircraftId: aircraftId),
+        ],
+      ),
+      throwsA(anything),
+    );
+
+    expect(await db.select(db.flightsTable).get(), isEmpty);
+    expect(await db.select(db.importBatchesTable).get(), isEmpty);
+    expect(await flights.listImportBatches(), isEmpty);
+  });
+
+  test(
+    'undoImportBatch deletes every draft in the batch and marks it undone',
+    () async {
+      final batchId = await flights.applyImportBatch(
+        sourceLabel: 'Test importer',
+        flights: [
+          (flight: _flight(hour: 9), aircraftId: aircraftId),
+          (flight: _flight(hour: 11), aircraftId: aircraftId),
+        ],
+      );
+
+      final result = await flights.undoImportBatch(batchId);
+
+      expect(result.deletedDraftCount, 2);
+      expect(result.tombstonedCommittedCount, 0);
+      expect(await db.select(db.flightsTable).get(), isEmpty);
+
+      final batches = await flights.listImportBatches();
+      expect(batches.single.isUndone, isTrue);
+      expect(batches.single.flightCount, 0);
+    },
+  );
+
+  test('undoImportBatch tombstones an already-committed flight instead of '
+      'deleting it, and reports the split', () async {
+    final batchId = await flights.applyImportBatch(
+      sourceLabel: 'Test importer',
+      flights: [
+        (flight: _flight(hour: 9), aircraftId: aircraftId),
+        (flight: _flight(hour: 11), aircraftId: aircraftId),
+      ],
+    );
+    final committedRow =
+        await (db.select(db.flightsTable)..where(
+              (t) => t.offBlocks.equals(
+                UtcInstant.utc(2026, 6, 1, 9).millisecondsSinceEpoch,
+              ),
+            ))
+            .getSingle();
+    await flights.commit(committedRow.id);
+
+    final result = await flights.undoImportBatch(batchId);
+
+    expect(result.deletedDraftCount, 1);
+    expect(result.tombstonedCommittedCount, 1);
+
+    final remaining = await db.select(db.flightsTable).get();
+    expect(remaining, hasLength(1));
+    expect(remaining.single.id, committedRow.id);
+    expect(remaining.single.tombstonedAt, isNotNull);
+    expect(remaining.single.importBatchId, batchId);
+  });
+
+  test('undoImportBatch throws for an unknown batch id', () async {
+    expect(
+      () => flights.undoImportBatch('nonexistent-batch'),
+      throwsStateError,
+    );
+  });
+
+  test('undoImportBatch throws if the batch is already undone', () async {
+    final batchId = await flights.applyImportBatch(
+      sourceLabel: 'Test importer',
+      flights: [(flight: _flight(), aircraftId: aircraftId)],
+    );
+    await flights.undoImportBatch(batchId);
+
+    expect(() => flights.undoImportBatch(batchId), throwsStateError);
+  });
+
+  test(
+    'editing a draft created by an import preserves its importBatchId',
+    () async {
+      final batchId = await flights.applyImportBatch(
+        sourceLabel: 'Test importer',
+        flights: [(flight: _flight(), aircraftId: aircraftId)],
+      );
+      final row = await db.select(db.flightsTable).getSingle();
+
+      await flights.updateDraft(row.id, _flight(hour: 12));
+
+      final updated = await (db.select(
+        db.flightsTable,
+      )..where((t) => t.id.equals(row.id))).getSingle();
+      expect(updated.importBatchId, batchId);
+    },
+  );
+
+  test('editing a committed flight created by an import preserves its '
+      'importBatchId', () async {
+    final batchId = await flights.applyImportBatch(
+      sourceLabel: 'Test importer',
+      flights: [(flight: _flight(), aircraftId: aircraftId)],
+    );
+    final row = await db.select(db.flightsTable).getSingle();
+    await flights.commit(row.id);
+
+    await flights.updateCommitted(row.id, _flight(hour: 12));
+
+    final updated = await (db.select(
+      db.flightsTable,
+    )..where((t) => t.id.equals(row.id))).getSingle();
+    expect(updated.importBatchId, batchId);
+  });
+}

--- a/test/io/import_pipeline_test.dart
+++ b/test/io/import_pipeline_test.dart
@@ -1,0 +1,233 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/aircraft_repository.dart';
+import 'package:easa_digital_log/data/repositories/flight_repository_drift.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/io/canonical_import_row.dart';
+import 'package:easa_digital_log/io/duplicate_matcher.dart';
+import 'package:easa_digital_log/io/import_adapter.dart';
+import 'package:easa_digital_log/io/import_pipeline.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+Flight _flight({String registration = 'N100AB', int hour = 10}) => Flight(
+  aircraftRegistration: registration,
+  route: const ['KABC', 'KDEF'],
+  prePlannedNavigation: false,
+  offBlocks: UtcInstant.utc(2026, 1, 1, hour),
+  onBlocks: UtcInstant.utc(2026, 1, 1, hour + 1),
+  capacity: _capacity,
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+const _importedAircraft = Aircraft(
+  registration: 'N100AB',
+  manufacturer: 'Cessna',
+  model: '172',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+void main() {
+  group('buildImportPreview', () {
+    test('pairs every row with its duplicate verdict and passes errors '
+        'through unchanged', () {
+      final duplicateFlight = _flight(hour: 10);
+      final newFlight = _flight(hour: 14);
+      final existing = FlightRecord(
+        id: 'existing-1',
+        flight: duplicateFlight,
+        aircraft: _importedAircraft,
+      );
+
+      final parseResult = ImportParseResult(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: duplicateFlight,
+            aircraft: _importedAircraft,
+          ),
+          CanonicalImportRow(
+            sourceRowNumber: 3,
+            flight: newFlight,
+            aircraft: _importedAircraft,
+          ),
+        ],
+        errors: const [ImportRowError(rowNumber: 4, message: 'bad row')],
+      );
+
+      final preview = buildImportPreview(
+        parseResult: parseResult,
+        existingFlights: [existing],
+      );
+
+      expect(preview.rows, hasLength(2));
+      expect(preview.rows[0].duplicate?.confidence, DuplicateConfidence.exact);
+      expect(preview.rows[1].duplicate, isNull);
+      expect(preview.errors, parseResult.errors);
+    });
+  });
+
+  group('applyImport', () {
+    late AppDatabase db;
+    late AircraftRepository aircraftRepository;
+    late DriftFlightRepository flightRepository;
+
+    setUp(() {
+      db = AppDatabase(NativeDatabase.memory());
+      aircraftRepository = AircraftRepository(db);
+      flightRepository = DriftFlightRepository(db);
+    });
+
+    tearDown(() => db.close());
+
+    test(
+      'a never-seen registration gets a new aircraft record created for it',
+      () async {
+        await applyImport(
+          rows: [
+            CanonicalImportRow(
+              sourceRowNumber: 2,
+              flight: _flight(),
+              aircraft: _importedAircraft,
+            ),
+          ],
+          sourceLabel: 'Test importer',
+          aircraftRepository: aircraftRepository,
+          flightRepository: flightRepository,
+        );
+
+        final storedAircraft = await db.select(db.aircraftsTable).get();
+        expect(storedAircraft, hasLength(1));
+        expect(storedAircraft.single.registration, 'N100AB');
+
+        final storedFlights = await db.select(db.flightsTable).get();
+        expect(storedFlights, hasLength(1));
+        expect(storedFlights.single.aircraftId, storedAircraft.single.id);
+      },
+    );
+
+    test('an existing registration reuses its stored aircraft id rather than '
+        'overwriting it with the freshly-parsed aircraft', () async {
+      final existingId = await aircraftRepository.upsert(
+        const Aircraft(
+          registration: 'N100AB',
+          manufacturer: 'Cessna',
+          model: '172 (hand-corrected)',
+          category: AircraftCategory.aeroplane,
+          engineType: EngineType.piston,
+          engineCount: 1,
+          operatingSurface: OperatingSurface.land,
+          requiresMultiCrew: false,
+        ),
+      );
+
+      await applyImport(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: _flight(),
+            // A freshly-parsed aircraft with different model text --
+            // must not clobber the pilot's hand-corrected record.
+            aircraft: _importedAircraft,
+          ),
+        ],
+        sourceLabel: 'Test importer',
+        aircraftRepository: aircraftRepository,
+        flightRepository: flightRepository,
+      );
+
+      final storedAircraft = await db.select(db.aircraftsTable).get();
+      expect(storedAircraft, hasLength(1));
+      expect(storedAircraft.single.id, existingId);
+      expect(storedAircraft.single.model, '172 (hand-corrected)');
+    });
+
+    test('two rows sharing a registration resolve to the same stored aircraft, '
+        'created once', () async {
+      await applyImport(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: _flight(hour: 9),
+            aircraft: _importedAircraft,
+          ),
+          CanonicalImportRow(
+            sourceRowNumber: 3,
+            flight: _flight(hour: 14),
+            aircraft: _importedAircraft,
+          ),
+        ],
+        sourceLabel: 'Test importer',
+        aircraftRepository: aircraftRepository,
+        flightRepository: flightRepository,
+      );
+
+      final storedAircraft = await db.select(db.aircraftsTable).get();
+      expect(storedAircraft, hasLength(1));
+
+      final storedFlights = await db.select(db.flightsTable).get();
+      expect(storedFlights, hasLength(2));
+      expect(
+        storedFlights.every((f) => f.aircraftId == storedAircraft.single.id),
+        isTrue,
+      );
+    });
+
+    test(
+      'the returned batch id is recorded and covers every imported row',
+      () async {
+        final batchId = await applyImport(
+          rows: [
+            CanonicalImportRow(
+              sourceRowNumber: 2,
+              flight: _flight(hour: 9),
+              aircraft: _importedAircraft,
+            ),
+            CanonicalImportRow(
+              sourceRowNumber: 3,
+              flight: _flight(hour: 14),
+              aircraft: _importedAircraft,
+            ),
+          ],
+          sourceLabel: 'Test importer',
+          aircraftRepository: aircraftRepository,
+          flightRepository: flightRepository,
+        );
+
+        final batches = await flightRepository.listImportBatches();
+        expect(batches.single.id, batchId);
+        expect(batches.single.sourceLabel, 'Test importer');
+        expect(batches.single.flightCount, 2);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

**Schema v8** adds `import_batches` and `export_records` tables, plus a nullable `importBatchId` on `flights` referencing the new table. Folds in #70's own leftover "record of what has previously been exported, to warn about overlap" criterion, since both needed a persistence layer this PR was already adding.

**`FlightRepository` grows three methods**, all backed by `DriftFlightRepository`:
- `applyImportBatch`: creates every given `(Flight, aircraftId)` pair as a new draft tagged with one new batch id, all inside a single transaction. If any row fails (an FK violation, say), nothing among them is written and no batch is recorded — CLAUDE.md's "every import is a transaction ... must never partially apply", verified by a test that injects a bad `aircraftId` partway through a batch and asserts the database is left completely untouched.
- `listImportBatches`: every recorded batch, including undone ones — the batch's own row survives independently of whichever flights it created, so a fully-undone all-drafts batch is still visible.
- `undoImportBatch`: deletes every flight in the batch still a draft, tombstones every one already committed (a committed flight is never hard-deleted — rule 4), and reports the split. Reuses the existing `deleteDraft`/`tombstone` methods internally via Drift's nested-transaction (savepoint) support, rather than duplicating their logic.

`createDraft` grows an optional `importBatchId` parameter, defaulting null for every existing caller. `updateDraft`/`updateCommitted` now explicitly preserve the current row's `importBatchId` when reconstructing it — both already fully replace the row via `flightToRow`, so without this fix an ordinary edit would have silently wiped a flight's import provenance. (Caught this while wiring the column in — not part of the original plan, but a real bug the schema change would otherwise have introduced silently.)

**New `ExportRecordRepository`** (domain interface + Drift implementation) records an export's format and date range and answers whether a new range overlaps a previous one — #70's own acceptance criterion, independent of any particular exporter.

**New `lib/io/import_pipeline.dart`** orchestrates the pieces #68/#69/#71/#75 already built into what #73 actually needs: `buildImportPreview` pairs every parsed row with its duplicate verdict (#75) without writing anything — the preview step, already satisfiable by composing existing pure functions; `applyImport` resolves each row's aircraft (reusing an existing registration's stored id rather than overwriting it with the freshly-parsed one, so a pilot's hand-corrected aircraft data survives a re-import) and commits the batch transactionally.

## Scope note
The actual preview screen UI (a visual list with per-row skip/import checkboxes and bulk actions) is not part of this PR — this is the data/orchestration layer a future screen will call. This mirrors the same UI-layer split #75 used for its own preview dependency.

## Incidental fix
Two pre-existing migration test fixtures (`_seedV5Database`, `_seedV6Database`) were missing a `flights` table entirely, since neither test needed one for its own narrower step in isolation. This PR's new `from < 8` migration step touches `flights` unconditionally (adding `importBatchId`), which #61's `from < 7` step already does for `aircraft` for the same reason — so both fixtures now also seed an empty `flights` table at the v4+ shape, matching what a real database at that version actually has.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 809/809 passing
- [x] Atomicity test: injects a foreign-key-violating row partway through `applyImportBatch`, asserts the database has zero flights and zero batches afterward
- [x] Undo tests: all-drafts full delete, mixed draft+committed split with correct counts, already-undone/unknown-batch error cases, import provenance preserved across edits
- [x] Export-record overlap tests: fully inside, boundary-touching, before, different format, multiple matches
- [x] Import-pipeline tests: new aircraft created, existing aircraft reused without being overwritten, shared registration resolved once, batch recorded correctly
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_no_networking.dart` / `check_schema_snapshot.dart` — all clean
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 96.2% (threshold 90%)
- [x] `dart run tool/check_io_vendor_leak.dart` — no vendor identifier outside `lib/io/`
- [x] Formatting verified against CI-pinned Flutter 3.44.0's `dart format`

Progresses #73 and #70 (see scope note above for what's left on each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)