### PR TITLE
feat: import preview and column-mapping UI (#73, #72, #75)

### DIFF
--- a/lib/io/supported_import_formats.dart
+++ b/lib/io/supported_import_formats.dart
@@ -1,11 +1,10 @@
 /// A short, human-readable summary of which vendor formats import supports
 /// — the one place outside an adapter's own file that names a vendor by
 /// name is allowed to live, so a screen that just wants to *say* what's
-/// supported (Settings' placeholder row, before #69/#71/#72 exist) doesn't
-/// have to spell out "ForeFlight or Garmin" itself (#68: "never let a
-/// vendor's field naming past `io/`").
+/// supported (Settings' Import row) doesn't have to spell out "ForeFlight
+/// or Garmin" itself (#68: "never let a vendor's field naming past `io/`").
 ///
 /// Update this alongside `ImportAdapter.displayName` as adapters are added
-/// — there is no registry yet listing them for this to read live, since
-/// none exist.
-const String supportedImportFormatsLabel = 'ForeFlight or Garmin CSV';
+/// — there is no registry yet listing them for this to read live.
+const String supportedImportFormatsLabel =
+    'ForeFlight, Garmin Pilot, or a generic CSV';

--- a/lib/ui/io/generic_csv_mapping_screen.dart
+++ b/lib/ui/io/generic_csv_mapping_screen.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/csv_mapping_profile_repository.dart';
+import '../../io/generic_csv/generic_csv_adapter.dart';
+import '../../io/generic_csv/generic_csv_field.dart';
+import '../../io/generic_csv/generic_csv_mapping.dart';
+import '../../io/import_adapter.dart';
+import '../providers/csv_mapping_profile_providers.dart';
+import '../providers/repository_providers.dart';
+import '../theme/app_colors.dart';
+import 'import_preview_screen.dart';
+
+const Map<GenericCsvField, String> _fieldLabels = {
+  GenericCsvField.date: 'Date',
+  GenericCsvField.offBlocksTime: 'Off-blocks time',
+  GenericCsvField.onBlocksTime: 'On-blocks time',
+  GenericCsvField.aircraftRegistration: 'Aircraft registration',
+  GenericCsvField.aircraftType: 'Aircraft type (optional)',
+  GenericCsvField.departure: 'Departure',
+  GenericCsvField.destination: 'Destination',
+  GenericCsvField.picDuration: 'PIC duration',
+  GenericCsvField.sicDuration: 'SIC duration',
+  GenericCsvField.dualReceivedDuration: 'Dual received duration',
+  GenericCsvField.soloDuration: 'Solo duration',
+  GenericCsvField.dayLandings: 'Day landings',
+  GenericCsvField.nightLandings: 'Night landings',
+  GenericCsvField.remarks: 'Remarks',
+};
+
+const Map<CsvDateFormat, String> _dateFormatLabels = {
+  CsvDateFormat.isoYmd: 'YYYY-MM-DD',
+  CsvDateFormat.usMdy: 'MM/DD/YYYY',
+  CsvDateFormat.dmy: 'DD/MM/YYYY',
+};
+
+const Map<CsvDurationFormat, String> _durationFormatLabels = {
+  CsvDurationFormat.decimalHours: 'Decimal hours (1.5)',
+  CsvDurationFormat.hoursMinutes: 'Hours:minutes (1:30)',
+};
+
+/// #72's column-mapping step: detects [csv]'s own header row and lets the
+/// pilot assign each to a canonical field, choose the date/duration
+/// formats explicitly (never guessed), optionally load or save a named
+/// mapping profile, then hands the resulting `ImportParseResult` to
+/// [ImportPreviewScreen] — the same preview every other format's importer
+/// uses.
+class GenericCsvMappingScreen extends ConsumerStatefulWidget {
+  const GenericCsvMappingScreen({super.key, required this.csv});
+
+  final String csv;
+
+  @override
+  ConsumerState<GenericCsvMappingScreen> createState() =>
+      _GenericCsvMappingScreenState();
+}
+
+class _GenericCsvMappingScreenState
+    extends ConsumerState<GenericCsvMappingScreen> {
+  late final List<String> _headers = detectCsvHeaders(widget.csv);
+  final Map<GenericCsvField, String?> _selection = {
+    for (final field in GenericCsvField.values) field: null,
+  };
+  CsvDateFormat _dateFormat = CsvDateFormat.isoYmd;
+  CsvDurationFormat _durationFormat = CsvDurationFormat.hoursMinutes;
+  final _nameController = TextEditingController();
+  bool _saveForReuse = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _loadProfile(GenericCsvMapping mapping) {
+    setState(() {
+      for (final field in GenericCsvField.values) {
+        _selection[field] = mapping.columnByField[field];
+      }
+      _dateFormat = mapping.dateFormat;
+      _durationFormat = mapping.durationFormat;
+      _nameController.text = mapping.name;
+    });
+  }
+
+  Future<void> _continue() async {
+    final missing = [
+      for (final field in requiredGenericCsvFields)
+        if (_selection[field] == null) _fieldLabels[field]!,
+    ];
+    if (missing.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Still needs: ${missing.join(', ')}')),
+      );
+      return;
+    }
+
+    final mapping = GenericCsvMapping(
+      name: _nameController.text.trim().isEmpty
+          ? 'Untitled mapping'
+          : _nameController.text.trim(),
+      columnByField: {
+        for (final entry in _selection.entries)
+          if (entry.value != null) entry.key: entry.value!,
+      },
+      dateFormat: _dateFormat,
+      durationFormat: _durationFormat,
+    );
+
+    ImportParseResult parsed;
+    try {
+      parsed = GenericCsvAdapter(
+        mapping,
+      ).parse({GenericCsvAdapter.csvKey: widget.csv});
+    } on FormatException catch (error) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
+      return;
+    }
+
+    if (_saveForReuse) {
+      await ref.read(csvMappingProfileRepositoryProvider).upsert(mapping);
+      ref.invalidate(savedCsvMappingProfilesProvider);
+    }
+
+    if (!mounted) return;
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => ImportPreviewScreen(
+          parseResult: parsed,
+          sourceLabel: 'Generic CSV (${mapping.name})',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final savedProfilesAsync = ref.watch(savedCsvMappingProfilesProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(4, 4, 16, 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip: 'Back',
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  Expanded(
+                    child: Text(
+                      'Map columns',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 96),
+                children: [
+                  savedProfilesAsync.when(
+                    loading: () => const SizedBox.shrink(),
+                    error: (error, stackTrace) => const SizedBox.shrink(),
+                    data: (profiles) => profiles.isEmpty
+                        ? const SizedBox.shrink()
+                        : Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child:
+                                DropdownButtonFormField<
+                                  CsvMappingProfileRecord
+                                >(
+                                  decoration: const InputDecoration(
+                                    labelText: 'Load a saved mapping',
+                                  ),
+                                  items: [
+                                    for (final record in profiles)
+                                      DropdownMenuItem(
+                                        value: record,
+                                        child: Text(record.mapping.name),
+                                      ),
+                                  ],
+                                  onChanged: (record) {
+                                    if (record != null) {
+                                      _loadProfile(record.mapping);
+                                    }
+                                  },
+                                ),
+                          ),
+                  ),
+                  Text(
+                    'COLUMNS',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  for (final field in GenericCsvField.values)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: DropdownButtonFormField<String?>(
+                        initialValue: _selection[field],
+                        decoration: InputDecoration(
+                          labelText:
+                              '${_fieldLabels[field]}'
+                              '${requiredGenericCsvFields.contains(field) ? ' *' : ''}',
+                        ),
+                        items: [
+                          const DropdownMenuItem<String?>(
+                            child: Text('— not mapped —'),
+                          ),
+                          for (final header in _headers)
+                            DropdownMenuItem(
+                              value: header,
+                              child: Text(header),
+                            ),
+                        ],
+                        onChanged: (value) =>
+                            setState(() => _selection[field] = value),
+                      ),
+                    ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'FORMATS',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  DropdownButtonFormField<CsvDateFormat>(
+                    initialValue: _dateFormat,
+                    decoration: const InputDecoration(labelText: 'Date format'),
+                    items: [
+                      for (final format in CsvDateFormat.values)
+                        DropdownMenuItem(
+                          value: format,
+                          child: Text(_dateFormatLabels[format]!),
+                        ),
+                    ],
+                    onChanged: (value) =>
+                        setState(() => _dateFormat = value ?? _dateFormat),
+                  ),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<CsvDurationFormat>(
+                    initialValue: _durationFormat,
+                    decoration: const InputDecoration(
+                      labelText: 'Duration format',
+                    ),
+                    items: [
+                      for (final format in CsvDurationFormat.values)
+                        DropdownMenuItem(
+                          value: format,
+                          child: Text(_durationFormatLabels[format]!),
+                        ),
+                    ],
+                    onChanged: (value) => setState(
+                      () => _durationFormat = value ?? _durationFormat,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    value: _saveForReuse,
+                    onChanged: (value) =>
+                        setState(() => _saveForReuse = value ?? false),
+                    title: const Text('Save this mapping for reuse'),
+                  ),
+                  if (_saveForReuse)
+                    TextField(
+                      controller: _nameController,
+                      decoration: const InputDecoration(
+                        labelText: 'Mapping name',
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _continue,
+              child: const Text('Preview import'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/io/import_preview_screen.dart
+++ b/lib/ui/io/import_preview_screen.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/model/utc_instant.dart';
+import '../../domain/repository/flight_read_repository.dart';
+import '../../io/duplicate_matcher.dart';
+import '../../io/import_adapter.dart';
+import '../../io/import_pipeline.dart';
+import '../providers/flight_records_providers.dart';
+import '../providers/repository_providers.dart';
+import '../theme/app_colors.dart';
+
+String _formatUtcDate(UtcInstant instant) {
+  final d = instant.asUtcDateTime;
+  return '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+}
+
+String _formatUtcTime(UtcInstant instant) {
+  final d = instant.asUtcDateTime;
+  return '${d.hour.toString().padLeft(2, '0')}:'
+      '${d.minute.toString().padLeft(2, '0')}Z';
+}
+
+/// #73's preview step and #75's duplicate surfacing, in one screen: every
+/// mappable row from [parseResult] with a per-row skip/import checkbox
+/// (defaulting a flagged duplicate to skipped, everything else to
+/// imported), every unmappable row shown read-only with its error, and a
+/// bulk "skip all duplicates"/"select all" pair for the common case of a
+/// wholly overlapping re-import. Nothing is written until "Import" is
+/// pressed.
+class ImportPreviewScreen extends ConsumerStatefulWidget {
+  const ImportPreviewScreen({
+    super.key,
+    required this.parseResult,
+    required this.sourceLabel,
+  });
+
+  final ImportParseResult parseResult;
+  final String sourceLabel;
+
+  @override
+  ConsumerState<ImportPreviewScreen> createState() =>
+      _ImportPreviewScreenState();
+}
+
+class _ImportPreviewScreenState extends ConsumerState<ImportPreviewScreen> {
+  ImportPreview? _preview;
+  Set<int> _excludedRowNumbers = {};
+  bool _importing = false;
+
+  ImportPreview _buildPreview(List<FlightRecord> existingFlights) {
+    final preview = buildImportPreview(
+      parseResult: widget.parseResult,
+      existingFlights: existingFlights,
+    );
+    // Default a flagged duplicate to skipped, everything else to imported
+    // — computed once, the first time the existing-flights data resolves,
+    // never recomputed just because the pilot toggled a checkbox.
+    _excludedRowNumbers = {
+      for (final row in preview.rows)
+        if (row.duplicate != null) row.row.sourceRowNumber,
+    };
+    return preview;
+  }
+
+  Future<void> _import(ImportPreview preview) async {
+    final selected = [
+      for (final row in preview.rows)
+        if (!_excludedRowNumbers.contains(row.row.sourceRowNumber)) row.row,
+    ];
+    if (selected.isEmpty) return;
+
+    setState(() => _importing = true);
+    try {
+      final batchId = await applyImport(
+        rows: selected,
+        sourceLabel: widget.sourceLabel,
+        aircraftRepository: ref.read(aircraftRepositoryProvider),
+        flightRepository: ref.read(flightRepositoryProvider),
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('${selected.length} flight(s) imported as drafts.'),
+          action: SnackBarAction(
+            label: 'Undo',
+            onPressed: () async {
+              try {
+                await ref
+                    .read(flightRepositoryProvider)
+                    .undoImportBatch(batchId);
+              } on StateError {
+                // Already undone (e.g. double-tapped) — nothing more to do.
+              }
+            },
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final existingAsync = ref.watch(allFlightRecordsProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(4, 4, 16, 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip: 'Back',
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  Expanded(
+                    child: Text(
+                      'Preview import',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: existingAsync.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (error, stackTrace) => Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Text(
+                    'Could not check for duplicates: $error',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+                data: (existingFlights) {
+                  final preview = _preview ??= _buildPreview(existingFlights);
+                  return _PreviewBody(
+                    preview: preview,
+                    excludedRowNumbers: _excludedRowNumbers,
+                    importing: _importing,
+                    onExcludedChanged: (updated) =>
+                        setState(() => _excludedRowNumbers = updated),
+                    onImport: () => _import(preview),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PreviewBody extends StatelessWidget {
+  const _PreviewBody({
+    required this.preview,
+    required this.excludedRowNumbers,
+    required this.importing,
+    required this.onExcludedChanged,
+    required this.onImport,
+  });
+
+  final ImportPreview preview;
+  final Set<int> excludedRowNumbers;
+  final bool importing;
+  final ValueChanged<Set<int>> onExcludedChanged;
+  final VoidCallback onImport;
+
+  int get _selectedCount => preview.rows
+      .where((r) => !excludedRowNumbers.contains(r.row.sourceRowNumber))
+      .length;
+
+  int get _duplicateCount =>
+      preview.rows.where((r) => r.duplicate != null).length;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+          child: Text(
+            '${preview.rows.length} flight(s) found'
+            '${_duplicateCount > 0 ? ' · $_duplicateCount possible duplicate(s)' : ''}'
+            '${preview.errors.isNotEmpty ? ' · ${preview.errors.length} row(s) could not be read' : ''}.',
+            style: theme.textTheme.bodySmall?.copyWith(color: ink.muted),
+          ),
+        ),
+        if (_duplicateCount > 0)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+            child: Wrap(
+              spacing: 8,
+              children: [
+                TextButton(
+                  onPressed: () => onExcludedChanged({
+                    for (final row in preview.rows)
+                      if (row.duplicate != null) row.row.sourceRowNumber,
+                  }),
+                  child: const Text('Skip all duplicates'),
+                ),
+                TextButton(
+                  onPressed: () => onExcludedChanged({}),
+                  child: const Text('Select all'),
+                ),
+              ],
+            ),
+          ),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.only(bottom: 96),
+            children: [
+              for (final row in preview.rows)
+                _PreviewRowTile(
+                  row: row,
+                  selected: !excludedRowNumbers.contains(
+                    row.row.sourceRowNumber,
+                  ),
+                  onChanged: (selected) {
+                    final updated = Set<int>.of(excludedRowNumbers);
+                    if (selected) {
+                      updated.remove(row.row.sourceRowNumber);
+                    } else {
+                      updated.add(row.row.sourceRowNumber);
+                    }
+                    onExcludedChanged(updated);
+                  },
+                ),
+              if (preview.errors.isNotEmpty) ...[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                  child: Text(
+                    'ROWS THAT COULD NOT BE READ',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                ),
+                for (final error in preview.errors) _ErrorRowTile(error: error),
+              ],
+            ],
+          ),
+        ),
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: (_selectedCount == 0 || importing) ? null : onImport,
+                child: importing
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text('Import $_selectedCount flight(s)'),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviewRowTile extends StatelessWidget {
+  const _PreviewRowTile({
+    required this.row,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final ImportPreviewRow row;
+  final bool selected;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final semantic = context.semanticColors;
+    final flight = row.row.flight;
+    final duplicate = row.duplicate;
+
+    return InkWell(
+      onTap: () => onChanged(!selected),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Checkbox(value: selected, onChanged: (v) => onChanged(v ?? false)),
+            const SizedBox(width: 4),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${_formatUtcDate(flight.offBlocks)} · '
+                    '${row.row.aircraft.registration} · '
+                    '${flight.route.join(" → ")}',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${_formatUtcTime(flight.offBlocks)}–'
+                    '${_formatUtcTime(flight.onBlocks)}'
+                    '${row.row.reviewNotes.isNotEmpty ? ' · ${row.row.reviewNotes.length} note(s) to verify' : ''}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                  if (duplicate != null) ...[
+                    const SizedBox(height: 4),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
+                      decoration: BoxDecoration(
+                        color: semantic.currencyWarningSurface,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        duplicate.confidence == DuplicateConfidence.exact
+                            ? 'Exact duplicate — ${duplicate.reason}'
+                            : 'Possible duplicate — ${duplicate.reason}',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: semantic.currencyWarning,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorRowTile extends StatelessWidget {
+  const _ErrorRowTile({required this.error});
+
+  final ImportRowError error;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.error_outline, size: 18, color: colorScheme.error),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Row ${error.rowNumber}: ${error.message}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.error,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/io/import_screen.dart
+++ b/lib/ui/io/import_screen.dart
@@ -1,0 +1,209 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../../io/foreflight/foreflight_adapter.dart';
+import '../../io/garmin/garmin_adapter.dart';
+import '../../io/import_adapter.dart';
+import '../theme/app_colors.dart';
+import 'generic_csv_mapping_screen.dart';
+import 'import_preview_screen.dart';
+
+/// Entry point for #73's transactional import flow, reached from Settings.
+/// Picks a format, reads whichever file(s) that format's [ImportAdapter]
+/// needs from disk, and hands the resulting [ImportParseResult] to
+/// [ImportPreviewScreen] — nothing here writes to the database; parsing a
+/// file is pure (`ImportAdapter.parse`'s own contract).
+class ImportScreen extends StatefulWidget {
+  const ImportScreen({super.key});
+
+  @override
+  State<ImportScreen> createState() => _ImportScreenState();
+}
+
+class _ImportScreenState extends State<ImportScreen> {
+  bool _busy = false;
+
+  Future<String?> _pickCsv({required String dialogTitle}) async {
+    final picked = await FilePicker.pickFile(
+      dialogTitle: dialogTitle,
+      type: FileType.custom,
+      allowedExtensions: ['csv'],
+    );
+    final path = picked?.path;
+    if (path == null) return null;
+    return File(path).readAsString();
+  }
+
+  Future<void> _run(
+    String sourceLabel,
+    Future<ImportParseResult?> Function() build,
+  ) async {
+    setState(() => _busy = true);
+    try {
+      final result = await build();
+      if (result == null) return; // pilot cancelled a file picker.
+      if (!mounted) return;
+      await Navigator.of(context).push<void>(
+        MaterialPageRoute(
+          builder: (_) => ImportPreviewScreen(
+            parseResult: result,
+            sourceLabel: sourceLabel,
+          ),
+        ),
+      );
+    } on FormatException catch (error) {
+      _showError(error.message);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _showError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _importForeFlight() => _run('ForeFlight', () async {
+    final csv = await _pickCsv(dialogTitle: 'Select logbook_template.csv');
+    if (csv == null) return null;
+    return ForeFlightAdapter().parse({ForeFlightAdapter.logbookKey: csv});
+  });
+
+  Future<void> _importGarmin() => _run('Garmin Pilot', () async {
+    final aircraftTypesCsv = await _pickCsv(
+      dialogTitle: 'Select the aircraft-types export',
+    );
+    if (aircraftTypesCsv == null) return null;
+    if (!mounted) return null;
+    final logEntriesCsv = await _pickCsv(
+      dialogTitle: 'Select the logbook export',
+    );
+    if (logEntriesCsv == null) return null;
+    return GarminAdapter().parse({
+      GarminAdapter.aircraftTypesKey: aircraftTypesCsv,
+      GarminAdapter.logEntriesKey: logEntriesCsv,
+    });
+  });
+
+  Future<void> _startGenericCsv() async {
+    setState(() => _busy = true);
+    try {
+      final csv = await _pickCsv(dialogTitle: 'Select a CSV logbook export');
+      if (csv == null) return;
+      if (!mounted) return;
+      await Navigator.of(context).push<void>(
+        MaterialPageRoute(builder: (_) => GenericCsvMappingScreen(csv: csv)),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(4, 4, 16, 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip: 'Back',
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  Expanded(
+                    child: Text('Import', style: theme.textTheme.titleMedium),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+              child: Text(
+                'Choose the format your logbook was exported in. You\'ll '
+                'see every flight before anything is imported.',
+                style: theme.textTheme.bodyMedium?.copyWith(color: ink.muted),
+              ),
+            ),
+            if (_busy) const LinearProgressIndicator(),
+            _FormatRow(
+              title: 'ForeFlight',
+              subtitle: 'logbook_template.csv',
+              onTap: _busy ? null : _importForeFlight,
+            ),
+            const Divider(height: 1),
+            _FormatRow(
+              title: 'Garmin Pilot',
+              subtitle: 'Aircraft types + logbook CSV (two files)',
+              onTap: _busy ? null : _importGarmin,
+            ),
+            const Divider(height: 1),
+            _FormatRow(
+              title: 'Generic CSV',
+              subtitle:
+                  'LogTen, Skylog, MCC Pilot Log, or your own spreadsheet',
+              onTap: _busy ? null : _startGenericCsv,
+            ),
+            const Divider(height: 1),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FormatRow extends StatelessWidget {
+  const _FormatRow({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, color: ink.faint),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/providers/csv_mapping_profile_providers.dart
+++ b/lib/ui/providers/csv_mapping_profile_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/csv_mapping_profile_repository.dart';
+import 'repository_providers.dart';
+
+/// Every saved generic-CSV mapping (#72) — a one-shot fetch, not a stream:
+/// the only writer is the mapping screen's own "save for reuse" action,
+/// which invalidates this afterward rather than needing a live query for
+/// something nothing else writes to concurrently (the same reasoning
+/// `flightHistoryProvider` documents).
+final savedCsvMappingProfilesProvider =
+    FutureProvider<List<CsvMappingProfileRecord>>((ref) {
+      return ref.watch(csvMappingProfileRepositoryProvider).listAll();
+    });

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -12,6 +12,7 @@ import '../../domain/totals/totals_summary.dart';
 import '../aircraft/aircraft_list_screen.dart';
 import '../currency/rule_asset_paths.dart';
 import '../currency/sample_currency_data.dart';
+import '../io/import_screen.dart';
 import '../../io/supported_import_formats.dart';
 import '../preferences/app_preferences.dart';
 import '../providers/aircraft_providers.dart';
@@ -135,11 +136,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                       'yet (#63)',
                 ),
                 const _Divider(),
-                const _InertRow(
-                  title: 'Import',
-                  subtitle:
-                      '$supportedImportFormatsLabel · preview before applying',
-                ),
+                const _ImportRow(),
                 const _Divider(),
                 // `exportDatabaseBackup`/`isBackupOverdue`
                 // (lib/data/database_backup.dart) are real and tested, but
@@ -286,6 +283,39 @@ class _InertRow extends StatelessWidget {
 /// #61: the one row in "DATA" backed by a real, live repository rather
 /// than the sample fixtures the rest of this screen still runs on —
 /// `aircraftRecordsProvider` reads the actual on-device database.
+class _ImportRow extends StatelessWidget {
+  const _ImportRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return InkWell(
+      onTap: () => Navigator.of(
+        context,
+      ).push<void>(MaterialPageRoute(builder: (_) => const ImportScreen())),
+      child: SizedBox(
+        width: double.infinity,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Import', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 2),
+              Text(
+                '$supportedImportFormatsLabel · preview before applying',
+                style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _AircraftRow extends ConsumerWidget {
   const _AircraftRow();
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker_darwin
 import package_info_plus
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
+  android_file_picker:
+    dependency: transitive
+    description:
+      name: android_file_picker
+      sha256: "0d84bb91fb78af33756107f00cf71ee084474169d481b882b335c3006077a913"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   args:
     dependency: transitive
     description:
@@ -169,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+5"
   crypto:
     dependency: transitive
     description:
@@ -193,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.15"
   drift:
     dependency: "direct main"
     description:
@@ -249,6 +273,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "0631f51bbc2e1184bdc9e79384db158dc7830e15b3001feeca700e86563f4d24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.2.0"
+  file_picker_darwin:
+    dependency: transitive
+    description:
+      name: file_picker_darwin
+      sha256: "5c32c9400f5c8976c9dd7aa34693c7d2f0c853c28704a1c1409029cb760f5251"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_picker_linux:
+    dependency: transitive
+    description:
+      name: file_picker_linux
+      sha256: bd52ff1e0048f29df95f913c55ad2991c72791d93e6c42241912c4bdee946cb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: file_picker_platform_interface
+      sha256: d35d8cb68446fae921335bb61501d66cb2469d74c8f3103b8c6ccdbe3fe5afd8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  file_picker_web:
+    dependency: transitive
+    description:
+      name: file_picker_web
+      sha256: "935560a9d29fa6f006f2855addebb88e88d438e13627d4cc24187033c106f227"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   fixnum:
     dependency: transitive
     description:
@@ -608,6 +672,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -1005,6 +1077,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.4.0"
+  windows_file_picker:
+    dependency: transitive
+    description:
+      name: windows_file_picker
+      sha256: d999c1c085374724668af0b674a9758d96255c50933faa2ac1cc51eff8308caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1013,6 +1093,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   yaml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   # during the Currency-screen scoping pass rather than hand-rolling bars,
   # since later screens may need richer charts too.
   fl_chart: ^1.1.1
+  file_picker: ^12.2.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^3.4.2

--- a/test/ui/io/generic_csv_mapping_screen_test.dart
+++ b/test/ui/io/generic_csv_mapping_screen_test.dart
@@ -1,0 +1,104 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/ui/io/generic_csv_mapping_screen.dart';
+import 'package:easa_digital_log/ui/io/import_preview_screen.dart';
+import 'package:easa_digital_log/ui/providers/database_provider.dart';
+import 'package:easa_digital_log/ui/providers/flight_records_providers.dart';
+import 'package:easa_digital_log/ui/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _csv =
+    'Date,Off,On,Reg,From,To,PIC\n'
+    '2026-01-01,10:00,11:00,N100AB,KABC,KDEF,1:00\n';
+
+void main() {
+  Future<void> pumpScreen(WidgetTester tester) async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          databaseProvider.overrideWithValue(db),
+          // Navigating "Preview import" pushes ImportPreviewScreen, which
+          // reads allFlightRecordsProvider — its real jurisdiction-asset/
+          // drift-stream chain needs real wall-clock time under a widget
+          // test's fake clock (see import_preview_screen_test.dart's own
+          // note), irrelevant to what this screen's own tests check.
+          allFlightRecordsProvider.overrideWith(
+            (ref) async => <FlightRecord>[],
+          ),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.light(),
+          home: const GenericCsvMappingScreen(csv: _csv),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> selectDropdown(
+    WidgetTester tester,
+    String labelText,
+    String optionText,
+  ) async {
+    final dropdown = find.ancestor(
+      of: find.text(labelText),
+      matching: find.byType(DropdownButtonFormField<String?>),
+    );
+    await tester.tap(dropdown);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(optionText).last);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('detects the CSV header row and offers it in every dropdown', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    final dateDropdown = find.ancestor(
+      of: find.text('Date *'),
+      matching: find.byType(DropdownButtonFormField<String?>),
+    );
+    await tester.tap(dateDropdown);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Date').last, findsOneWidget);
+    expect(find.text('Reg'), findsOneWidget);
+    expect(find.text('PIC'), findsOneWidget);
+  });
+
+  testWidgets('shows which required fields are still missing rather than a raw '
+      'exception', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Preview import'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Still needs:'), findsOneWidget);
+  });
+
+  testWidgets(
+    'mapping every required field and continuing opens the preview screen',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await selectDropdown(tester, 'Date *', 'Date');
+      await selectDropdown(tester, 'Off-blocks time *', 'Off');
+      await selectDropdown(tester, 'On-blocks time *', 'On');
+      await selectDropdown(tester, 'Aircraft registration *', 'Reg');
+      await selectDropdown(tester, 'Departure *', 'From');
+      await selectDropdown(tester, 'Destination *', 'To');
+
+      await tester.tap(find.text('Preview import'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ImportPreviewScreen), findsOneWidget);
+    },
+  );
+}

--- a/test/ui/io/import_preview_screen_test.dart
+++ b/test/ui/io/import_preview_screen_test.dart
@@ -1,0 +1,231 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/aircraft_repository.dart';
+import 'package:easa_digital_log/domain/model/aircraft.dart';
+import 'package:easa_digital_log/domain/model/flight.dart';
+import 'package:easa_digital_log/domain/model/flight_duration.dart';
+import 'package:easa_digital_log/domain/model/pilot_capacity.dart';
+import 'package:easa_digital_log/domain/model/utc_instant.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/io/canonical_import_row.dart';
+import 'package:easa_digital_log/io/import_adapter.dart';
+import 'package:easa_digital_log/ui/io/import_preview_screen.dart';
+import 'package:easa_digital_log/ui/providers/database_provider.dart';
+import 'package:easa_digital_log/ui/providers/flight_records_providers.dart';
+import 'package:easa_digital_log/ui/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _capacity = PilotCapacity(
+  commandAuthority: true,
+  soleManipulator: true,
+  soleOccupant: true,
+  multiPilotOperation: false,
+  additionalCrewRequiredByRule: false,
+  actingAsInstructor: false,
+  actingAsExaminer: false,
+  picusClaimed: false,
+  picInterventionNotRequired: false,
+);
+
+const _aircraft = Aircraft(
+  registration: 'N100AB',
+  manufacturer: 'Cessna',
+  model: '172',
+  category: AircraftCategory.aeroplane,
+  engineType: EngineType.piston,
+  engineCount: 1,
+  operatingSurface: OperatingSurface.land,
+  requiresMultiCrew: false,
+);
+
+Flight _flight({int hour = 10}) => Flight(
+  aircraftRegistration: 'N100AB',
+  route: const ['KABC', 'KDEF'],
+  prePlannedNavigation: false,
+  offBlocks: UtcInstant.utc(2026, 1, 1, hour),
+  onBlocks: UtcInstant.utc(2026, 1, 1, hour + 1),
+  capacity: _capacity,
+  carryingPassengers: false,
+  takeoffs: const CircuitCounts(dayFullStop: 1),
+  landings: const CircuitCounts(dayFullStop: 1),
+  ifrFlightPlanFiled: false,
+  actualInstrumentTime: FlightDuration.zero,
+  simulatedInstrumentTime: FlightDuration.zero,
+  approaches: const [],
+  holdingProceduresCount: 0,
+  trackingPerformed: false,
+  remarks: '',
+);
+
+/// #73's preview screen — proves the duplicate-defaults-to-skipped and
+/// clean-row-defaults-to-imported behaviour, the error section, and that
+/// pressing "Import" genuinely writes a draft through the real repository
+/// stack, not just updates local widget state.
+///
+/// `allFlightRecordsProvider` is overridden directly to a hand-built list
+/// rather than exercised through its real jurisdiction-asset/drift-stream
+/// chain: that chain needs real wall-clock time under a widget test's fake
+/// clock (see `logbook_screen_test.dart`'s own note), and this screen's own
+/// logic (`buildImportPreview`) is exactly as real either way — only the
+/// data source differs.
+void main() {
+  Future<AppDatabase> pumpScreen(
+    WidgetTester tester, {
+    required ImportParseResult parseResult,
+    List<FlightRecord> existingFlights = const [],
+  }) async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    await AircraftRepository(db).upsert(_aircraft, id: 'aircraft-1');
+
+    final container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        allFlightRecordsProvider.overrideWith((ref) async => existingFlights),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: AppTheme.light(),
+          home: ImportPreviewScreen(
+            parseResult: parseResult,
+            sourceLabel: 'Test importer',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return db;
+  }
+
+  testWidgets('a duplicate flight defaults to skipped, a new one defaults to '
+      'imported, and an error row is shown read-only', (tester) async {
+    final existingFlight = _flight(hour: 9);
+    await pumpScreen(
+      tester,
+      parseResult: ImportParseResult(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: existingFlight, // exact duplicate of the seed below
+            aircraft: _aircraft,
+          ),
+          CanonicalImportRow(
+            sourceRowNumber: 3,
+            flight: _flight(hour: 14),
+            aircraft: _aircraft,
+          ),
+        ],
+        errors: const [ImportRowError(rowNumber: 4, message: 'bad row')],
+      ),
+      existingFlights: [
+        FlightRecord(
+          id: 'existing-1',
+          flight: existingFlight,
+          aircraft: _aircraft,
+        ),
+      ],
+    );
+
+    expect(find.textContaining('bad row'), findsOneWidget);
+
+    final checkboxes = tester.widgetList<Checkbox>(find.byType(Checkbox));
+    expect(checkboxes, hasLength(2));
+    expect(checkboxes.map((c) => c.value), [false, true]);
+  });
+
+  testWidgets('pressing Import writes the selected flight as a draft', (
+    tester,
+  ) async {
+    final db = await pumpScreen(
+      tester,
+      parseResult: ImportParseResult(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: _flight(),
+            aircraft: _aircraft,
+          ),
+        ],
+        errors: const [],
+      ),
+    );
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Import 1 flight(s)'));
+    await tester.pumpAndSettle();
+
+    final flights = await db.select(db.flightsTable).get();
+    expect(flights, hasLength(1));
+    expect(flights.single.committedAt, isNull);
+    expect(flights.single.importBatchId, isNotNull);
+
+    final batches = await db.select(db.importBatchesTable).get();
+    expect(batches.single.sourceLabel, 'Test importer');
+  });
+
+  testWidgets('unchecking the only row disables the Import button', (
+    tester,
+  ) async {
+    await pumpScreen(
+      tester,
+      parseResult: ImportParseResult(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: _flight(),
+            aircraft: _aircraft,
+          ),
+        ],
+        errors: const [],
+      ),
+    );
+
+    await tester.tap(find.byType(Checkbox).first);
+    await tester.pumpAndSettle();
+
+    final button = tester.widget<FilledButton>(find.byType(FilledButton));
+    expect(button.onPressed, isNull);
+  });
+
+  testWidgets('"Skip all duplicates" excludes every flagged row at once', (
+    tester,
+  ) async {
+    final existingFlight = _flight(hour: 9);
+    await pumpScreen(
+      tester,
+      parseResult: ImportParseResult(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: existingFlight,
+            aircraft: _aircraft,
+          ),
+        ],
+        errors: const [],
+      ),
+      existingFlights: [
+        FlightRecord(
+          id: 'existing-1',
+          flight: existingFlight,
+          aircraft: _aircraft,
+        ),
+      ],
+    );
+
+    // The one row is already excluded by default (it's a duplicate) —
+    // select it, then use "Skip all duplicates" to exclude it again.
+    await tester.tap(find.byType(Checkbox).first);
+    await tester.pumpAndSettle();
+    expect(tester.widget<Checkbox>(find.byType(Checkbox).first).value, isTrue);
+
+    await tester.tap(find.text('Skip all duplicates'));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Checkbox>(find.byType(Checkbox).first).value, isFalse);
+  });
+}

--- a/test/ui/io/import_screen_test.dart
+++ b/test/ui/io/import_screen_test.dart
@@ -1,0 +1,51 @@
+import 'package:easa_digital_log/ui/io/import_screen.dart';
+import 'package:easa_digital_log/ui/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A render-only test — actually driving `file_picker`'s native dialog
+/// isn't exercised here (it's a platform channel with no fake to hand a
+/// path back through in a widget test); this proves the three format
+/// options are presented and the screen doesn't crash before a pilot picks
+/// one.
+void main() {
+  testWidgets('presents the three supported import formats', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(theme: AppTheme.light(), home: const ImportScreen()),
+    );
+
+    expect(find.text('ForeFlight'), findsOneWidget);
+    expect(find.text('Garmin Pilot'), findsOneWidget);
+    expect(find.text('Generic CSV'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the back button pops the screen', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () => Navigator.of(context).push<void>(
+                  MaterialPageRoute(builder: (_) => const ImportScreen()),
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Import'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.pumpAndSettle();
+    expect(find.text('Import'), findsNothing);
+    expect(find.text('Open'), findsOneWidget);
+  });
+}

--- a/tool/check_no_networking.dart
+++ b/tool/check_no_networking.dart
@@ -35,6 +35,7 @@ const Set<String> allowedPackages = {
   // "dependencies:").
   'csv',
   'drift',
+  'file_picker',
   'fl_chart',
   'flutter',
   'flutter_riverpod',
@@ -150,6 +151,23 @@ const Set<String> allowedPackages = {
   'web',
   'win32',
   'xdg_directories',
+
+  // ---- file_picker (#72's import flow) and its own transitive tree —
+  // every one of these opens a native document/file picker or supports
+  // one; none opens a socket. `dbus` is Linux desktop-portal IPC (the
+  // GTK/KDE file-open dialog), not network I/O, and irrelevant on this
+  // app's actual targets regardless (iOS/Android). `xml`/`petitparser`
+  // back `file_picker`'s Windows/macOS metadata parsing.
+  'android_file_picker',
+  'cross_file',
+  'dbus',
+  'file_picker_darwin',
+  'file_picker_linux',
+  'file_picker_platform_interface',
+  'file_picker_web',
+  'petitparser',
+  'windows_file_picker',
+  'xml',
 
   // ---- Genuinely networking-capable packages, present but dead code on
   // this app's targets.


### PR DESCRIPTION
## Summary
Adds the screens the transactional import pipeline (#73), duplicate detection (#75) and generic CSV mapping (#72) had no UI for yet, reached from Settings' Import row (previously an inert placeholder).

- **`ImportScreen`**: format picker (ForeFlight / Garmin Pilot / Generic CSV), using a new `file_picker` dependency to read the file(s) each format's adapter needs from disk. Parsing is pure — nothing here touches the database.
- **`GenericCsvMappingScreen`**: detects a CSV's header row, lets the pilot assign each to a canonical field via dropdowns, choose date/duration formats explicitly, load a previously saved mapping, and optionally save the current one for reuse. Required fields still unmapped are reported by name rather than surfacing `GenericCsvAdapter`'s own `FormatException` raw.
- **`ImportPreviewScreen`**: the actual preview + apply + undo step. Every mappable row gets a checkbox, defaulting a flagged duplicate (#75) to skipped and everything else to imported, with the duplicate's own reason shown inline. Unmappable rows are listed read-only with their error. "Skip all duplicates"/"Select all" cover the common case of a wholly overlapping re-import. Pressing Import calls `applyImport` (#73) transactionally and offers an Undo action wired to `undoImportBatch`.

`allFlightRecordsProvider` (drafts + committed, already existing) feeds the duplicate check directly — no new read provider needed for that. A new `savedCsvMappingProfilesProvider` exposes the mapping repository the same way `aircraftRecordsProvider` exposes `AircraftRepository`.

## Dependency
`file_picker` is a new dependency (confirmed with the project owner before adding it) — pinned to `^12.2.0`, the version `package_info_plus`'s own `win32` constraint requires. Its transitive tree is added to `check_no_networking`'s allowlist with an explanation: all local file-picker/parsing support, none of it opens a socket (`dbus` is Linux desktop-portal IPC, not network I/O, and irrelevant on this app's actual iOS/Android targets regardless).

## A debugging note worth flagging
Widget tests override `allFlightRecordsProvider` directly to a hand-built list rather than exercising its real jurisdiction-asset/drift-stream chain, which needs real wall-clock time `tester.pumpAndSettle`'s fake clock can't supply on its own (the same class of issue `logbook_screen_test.dart`/`totals_screen_test.dart` already document). Confirmed via a throwaway diagnostic test that the hang was in that prewarm chain, not in the new screens' own logic, before rewriting the tests around the simpler override.

## Scope note
`file_picker`'s own native dialog is a platform channel with no fake to hand a path back through in a widget test, so the actual file-selection interaction is exercised only by construction (the picked path flows straight into `File(path).readAsString()`), not by an automated test. I was not able to do a live on-device run-through of the native picker itself in this environment — everything else (navigation, real Riverpod wiring, real repository writes, dropdown interactions, duplicate defaults) is exercised by the new widget tests against a real in-memory database.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 835/835 passing
- [x] `ImportPreviewScreen`: duplicate-defaults-to-skipped, clean-row-defaults-to-imported, error rows shown read-only, pressing Import writes a real draft + batch record, unchecking the only row disables Import, "Skip all duplicates" bulk action
- [x] `GenericCsvMappingScreen`: headers detected and offered in dropdowns, missing-required-field message, full mapping flow navigates to the preview screen
- [x] `ImportScreen`: format list renders, back button pops
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_no_networking.dart` / `check_schema_snapshot.dart` — all clean
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 96.2% (threshold 90%)
- [x] `dart run tool/check_io_vendor_leak.dart` — no vendor identifier outside `lib/io/`
- [x] Formatting verified against CI-pinned Flutter 3.44.0's `dart format`

Progresses #73, #72, #75 (the preview-screen/mapping-UI gap each was left open for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)