### PR TITLE
fix: close lib/ui/io/ exemption gap in check_io_vendor_leak

### DIFF
--- a/lib/io/import_formats.dart
+++ b/lib/io/import_formats.dart
@@ -1,0 +1,66 @@
+/// Generic-shaped descriptions of the import formats needing a direct
+/// [ImportAdapter] dispatch, so `lib/ui/` can present and drive them without
+/// ever naming a vendor or its adapter class itself (#68: "never let a
+/// vendor's field naming past `io/`" — a UI label or a bare `FooAdapter()`
+/// call is exactly that kind of leak, not just a stored field). The generic
+/// CSV format needs no entry here since its own screen never names a
+/// vendor.
+///
+/// Update alongside `ImportAdapter.displayName` as adapters are added —
+/// there is no registry yet listing them for this to read live.
+library;
+
+import 'foreflight/foreflight_adapter.dart';
+import 'garmin/garmin_adapter.dart';
+import 'import_adapter.dart';
+
+/// An import format needing exactly one picked file.
+class SingleFileImportFormat {
+  const SingleFileImportFormat({
+    required this.label,
+    required this.subtitle,
+    required this.dialogTitle,
+    required this.parse,
+  });
+
+  final String label;
+  final String subtitle;
+  final String dialogTitle;
+  final ImportParseResult Function(String source) parse;
+}
+
+/// An import format needing exactly two picked files, in a fixed order.
+class TwoFileImportFormat {
+  const TwoFileImportFormat({
+    required this.label,
+    required this.subtitle,
+    required this.firstDialogTitle,
+    required this.secondDialogTitle,
+    required this.parse,
+  });
+
+  final String label;
+  final String subtitle;
+  final String firstDialogTitle;
+  final String secondDialogTitle;
+  final ImportParseResult Function(String first, String second) parse;
+}
+
+final SingleFileImportFormat foreFlightImportFormat = SingleFileImportFormat(
+  label: 'ForeFlight',
+  subtitle: 'logbook_template.csv',
+  dialogTitle: 'Select logbook_template.csv',
+  parse: (source) =>
+      ForeFlightAdapter().parse({ForeFlightAdapter.logbookKey: source}),
+);
+
+final TwoFileImportFormat garminImportFormat = TwoFileImportFormat(
+  label: 'Garmin Pilot',
+  subtitle: 'Aircraft types + logbook CSV (two files)',
+  firstDialogTitle: 'Select the aircraft-types export',
+  secondDialogTitle: 'Select the logbook export',
+  parse: (aircraftTypes, logEntries) => GarminAdapter().parse({
+    GarminAdapter.aircraftTypesKey: aircraftTypes,
+    GarminAdapter.logEntriesKey: logEntries,
+  }),
+);

--- a/lib/ui/io/import_screen.dart
+++ b/lib/ui/io/import_screen.dart
@@ -3,9 +3,8 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
-import '../../io/foreflight/foreflight_adapter.dart';
-import '../../io/garmin/garmin_adapter.dart';
 import '../../io/import_adapter.dart';
+import '../../io/import_formats.dart';
 import '../theme/app_colors.dart';
 import 'generic_csv_mapping_screen.dart';
 import 'import_preview_screen.dart';
@@ -67,27 +66,22 @@ class _ImportScreenState extends State<ImportScreen> {
     ).showSnackBar(SnackBar(content: Text(message)));
   }
 
-  Future<void> _importForeFlight() => _run('ForeFlight', () async {
-    final csv = await _pickCsv(dialogTitle: 'Select logbook_template.csv');
-    if (csv == null) return null;
-    return ForeFlightAdapter().parse({ForeFlightAdapter.logbookKey: csv});
-  });
+  Future<void> _importSingleFile(SingleFileImportFormat format) =>
+      _run(format.label, () async {
+        final source = await _pickCsv(dialogTitle: format.dialogTitle);
+        if (source == null) return null;
+        return format.parse(source);
+      });
 
-  Future<void> _importGarmin() => _run('Garmin Pilot', () async {
-    final aircraftTypesCsv = await _pickCsv(
-      dialogTitle: 'Select the aircraft-types export',
-    );
-    if (aircraftTypesCsv == null) return null;
-    if (!mounted) return null;
-    final logEntriesCsv = await _pickCsv(
-      dialogTitle: 'Select the logbook export',
-    );
-    if (logEntriesCsv == null) return null;
-    return GarminAdapter().parse({
-      GarminAdapter.aircraftTypesKey: aircraftTypesCsv,
-      GarminAdapter.logEntriesKey: logEntriesCsv,
-    });
-  });
+  Future<void> _importTwoFiles(TwoFileImportFormat format) =>
+      _run(format.label, () async {
+        final first = await _pickCsv(dialogTitle: format.firstDialogTitle);
+        if (first == null) return null;
+        if (!mounted) return null;
+        final second = await _pickCsv(dialogTitle: format.secondDialogTitle);
+        if (second == null) return null;
+        return format.parse(first, second);
+      });
 
   Future<void> _startGenericCsv() async {
     setState(() => _busy = true);
@@ -138,15 +132,17 @@ class _ImportScreenState extends State<ImportScreen> {
             ),
             if (_busy) const LinearProgressIndicator(),
             _FormatRow(
-              title: 'ForeFlight',
-              subtitle: 'logbook_template.csv',
-              onTap: _busy ? null : _importForeFlight,
+              title: foreFlightImportFormat.label,
+              subtitle: foreFlightImportFormat.subtitle,
+              onTap: _busy
+                  ? null
+                  : () => _importSingleFile(foreFlightImportFormat),
             ),
             const Divider(height: 1),
             _FormatRow(
-              title: 'Garmin Pilot',
-              subtitle: 'Aircraft types + logbook CSV (two files)',
-              onTap: _busy ? null : _importGarmin,
+              title: garminImportFormat.label,
+              subtitle: garminImportFormat.subtitle,
+              onTap: _busy ? null : () => _importTwoFiles(garminImportFormat),
             ),
             const Divider(height: 1),
             _FormatRow(

--- a/tool/check_io_vendor_leak.dart
+++ b/tool/check_io_vendor_leak.dart
@@ -53,10 +53,18 @@ class VendorLeak {
   String toString() => '$filePath:$line  names "$vendorName"';
 }
 
-/// Whether [filePath] sits inside the exempt `lib/io/` tree.
+/// Whether [filePath] sits inside the exempt `lib/io/` tree — the path's
+/// first two segments must be exactly `lib/io`, not merely contain an `io`
+/// segment anywhere. #70 caught the difference the hard way: `lib/ui/io/`
+/// (this app's import/export *screens*, not adapters) has its own `io`
+/// segment too, and a bare `segments.contains('io')` check exempted it
+/// right along with the real `lib/io/` adapter tree — silently un-checking
+/// every vendor-name string literal those screens happen to show a pilot.
 bool _isExempt(String filePath) {
   final segments = filePath.replaceAll(r'\', '/').split('/');
-  return segments.contains(_ioSegment);
+  return segments.length >= 2 &&
+      segments[0] == _sourceTarget &&
+      segments[1] == _ioSegment;
 }
 
 /// Returns every banned vendor name [source] mentions, outside comments.


### PR DESCRIPTION
## Summary
- `check_io_vendor_leak.dart`'s `_isExempt` matched any path segment named `io` anywhere in the path, so `lib/ui/io/` (the import/export screens' own folder, added in #145) was treated as exempt identically to the real `lib/io/` adapter tree — silently un-checking every vendor-name string literal and direct adapter reference those screens contained.
- Narrowed the exemption to require the path's first two segments be exactly `lib/io`.
- Fixed the resulting leaks in `import_screen.dart` by moving its vendor-specific dispatch (which adapter to construct, which dialog titles to show) behind generic `SingleFileImportFormat`/`TwoFileImportFormat` specs in a new `lib/io/import_formats.dart`, so the screen itself never names `ForeFlightAdapter`/`GarminAdapter` or a vendor string directly.

## Test plan
- [x] `dart run tool/check_io_vendor_leak.dart` — clean
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — all passing