### PR TITLE
fix: report the undo split in the import preview screen (#73)

### DIFF
--- a/lib/ui/io/import_preview_screen.dart
+++ b/lib/ui/io/import_preview_screen.dart
@@ -81,17 +81,40 @@ class _ImportPreviewScreenState extends ConsumerState<ImportPreviewScreen> {
         flightRepository: ref.read(flightRepositoryProvider),
       );
       if (!mounted) return;
+      // Captured before popping: ScaffoldMessenger.of resolves to the app's
+      // single ancestor messenger (above the Navigator), which stays
+      // mounted across this pop — the "Undo" SnackBar's own action, and its
+      // own follow-up report, both need to post after this screen is gone.
+      final messenger = ScaffoldMessenger.of(context);
+      final flightRepository = ref.read(flightRepositoryProvider);
       Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(
           content: Text('${selected.length} flight(s) imported as drafts.'),
           action: SnackBarAction(
             label: 'Undo',
             onPressed: () async {
               try {
-                await ref
-                    .read(flightRepositoryProvider)
-                    .undoImportBatch(batchId);
+                // #73: "reporting the split to the user" — a flight already
+                // committed in the meantime is tombstoned, not deleted, so
+                // the pilot needs to know both counts, not just "undone".
+                final result = await flightRepository.undoImportBatch(batchId);
+                // Replace the "imported" SnackBar immediately rather than
+                // queuing behind its own display duration — the pilot just
+                // asked for this outcome, they shouldn't wait ~4s to see it
+                // confirmed.
+                messenger.hideCurrentSnackBar();
+                messenger.showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      result.tombstonedCommittedCount == 0
+                          ? '${result.deletedDraftCount} flight(s) removed.'
+                          : '${result.deletedDraftCount} flight(s) removed, '
+                                '${result.tombstonedCommittedCount} already '
+                                'committed flight(s) tombstoned.',
+                    ),
+                  ),
+                );
               } on StateError {
                 // Already undone (e.g. double-tapped) — nothing more to do.
               }

--- a/test/ui/io/import_preview_screen_test.dart
+++ b/test/ui/io/import_preview_screen_test.dart
@@ -76,6 +76,14 @@ void main() {
     required ImportParseResult parseResult,
     List<FlightRecord> existingFlights = const [],
   }) async {
+    // A SnackBar's "Undo" action can render outside the default 800x600
+    // test viewport (see logbook_screen_test.dart's own note) — enough
+    // height that it stays reachable by tap().
+    tester.view.physicalSize = const Size(390, 2000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
     final db = AppDatabase(NativeDatabase.memory());
     addTearDown(db.close);
     await AircraftRepository(db).upsert(_aircraft, id: 'aircraft-1');
@@ -167,6 +175,52 @@ void main() {
 
     final batches = await db.select(db.importBatchesTable).get();
     expect(batches.single.sourceLabel, 'Test importer');
+  });
+
+  testWidgets('tapping Undo removes the imported draft and reports the split', (
+    tester,
+  ) async {
+    final db = await pumpScreen(
+      tester,
+      parseResult: ImportParseResult(
+        rows: [
+          CanonicalImportRow(
+            sourceRowNumber: 2,
+            flight: _flight(),
+            aircraft: _aircraft,
+          ),
+        ],
+        errors: const [],
+      ),
+    );
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Import 1 flight(s)'));
+    // Not pumpAndSettle: a SnackBar's default display duration (4s) would
+    // elapse under the fake clock's accelerated pumping and dismiss it
+    // before its action could be invoked. Pump in short steps instead,
+    // stopping as soon as it appears, well inside that 4s window.
+    for (var i = 0; i < 20 && find.text('Undo').evaluate().isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    expect(find.text('1 flight(s) imported as drafts.'), findsOneWidget);
+
+    // The SnackBarAction's own render position sits right at (and, in
+    // this test environment, very slightly past) the edge of even a
+    // generously tall test viewport, so `tap()`'s hit-testing misses it —
+    // invoking its callback directly exercises the same behaviour a real
+    // tap would without fighting that geometry.
+    final action = tester.widget<SnackBarAction>(find.byType(SnackBarAction));
+    action.onPressed();
+    for (
+      var i = 0;
+      i < 20 && find.text('1 flight(s) removed.').evaluate().isEmpty;
+      i++
+    ) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    expect(await db.select(db.flightsTable).get(), isEmpty);
+    expect(find.text('1 flight(s) removed.'), findsOneWidget);
   });
 
   testWidgets('unchecking the only row disables the Import button', (


### PR DESCRIPTION
## Summary
The preview screen's "Undo" SnackBar action called `FlightRepository.undoImportBatch` but never showed its result — #73's own acceptance criterion is "reporting the split to the user" when a batch contains an already-committed flight (tombstoned, not deleted) alongside drafts (deleted). Found this gap while re-checking the just-merged UI (#145) against #73's full criteria list.

Also replaces the "imported" SnackBar immediately via `hideCurrentSnackBar()` rather than letting the follow-up "removed" message queue behind its own ~4s display duration — the pilot just asked for this outcome and shouldn't have to wait to see it confirmed.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 836/836 passing
- [x] New test taps Import, invokes the Undo action, and asserts both the draft is actually gone and the reported count text is correct
- [x] `dart run tool/check_layering.dart` / `check_domain_types.dart` / `check_currency_rules.dart` / `check_no_networking.dart` / `check_schema_snapshot.dart` — all clean
- [x] `dart run tool/check_domain_coverage.dart coverage/lcov.info` — 96.2% (threshold 90%)
- [x] `dart run tool/check_io_vendor_leak.dart` — no vendor identifier outside `lib/io/`
- [x] Formatting verified against CI-pinned Flutter 3.44.0's `dart format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)