### PR TITLE
feat: per-row import validation gaps closed (#74)

### DIFF
--- a/lib/io/foreflight/foreflight_aircraft_mapper.dart
+++ b/lib/io/foreflight/foreflight_aircraft_mapper.dart
@@ -1,4 +1,5 @@
 import '../../domain/model/aircraft.dart';
+import '../icao_type_designator.dart';
 
 /// One aircraft-table row mapped to this app's own [Aircraft] model, plus
 /// any notes about assumptions the mapping had to make.
@@ -163,14 +164,20 @@ ForeFlightAircraftMapping? mapForeFlightAircraft(Map<String, String> row) {
     }
   }
 
+  final typeCode = row['TypeCode'] ?? '';
+  if (typeCode.isNotEmpty && !looksLikeIcaoTypeDesignator(typeCode)) {
+    notes.add(
+      'TypeCode "$typeCode" does not look like a real ICAO type designator '
+      '— kept as entered, verify under Aircraft management.',
+    );
+  }
+
   return ForeFlightAircraftMapping(
     aircraft: Aircraft(
       registration: registration,
       manufacturer: manufacturer,
       model: model,
-      icaoTypeDesignator: (row['TypeCode'] ?? '').isEmpty
-          ? null
-          : row['TypeCode'],
+      icaoTypeDesignator: typeCode.isEmpty ? null : typeCode,
       category: category,
       engineType: engineType ?? EngineType.none,
       engineCount: engineCount,

--- a/lib/io/foreflight/foreflight_flight_mapper.dart
+++ b/lib/io/foreflight/foreflight_flight_mapper.dart
@@ -381,9 +381,10 @@ ForeFlightFlightMapping mapForeFlightFlight({
   final offBlocks = _parseDateTime(row['Date'] ?? '', row['TimeOut'] ?? '');
   var onBlocks = _parseDateTime(row['Date'] ?? '', row['TimeIn'] ?? '');
   if (offBlocks == null || onBlocks == null) {
-    return const ForeFlightFlightMapping.error(
-      'Date, TimeOut or TimeIn is missing or unparseable — every flight '
-      'needs both block times.',
+    return ForeFlightFlightMapping.error(
+      'Date "${row['Date']}", TimeOut "${row['TimeOut']}" or TimeIn '
+      '"${row['TimeIn']}" is missing or unparseable — every flight needs '
+      'both block times.',
     );
   }
   // A flight landing after midnight Zulu has an earlier time-of-day than

--- a/lib/io/garmin/garmin_flight_mapper.dart
+++ b/lib/io/garmin/garmin_flight_mapper.dart
@@ -81,7 +81,7 @@ UtcInstant? _dateStart(String dateRaw) {
     return (
       offBlocks: null,
       onBlocks: null,
-      error: 'Date is missing or unparseable.',
+      error: 'Date "${row['Date']}" is missing or unparseable.',
     );
   }
   final dateEnd = dateStart.add(const Duration(days: 1));

--- a/lib/io/generic_csv/generic_csv_adapter.dart
+++ b/lib/io/generic_csv/generic_csv_adapter.dart
@@ -259,10 +259,12 @@ GenericCsvRowMapping mapGenericCsvRow(
     mapping.dateFormat,
   );
   if (offBlocks == null || onBlocks == null) {
-    return const GenericCsvRowMapping.error(
-      'Date, off-blocks time or on-blocks time is missing or unparseable '
-      'for the mapping\'s configured formats — every flight needs both '
-      'block times.',
+    return GenericCsvRowMapping.error(
+      'Date "$dateRaw", off-blocks time '
+      '"${_value(row, mapping, GenericCsvField.offBlocksTime)}" or on-blocks '
+      'time "${_value(row, mapping, GenericCsvField.onBlocksTime)}" is '
+      "missing or unparseable for the mapping's configured formats — every "
+      'flight needs both block times.',
     );
   }
   if (onBlocks < offBlocks) onBlocks = onBlocks.add(const Duration(days: 1));

--- a/lib/io/icao_type_designator.dart
+++ b/lib/io/icao_type_designator.dart
@@ -1,0 +1,9 @@
+/// Whether [value] has the shape of a real ICAO aircraft type designator
+/// (ICAO Doc 8643): two to four characters, letters and digits only, no
+/// separators. A shape check, not a lookup against the actual registry — a
+/// real but obscure type this app has never heard of still passes; this
+/// exists to catch a vendor column that plainly isn't an ICAO code at all
+/// (a full model name, a hyphenated variant suffix, embedded spaces), which
+/// #74 requires be flagged rather than trusted or silently dropped.
+bool looksLikeIcaoTypeDesignator(String value) =>
+    RegExp(r'^[A-Z0-9]{2,4}$').hasMatch(value);

--- a/lib/ui/io/import_preview_screen.dart
+++ b/lib/ui/io/import_preview_screen.dart
@@ -49,6 +49,7 @@ class _ImportPreviewScreenState extends ConsumerState<ImportPreviewScreen> {
   ImportPreview? _preview;
   Set<int> _excludedRowNumbers = {};
   bool _importing = false;
+  bool _unreadableRowsAcknowledged = false;
 
   ImportPreview _buildPreview(List<FlightRecord> existingFlights) {
     final preview = buildImportPreview(
@@ -171,8 +172,11 @@ class _ImportPreviewScreenState extends ConsumerState<ImportPreviewScreen> {
                     preview: preview,
                     excludedRowNumbers: _excludedRowNumbers,
                     importing: _importing,
+                    unreadableRowsAcknowledged: _unreadableRowsAcknowledged,
                     onExcludedChanged: (updated) =>
                         setState(() => _excludedRowNumbers = updated),
+                    onUnreadableRowsAcknowledgedChanged: (value) =>
+                        setState(() => _unreadableRowsAcknowledged = value),
                     onImport: () => _import(preview),
                   );
                 },
@@ -190,14 +194,18 @@ class _PreviewBody extends StatelessWidget {
     required this.preview,
     required this.excludedRowNumbers,
     required this.importing,
+    required this.unreadableRowsAcknowledged,
     required this.onExcludedChanged,
+    required this.onUnreadableRowsAcknowledgedChanged,
     required this.onImport,
   });
 
   final ImportPreview preview;
   final Set<int> excludedRowNumbers;
   final bool importing;
+  final bool unreadableRowsAcknowledged;
   final ValueChanged<Set<int>> onExcludedChanged;
+  final ValueChanged<bool> onUnreadableRowsAcknowledgedChanged;
   final VoidCallback onImport;
 
   int get _selectedCount => preview.rows
@@ -275,6 +283,17 @@ class _PreviewBody extends StatelessWidget {
                   ),
                 ),
                 for (final error in preview.errors) _ErrorRowTile(error: error),
+                CheckboxListTile(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                  value: unreadableRowsAcknowledged,
+                  onChanged: (value) =>
+                      onUnreadableRowsAcknowledgedChanged(value ?? false),
+                  title: Text(
+                    "I've reviewed the ${preview.errors.length} row(s) "
+                    "above that won't be imported",
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ),
               ],
             ],
           ),
@@ -286,7 +305,13 @@ class _PreviewBody extends StatelessWidget {
             child: SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: (_selectedCount == 0 || importing) ? null : onImport,
+                onPressed:
+                    (_selectedCount == 0 ||
+                        importing ||
+                        (preview.errors.isNotEmpty &&
+                            !unreadableRowsAcknowledged))
+                    ? null
+                    : onImport,
                 child: importing
                     ? const SizedBox(
                         width: 20,

--- a/test/io/foreflight/foreflight_aircraft_mapper_test.dart
+++ b/test/io/foreflight/foreflight_aircraft_mapper_test.dart
@@ -1,0 +1,50 @@
+import 'package:easa_digital_log/io/foreflight/foreflight_aircraft_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, String> _row({String typeCode = ''}) => {
+  'AircraftID': 'G-ABCD',
+  'TypeCode': typeCode,
+  'Make': 'Cessna',
+  'Model': '152',
+  'GearType': 'fixed_tricycle',
+  'EngineType': 'Piston',
+  'equipType (FAA)': 'aircraft',
+  'aircraftClass (FAA)': 'airplane_single_engine_land',
+  'complexAircraft (FAA)': 'FALSE',
+  'taa (FAA)': 'FALSE',
+  'highPerformance (FAA)': 'FALSE',
+  'pressurized (FAA)': 'FALSE',
+};
+
+void main() {
+  test('a real ICAO-shaped TypeCode is kept with no review note', () {
+    final mapping = mapForeFlightAircraft(_row(typeCode: 'C152'))!;
+
+    expect(mapping.aircraft.icaoTypeDesignator, 'C152');
+    expect(mapping.reviewNotes, isEmpty);
+  });
+
+  test('a TypeCode that is not ICAO-shaped is kept as entered but flagged '
+      '(#74: never invent, never silently trust)', () {
+    final mapping = mapForeFlightAircraft(
+      _row(typeCode: 'Cessna 152 (Aerobat)'),
+    )!;
+
+    expect(
+      mapping.aircraft.icaoTypeDesignator,
+      'Cessna 152 (Aerobat)',
+      reason: "the pilot's own raw value is preserved, never dropped",
+    );
+    expect(
+      mapping.reviewNotes,
+      contains(contains('does not look like a real ICAO type designator')),
+    );
+  });
+
+  test('a blank TypeCode leaves icaoTypeDesignator null with no note', () {
+    final mapping = mapForeFlightAircraft(_row())!;
+
+    expect(mapping.aircraft.icaoTypeDesignator, isNull);
+    expect(mapping.reviewNotes, isEmpty);
+  });
+}

--- a/test/io/icao_type_designator_test.dart
+++ b/test/io/icao_type_designator_test.dart
@@ -1,0 +1,20 @@
+import 'package:easa_digital_log/io/icao_type_designator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('a real two-to-four character alphanumeric code passes', () {
+    expect(looksLikeIcaoTypeDesignator('C152'), isTrue);
+    expect(looksLikeIcaoTypeDesignator('C172'), isTrue);
+    expect(looksLikeIcaoTypeDesignator('A320'), isTrue);
+    expect(looksLikeIcaoTypeDesignator('P28A'), isTrue);
+    expect(looksLikeIcaoTypeDesignator('B2'), isTrue);
+  });
+
+  test('a hyphenated variant suffix, embedded spaces, or lowercase fails', () {
+    expect(looksLikeIcaoTypeDesignator('M20J-201'), isFalse);
+    expect(looksLikeIcaoTypeDesignator('BEECH V35B TN'), isFalse);
+    expect(looksLikeIcaoTypeDesignator('c152'), isFalse);
+    expect(looksLikeIcaoTypeDesignator(''), isFalse);
+    expect(looksLikeIcaoTypeDesignator('TOOLONG5'), isFalse);
+  });
+}

--- a/test/ui/io/import_preview_screen_test.dart
+++ b/test/ui/io/import_preview_screen_test.dart
@@ -143,10 +143,43 @@ void main() {
 
     expect(find.textContaining('bad row'), findsOneWidget);
 
+    // Two per-row checkboxes plus the "reviewed the unreadable rows"
+    // acknowledgment checkbox #74 requires before Import enables.
     final checkboxes = tester.widgetList<Checkbox>(find.byType(Checkbox));
-    expect(checkboxes, hasLength(2));
-    expect(checkboxes.map((c) => c.value), [false, true]);
+    expect(checkboxes, hasLength(3));
+    expect(checkboxes.map((c) => c.value), [false, true, false]);
   });
+
+  testWidgets(
+    'Import stays disabled until the unreadable rows are acknowledged, '
+    'even with a valid row selected',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        parseResult: ImportParseResult(
+          rows: [
+            CanonicalImportRow(
+              sourceRowNumber: 2,
+              flight: _flight(),
+              aircraft: _aircraft,
+            ),
+          ],
+          errors: const [ImportRowError(rowNumber: 3, message: 'bad row')],
+        ),
+      );
+
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+
+      await tester.tap(find.byType(CheckboxListTile));
+      await tester.pumpAndSettle();
+
+      final buttonAfter = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(buttonAfter.onPressed, isNotNull);
+    },
+  );
 
   testWidgets('pressing Import writes the selected flight as a draft', (
     tester,


### PR DESCRIPTION
## Summary
#74's acceptance criteria were mostly already satisfied by earlier work (#69/#71/#72), but three gaps remained:

- **Non-ICAO type codes flagged, not trusted or dropped**: ForeFlight's `TypeCode` was stored verbatim into `Aircraft.icaoTypeDesignator` with no validation, even though that field feeds currency-rule matching. A shape-based ICAO Doc 8643 check (`lib/io/icao_type_designator.dart`) now flags a non-conforming value with a review note while still preserving it — never inventing a substitute, never silently dropping it.
- **Raw values missing from some per-row errors**: a few combined "field A, B or C is missing or unparseable" messages (ForeFlight's Date/TimeOut/TimeIn, Garmin's Date, generic CSV's date/off-blocks/on-blocks) didn't show what the actual malformed value was. All three now do.
- **Error rows could be silently skipped past**: the preview screen already excluded and listed unreadable rows, but nothing stopped the pilot from hitting Import without ever having looked at them. There's now a required "I've reviewed the row(s) that won't be imported" checkbox that gates the Import button whenever `parseResult.errors` is non-empty.

Date-format and duration-format ambiguity (the other two criteria) turned out to already be handled by #72's mapping screen, which requires an explicit file-level choice rather than guessing — no changes needed there.

## Test plan
- [x] New unit tests: `icao_type_designator_test.dart`, `foreflight_aircraft_mapper_test.dart`
- [x] Updated `import_preview_screen_test.dart` for the new acknowledgment gate (including a new test asserting Import stays disabled until checked)
- [x] `flutter analyze --fatal-infos` — clean
- [x] All `tool/check_*.dart` guards — clean
- [x] `flutter test` — 848 tests passing
- [x] Formatting verified against the CI-pinned Flutter 3.44.0 `dart format`