### PR TITLE
feat: ForeFlight export screen with date range and overlap warning (#70)

### DIFF
--- a/lib/io/export_formats.dart
+++ b/lib/io/export_formats.dart
@@ -1,0 +1,23 @@
+/// Generic-shaped export format info + a dispatch wrapper, so `lib/ui/`
+/// never has to name a vendor or its exporter functions directly (#68 —
+/// see `import_formats.dart`'s own note; the same leak applies on the
+/// export side).
+library;
+
+import '../domain/model/calendar_date.dart';
+import '../domain/projection/projection.dart';
+import '../domain/repository/flight_read_repository.dart';
+import 'foreflight/foreflight_exporter.dart';
+
+/// #70: the export format is FAA-shaped CSV, unconditionally.
+const String faaCsvExportFormatLabel = 'ForeFlight';
+
+String buildFaaCsvExport({
+  required List<FlightRecord> flights,
+  required Projection faaProjection,
+}) => exportForeFlightCsv(flights: flights, faaProjection: faaProjection);
+
+String faaCsvExportFilename({
+  required CalendarDate from,
+  required CalendarDate to,
+}) => foreFlightExportFilename(from: from, to: to);

--- a/lib/ui/io/export_screen.dart
+++ b/lib/ui/io/export_screen.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/model/calendar_date.dart';
+import '../../domain/repository/export_record_repository.dart';
+import '../../domain/repository/flight_read_repository.dart';
+import '../../io/export_formats.dart';
+import '../providers/foreflight_export_providers.dart';
+import '../providers/repository_providers.dart';
+import '../theme/app_colors.dart';
+
+/// #70's export screen: a mandatory date range (never inferred — CLAUDE.md's
+/// "Export asks which jurisdiction explicitly" spirit applied to a range
+/// too), a non-blocking warning when that range overlaps a previously
+/// recorded export, then a save-file dialog for the resulting CSV.
+///
+/// Only committed, active flights are exported — a draft is still "freely
+/// mutable... not yet asserted" (rule 4); sending an unfinished entry to
+/// another app is premature regardless of how export there differs from
+/// the official PDF logbook's own commit-on-export rule.
+class ExportScreen extends ConsumerStatefulWidget {
+  const ExportScreen({super.key});
+
+  @override
+  ConsumerState<ExportScreen> createState() => _ExportScreenState();
+}
+
+class _ExportScreenState extends ConsumerState<ExportScreen> {
+  CalendarDate? _from;
+  CalendarDate? _to;
+  Future<List<ExportRecord>>? _overlapCheck;
+  bool _exporting = false;
+
+  Future<void> _pickDate({required bool isFrom}) async {
+    final initial = (isFrom ? _from : _to) ?? _todayAsCalendarDate();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: DateTime(initial.year, initial.month, initial.day),
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100),
+    );
+    if (picked == null) return;
+    setState(() {
+      final date = CalendarDate(picked.year, picked.month, picked.day);
+      if (isFrom) {
+        _from = date;
+      } else {
+        _to = date;
+      }
+      _overlapCheck = null;
+      final from = _from;
+      final to = _to;
+      if (from != null && to != null && from <= to) {
+        _overlapCheck = ref
+            .read(exportRecordRepositoryProvider)
+            .findOverlapping(
+              format: faaCsvExportFormatLabel,
+              from: from,
+              to: to,
+            );
+      }
+    });
+  }
+
+  CalendarDate _todayAsCalendarDate() {
+    final now = DateTime.now();
+    return CalendarDate(now.year, now.month, now.day);
+  }
+
+  Future<void> _export() async {
+    final from = _from;
+    final to = _to;
+    if (from == null || to == null) return;
+
+    setState(() => _exporting = true);
+    try {
+      final faaProjection = await ref.read(faaProjectionProvider.future);
+      final projected = await ref
+          .read(flightReadRepositoryProvider)
+          .watchFlights(
+            projection: faaProjection,
+            query: FlightQuery(from: from, to: to),
+          )
+          .first;
+      final flights = [for (final p in projected) p.record];
+
+      if (flights.isEmpty) {
+        _showMessage('No committed flights between $from and $to.');
+        return;
+      }
+
+      final csv = buildFaaCsvExport(
+        flights: flights,
+        faaProjection: faaProjection,
+      );
+      final fileName = faaCsvExportFilename(from: from, to: to);
+
+      final savedUri = await FilePicker.saveFile(
+        fileName: fileName,
+        bytes: Uint8List.fromList(utf8.encode(csv)),
+        mimeType: 'text/csv',
+        dialogTitle: 'Save $faaCsvExportFormatLabel export',
+        type: FileType.custom,
+        allowedExtensions: ['csv'],
+      );
+      if (savedUri == null) return; // pilot cancelled the save dialog.
+
+      await ref
+          .read(exportRecordRepositoryProvider)
+          .recordExport(format: faaCsvExportFormatLabel, from: from, to: to);
+
+      _showMessage('${flights.length} flight(s) exported to $fileName.');
+    } finally {
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
+  void _showMessage(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+    final semantic = context.semanticColors;
+    final from = _from;
+    final to = _to;
+    final rangeValid = from != null && to != null && from <= to;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(4, 4, 16, 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip: 'Back',
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  Expanded(
+                    child: Text(
+                      'Export to $faaCsvExportFormatLabel',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 96),
+                children: [
+                  Text(
+                    'Choose a date range to export. Only committed flights '
+                    'are included.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: ink.muted,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('From'),
+                    subtitle: Text(from?.toString() ?? 'Not set'),
+                    trailing: const Icon(Icons.calendar_today),
+                    onTap: () => _pickDate(isFrom: true),
+                  ),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('To'),
+                    subtitle: Text(to?.toString() ?? 'Not set'),
+                    trailing: const Icon(Icons.calendar_today),
+                    onTap: () => _pickDate(isFrom: false),
+                  ),
+                  if (from != null && to != null && from > to)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(
+                        'The "From" date must be on or before "To".',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
+                    ),
+                  if (_overlapCheck != null)
+                    FutureBuilder<List<ExportRecord>>(
+                      future: _overlapCheck,
+                      builder: (context, snapshot) {
+                        final overlapping = snapshot.data ?? const [];
+                        if (overlapping.isEmpty) return const SizedBox.shrink();
+                        return Container(
+                          margin: const EdgeInsets.only(top: 16),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: semantic.currencyWarningSurface,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            'This range overlaps ${overlapping.length} '
+                            'previous export(s) — re-importing this file '
+                            'into $faaCsvExportFormatLabel may create '
+                            'duplicates there.',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: semantic.currencyWarning,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: (rangeValid && !_exporting) ? _export : null,
+              child: _exporting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Export'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/providers/foreflight_export_providers.dart
+++ b/lib/ui/providers/foreflight_export_providers.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/primitives/default_primitives.dart';
+import '../../domain/projection/jurisdiction_projection.dart';
+import 'aerodrome_providers.dart';
+import 'jurisdiction_providers.dart';
+
+/// The FAA projection, unconditionally — #70's own instruction ("Derived
+/// values computed via the FAA projection, since ForeFlight is FAA-shaped")
+/// applies regardless of which licence the pilot actually holds.
+/// `jurisdictionProjectionsProvider` only ever builds a projection for a
+/// jurisdiction backed by a held rating, which would leave a pilot with no
+/// FAA licence unable to export at all — this bypasses that filter and
+/// resolves `us.faa.part61` directly from the registry, since a
+/// `JurisdictionProjection`'s computation needs nothing more than a
+/// resolvable profile id.
+final faaProjectionProvider = FutureProvider<JurisdictionProjection>((
+  ref,
+) async {
+  final registry = await ref.watch(jurisdictionRegistryProvider.future);
+  final aerodromes = await ref.watch(aerodromeDirectoryProvider.future);
+  return JurisdictionProjection(
+    registry: registry,
+    primitives: defaultPrimitives,
+    aerodromes: aerodromes,
+    jurisdictionId: 'us.faa.part61',
+  );
+});

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -12,7 +12,9 @@ import '../../domain/totals/totals_summary.dart';
 import '../aircraft/aircraft_list_screen.dart';
 import '../currency/rule_asset_paths.dart';
 import '../currency/sample_currency_data.dart';
+import '../io/export_screen.dart';
 import '../io/import_screen.dart';
+import '../../io/export_formats.dart';
 import '../../io/supported_import_formats.dart';
 import '../preferences/app_preferences.dart';
 import '../providers/aircraft_providers.dart';
@@ -137,6 +139,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
                 const _Divider(),
                 const _ImportRow(),
+                const _Divider(),
+                const _ExportRow(),
                 const _Divider(),
                 // `exportDatabaseBackup`/`isBackupOverdue`
                 // (lib/data/database_backup.dart) are real and tested, but
@@ -306,6 +310,40 @@ class _ImportRow extends StatelessWidget {
               const SizedBox(height: 2),
               Text(
                 '$supportedImportFormatsLabel · preview before applying',
+                style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ExportRow extends StatelessWidget {
+  const _ExportRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ink = context.inkTiers;
+
+    return InkWell(
+      onTap: () => Navigator.of(
+        context,
+      ).push<void>(MaterialPageRoute(builder: (_) => const ExportScreen())),
+      child: SizedBox(
+        width: double.infinity,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 11),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Export', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 2),
+              Text(
+                '$faaCsvExportFormatLabel CSV · range-scoped, warns about '
+                'overlap',
                 style: theme.textTheme.labelSmall?.copyWith(color: ink.faint),
               ),
             ],

--- a/test/ui/io/export_screen_test.dart
+++ b/test/ui/io/export_screen_test.dart
@@ -1,0 +1,160 @@
+import 'package:drift/native.dart';
+import 'package:easa_digital_log/data/database.dart';
+import 'package:easa_digital_log/data/repositories/export_record_repository_drift.dart';
+import 'package:easa_digital_log/domain/jurisdiction/jurisdiction_registry.dart';
+import 'package:easa_digital_log/domain/model/aerodrome_directory.dart';
+import 'package:easa_digital_log/domain/model/calendar_date.dart';
+import 'package:easa_digital_log/domain/primitives/default_primitives.dart';
+import 'package:easa_digital_log/domain/projection/jurisdiction_projection.dart';
+import 'package:easa_digital_log/domain/projection/projection.dart';
+import 'package:easa_digital_log/domain/repository/flight_read_repository.dart';
+import 'package:easa_digital_log/ui/io/export_screen.dart';
+import 'package:easa_digital_log/ui/providers/database_provider.dart';
+import 'package:easa_digital_log/ui/providers/foreflight_export_providers.dart';
+import 'package:easa_digital_log/ui/providers/repository_providers.dart';
+import 'package:easa_digital_log/ui/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A minimal fake — `ExportScreen` only ever calls `watchFlights`, so
+/// everything else is unreachable and just throws if that ever changes
+/// without this fake being noticed.
+class _FakeFlightReadRepository implements FlightReadRepository {
+  _FakeFlightReadRepository(this.projectedFlights);
+
+  final List<ProjectedFlight> projectedFlights;
+
+  @override
+  Stream<List<ProjectedFlight>> watchFlights({
+    required Projection projection,
+    FlightQuery query = const FlightQuery(),
+  }) => Stream.value(projectedFlights);
+
+  @override
+  Future<ProjectedFlight?> find(
+    String flightId, {
+    required Projection projection,
+  }) => throw UnimplementedError();
+
+  @override
+  Stream<List<FlightRecord>> watchDrafts() => throw UnimplementedError();
+
+  @override
+  Future<FlightRecord?> findDraft(String flightId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<FlightHistory?> revisionHistory(String flightId) =>
+      throw UnimplementedError();
+}
+
+/// A render/flow test — actually driving `file_picker`'s native save dialog
+/// isn't exercised here (a platform channel with no fake to hand a path
+/// back through in a widget test, the same limitation `import_screen_test.dart`
+/// documents), so these tests stop short of tapping Export once a range
+/// with real flights is selected. The "no flights in range" path is
+/// exercised fully, since it returns before ever reaching the save dialog.
+///
+/// `faaProjectionProvider`/`flightReadRepositoryProvider` are overridden
+/// directly rather than exercising `jurisdictionProjectionsProvider`'s real
+/// asset-loading chain — this screen's own logic doesn't care where the
+/// data came from, only what it does with it.
+void main() {
+  final fakeFaaProjection = JurisdictionProjection(
+    registry: JurisdictionRegistry(const []),
+    primitives: defaultPrimitives,
+    aerodromes: AerodromeDirectory(const []),
+    jurisdictionId: 'us.faa.part61',
+  );
+
+  Future<AppDatabase> pumpScreen(
+    WidgetTester tester, {
+    List<ProjectedFlight> projectedFlights = const [],
+  }) async {
+    tester.view.physicalSize = const Size(390, 2000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        faaProjectionProvider.overrideWith((ref) async => fakeFaaProjection),
+        flightReadRepositoryProvider.overrideWithValue(
+          _FakeFlightReadRepository(projectedFlights),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(theme: AppTheme.light(), home: const ExportScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return db;
+  }
+
+  Future<void> pickDate(WidgetTester tester, String label) async {
+    await tester.tap(find.widgetWithText(ListTile, label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the Export button is disabled until a valid range is picked', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    final button = tester.widget<FilledButton>(find.byType(FilledButton));
+    expect(button.onPressed, isNull);
+
+    await pickDate(tester, 'From');
+    await pickDate(tester, 'To');
+
+    final buttonAfter = tester.widget<FilledButton>(find.byType(FilledButton));
+    expect(buttonAfter.onPressed, isNotNull);
+  });
+
+  testWidgets(
+    'exporting a range with no committed flights reports that rather than '
+    'opening a save dialog',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await pickDate(tester, 'From');
+      await pickDate(tester, 'To');
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Export'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('No committed flights'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'a range overlapping a previously recorded export shows a warning',
+    (tester) async {
+      final db = await pumpScreen(tester);
+      final today = DateTime.now();
+      await DriftExportRecordRepository(db).recordExport(
+        format: 'ForeFlight',
+        from: CalendarDate(today.year, today.month, 1),
+        to: CalendarDate(today.year, today.month, today.day),
+      );
+
+      await pickDate(tester, 'From');
+      await pickDate(tester, 'To');
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('overlaps'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New `ExportScreen`, reached from Settings: mandatory date range (`showDatePicker`-based, never inferred), a non-blocking banner when the range overlaps a previously recorded export (via #143's `ExportRecordRepository`), and a save-file dialog for the resulting CSV.
- Only committed, active flights are exported — a draft is still "freely mutable... not yet asserted" per rule 4.
- Derived figures come from a new `faaProjectionProvider`, which resolves `us.faa.part61` directly rather than through `jurisdictionProjectionsProvider` (that provider only builds a projection for a jurisdiction backed by a held rating, which would leave a pilot with no FAA licence unable to export at all).
- Vendor-specific export details (format label, exporter/filename functions) are hoisted into a new `lib/io/export_formats.dart`, keeping `lib/ui/` free of vendor naming per #68/#147.

Closes #70.

## Test plan
- [x] `dart run tool/check_io_vendor_leak.dart` — clean
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — all 839 tests passing, including 3 new `export_screen_test.dart` cases (button gating, no-flights-in-range message, overlap warning)